### PR TITLE
Make systemd and uuid optional

### DIFF
--- a/configure
+++ b/configure
@@ -27,6 +27,10 @@ for opt do
   ;;
   --datadir=*) datadir="$optarg"
   ;;
+  --disable-systemd) disable_systemd=1
+  ;;
+  --disable-uuid) disable_uuid=1
+  ;;
   *)
     echo "ERROR: unkown option $opt"
     echo "Try '$0 --help' for more information"
@@ -62,6 +66,8 @@ Options: [defaults in brackets after descriptions]
   --libdir=PATH            install libraries in PATH [$libdir]
   --mandir=PATH            install man pages in PATH [$mandir]
   --datadir=PATH           install shared data in PATH [$datadir]
+  --disable-systemd        do not link against libsystemd
+  --disable-uuid           do not link against libuuid
 EOF
 exit 0
 fi
@@ -177,18 +183,22 @@ print_and_output_mak "datadir" "$datadir"
 ##########################################
 # check for libuuid
 libuuid="no"
-${ld} -o /dev/null -luuid >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  libuuid="yes"
+if [ -z "$disable_uuid" ] ; then
+    ${ld} -o /dev/null -luuid >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+	libuuid="yes"
+    fi
 fi
 print_config "libuuid" "${libuuid}"
 
 ##########################################
 # check for SystemD
 systemd="no"
-pkg-config --exists libsystemd --atleast-version=232
-if [ $? -eq 0 ]; then
-  systemd="yes"
+if [ -z "$disable_systemd" ] ; then
+    pkg-config --exists libsystemd --atleast-version=232
+    if [ $? -eq 0 ]; then
+	systemd="yes"
+    fi
 fi
 print_config "systemd" "${systemd}"
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -17,9 +17,6 @@
 #include <unistd.h>
 
 #include <ccan/list/list.h>
-
-#include <uuid/uuid.h>
-
 #include "ioctl.h"
 #include "filters.h"
 #include "tree.h"
@@ -69,7 +66,11 @@ struct nvme_ns {
 
 	uint8_t eui64[8];
 	uint8_t nguid[16];
+#ifdef CONFIG_UUID
 	uuid_t  uuid;
+#else
+	uint8_t uuid[16];
+#endif
 	enum nvme_csi csi;
 };
 
@@ -740,10 +741,17 @@ const uint8_t *nvme_ns_get_nguid(nvme_ns_t n)
 	return n->nguid;
 }
 
+#ifdef CONFIG_UUID
 void nvme_ns_get_uuid(nvme_ns_t n, uuid_t out)
 {
 	uuid_copy(out, n->uuid);
 }
+#else
+void nvme_ns_get_uuid(nvme_ns_t n, uint8_t *out)
+{
+	memcpy(out, n, 16);
+}
+#endif
 
 int nvme_ns_identify(nvme_ns_t n, struct nvme_id_ns *ns)
 {

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -14,9 +14,9 @@
 #include <stddef.h>
 
 #include <sys/types.h>
-
+#ifdef CONFIG_UUID
 #include <uuid/uuid.h>
-
+#endif
 #include "ioctl.h"
 #include "util.h"
 
@@ -298,8 +298,11 @@ const uint8_t *nvme_ns_get_nguid(nvme_ns_t n);
  *
  * Copies the namespace's uuid to the destination buffer
  */
+#ifdef CONFIG_UUID
 void nvme_ns_get_uuid(nvme_ns_t n, uuid_t out);
-
+#else
+void nvme_ns_get_uuid(nvme_ns_t n, uint8_t *out);
+#endif
 /**
  * nvme_ns_get_sysfs_dir() -
  * @n:


### PR DESCRIPTION
Add configuration flags '--disable-systemd' and '--disable-uuid'
to forcibly exclude systemd and uuid during build.

Signed-off-by: Hannes Reinecke <hare@suse.de>