### PR TITLE
nvme/fabrics: fix compile error

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -657,8 +657,7 @@ static int uuid_from_systemd(char *system_uuid)
 
 	ret = sd_id128_get_machine_app_specific(NVME_HOSTNQN_ID, &id);
 	if (!ret)
-		asprintf(systemd_uuid, SD_ID128_FORMAT_STR,
-			 SD_ID128_FORMAT_VAL(id));
+		sd_id128_to_string(id, system_uuid);
 #endif
 	return ret;
 }


### PR DESCRIPTION
Fix string formatting of the uuid from systemd.

Fixes: 8999e3d9b218 ("fabrics: Read system UUID from DMI and merge hostnqn generation functions")
Signed-off-by: Klaus Jensen <k.jensen@samsung.com>