### PR TITLE
Parse 'address' string into components

### DIFF
--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -588,6 +588,30 @@ const char *nvme_ctrl_get_subsysnqn(nvme_ctrl_t c);
 nvme_subsystem_t nvme_ctrl_get_subsystem(nvme_ctrl_t c);
 
 /**
+ * nvme_ctrl_get_traddr() -
+ * @c:
+ *
+ * Return:
+ */
+const char *nvme_ctrl_get_traddr(nvme_ctrl_t c);
+
+/**
+ * nvme_ctrl_get_trsvcid() -
+ * @c:
+ *
+ * Return:
+ */
+const char *nvme_ctrl_get_trsvcid(nvme_ctrl_t c);
+
+/**
+ * nvme_ctrl_get_host_traddr() -
+ * @c:
+ *
+ * Return:
+ */
+const char *nvme_ctrl_get_host_traddr(nvme_ctrl_t c);
+
+/**
  * nvme_ctrl_identify() -
  * @c:
  * @id:


### PR DESCRIPTION
The 'address' string really are several parts (traddr, trsvcid, and
host_addr) which are separated by commas. So avoid every user having
to parse that string on its own this patch exposes the individual parts
via nvme_ctrl_get_{traddr,trsvcid,host_traddr}.
Each call might return NULL if the respective value isn't set.

Signed-off-by: Hannes Reinecke <hare@suse.de>