### PR TITLE
Fix dependency on systemd

### DIFF
--- a/configure
+++ b/configure
@@ -186,7 +186,7 @@ print_config "libuuid" "${libuuid}"
 ##########################################
 # check for SystemD
 systemd="no"
-pkg-config --exists systemd --atleast-version=232
+pkg-config --exists libsystemd --atleast-version=232
 if [ $? -eq 0 ]; then
   systemd="yes"
 fi

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,5 @@
 CFLAGS ?= -g -O2
-override CFLAGS += -Wall -D_GNU_SOURCE -L../src/ -I../src/ -lsystemd
+override CFLAGS += -Wall -D_GNU_SOURCE -L../src/ -I../src/
 
 include ../Makefile.quiet
 
@@ -12,7 +12,7 @@ all_targets += telemetry-listen display-tree display-columnar discover-loop
 all: $(all_targets)
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) -o $@ $< -lnvme
+	$(QUIET_CC)$(CC) $(CFLAGS) -o $@ $< -lnvme ${LDFLAGS}
 
 clean:
 	rm -f $(all_targets)

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,6 +2,10 @@ NAME=libnvme
 SPECFILE=$(NAME).spec
 VERSION=$(shell awk '/Version:/ { print $$2 }' $(SPECFILE))
 
+ifneq ($(MAKECMDGOALS),clean)
+include ../config-host.mak
+endif
+
 prefix ?= /usr
 includedir ?= $(prefix)/include
 libdir ?= $(prefix)/lib
@@ -12,7 +16,7 @@ CFLAGS ?= -g -fomit-frame-pointer -O2 -I/usr/include -Invme/ -I$(CCANDIR) -inclu
 override CFLAGS += -Wall -fPIC
 SO_CFLAGS=-shared $(CFLAGS)
 L_CFLAGS=$(CFLAGS)
-LINK_FLAGS= -L /usr/lib64 -lsystemd
+LINK_FLAGS= -L /usr/lib64
 LINK_FLAGS+=$(LDFLAGS)
 ENABLE_SHARED ?= 1
 SED ?= sed


### PR DESCRIPTION
When libsystemd is not installed on the system, then the pkg-config
check would still be true when systemd itself is on the system. Also,
when the library is unavailable then the hard-coded "-lsystemd" would
cause the build to fail. The following changes fix that.

* configure: changed check from "systemd" to the library "libsystemd"

* examples/Makefile: Replaced hard-coded "-lsystemd" with "${LDFLAGS}"
  as defined by "config-host.mak" in examples/Makefile

* src/Makefile: added include of "config-host.mak", removed hard-coded
  "-lsystemd", "-lsystemd" will trickle in from LDFLAGS

Signed-off-by: Simon A. F. Lund <simon.lund@samsung.com>

## Test

On my laptop (DebianBuster), it:

* Now builds with and without libsystemd
* ./test/test ran without error both with and without libsystemd