### PR TITLE
build: Include libnvme.pc in the default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INSTALL=install
 
 default: all
 
-all:
+all: $(NAME).pc
 	@$(MAKE) -C src
 	@$(MAKE) -C test
 	@$(MAKE) -C examples


### PR DESCRIPTION
Might be a matter of personal taste, however this comes handy when linking statically against an uninstalled source tree.