### PR TITLE
Rework tree reallocation

### DIFF
--- a/src/nvme/libnvme.i
+++ b/src/nvme/libnvme.i
@@ -167,9 +167,45 @@ static int discover_err = 0;
     struct nvmf_disc_log_entry *e = &log->entries[i];
     PyObject *entry = PyDict_New(), *val;
 
-    val = PyLong_FromLong(e->trtype);
+    switch (e->trtype) {
+    case NVMF_TRTYPE_UNSPECIFIED:
+      val = PyUnicode_FromString("unspecified");
+      break;
+    case NVMF_TRTYPE_RDMA:
+      val = PyUnicode_FromString("rdma");
+      break;
+    case NVMF_TRTYPE_FC:
+      val = PyUnicode_FromString("fc");
+      break;
+    case NVMF_TRTYPE_TCP:
+      val = PyUnicode_FromString("tcp");
+      break;
+    case NVMF_TRTYPE_LOOP:
+      val = PyUnicode_FromString("loop");
+      break;
+    default:
+      val = PyLong_FromLong(e->trtype);
+    }
     PyDict_SetItemString(entry, "trtype", val);
-    val = PyLong_FromLong(e->adrfam);
+    switch (e->adrfam) {
+    case NVMF_ADDR_FAMILY_PCI:
+      val = PyUnicode_FromString("pci");
+      break;
+    case NVMF_ADDR_FAMILY_IP4:
+      val = PyUnicode_FromString("ipv4");
+      break;
+    case NVMF_ADDR_FAMILY_IP6:
+      val = PyUnicode_FromString("ipv6");
+      break;
+    case NVMF_ADDR_FAMILY_IB:
+      val = PyUnicode_FromString("infiniband");
+      break;
+    case NVMF_ADDR_FAMILY_FC:
+      val = PyUnicode_FromString("fc");
+      break;
+    default:
+      val = PyLong_FromLong(e->adrfam);
+    }
     PyDict_SetItemString(entry, "adrfam", val);
     val = PyUnicode_FromString(e->traddr);
     PyDict_SetItemString(entry, "traddr", val);
@@ -177,9 +213,33 @@ static int discover_err = 0;
     PyDict_SetItemString(entry, "trsvcid", val);
     val = PyUnicode_FromString(e->subnqn);
     PyDict_SetItemString(entry, "subnqn", val);
-    val = PyLong_FromLong(e->subtype);
+    switch (e->subtype) {
+    case NVME_NQN_DISC:
+      val = PyUnicode_FromString("discovery");
+      break;
+    case NVME_NQN_NVME:
+      val = PyUnicode_FromString("nvme");
+      break;
+    default:
+      val = PyLong_FromLong(e->subtype);
+    }
     PyDict_SetItemString(entry, "subtype", val);
-    val = PyLong_FromLong(e->treq);
+    switch (e->treq) {
+    case NVMF_TREQ_NOT_SPECIFIED:
+      val = PyUnicode_FromString("not specified");
+      break;
+    case NVMF_TREQ_REQUIRED:
+      val = PyUnicode_FromString("required");
+      break;
+    case NVMF_TREQ_NOT_REQUIRED:
+      val = PyUnicode_FromString("not required");
+      break;
+    case NVMF_TREQ_DISABLE_SQFLOW:
+      val = PyUnicode_FromString("disable sqflow");
+      break;
+    default:
+      val = PyLong_FromLong(e->treq);
+    }
     PyDict_SetItemString(entry, "treq", val);
     val = PyLong_FromLong(e->portid);
     PyDict_SetItemString(entry, "portid", val);

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -59,7 +59,6 @@ struct nvme_ctrl {
 	struct list_head paths;
 	struct list_head namespaces;
 	struct nvme_subsystem *s;
-	int refcount;
 
 	int fd;
 	char *name;
@@ -90,7 +89,6 @@ struct nvme_subsystem {
 	struct list_head ctrls;
 	struct list_head namespaces;
 	struct nvme_host *h;
-	int refcount;
 
 	char *name;
 	char *sysfs_dir;
@@ -104,7 +102,6 @@ struct nvme_host {
 	struct list_node entry;
 	struct list_head subsystems;
 	struct nvme_root *r;
-	int refcount;
 
 	char *hostnqn;
 	char *hostid;
@@ -113,7 +110,6 @@ struct nvme_host {
 struct nvme_root {
 	char *config_file;
 	struct list_head hosts;
-	int refcount;
 	bool modified;
 };
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -32,6 +32,8 @@
 
 static struct nvme_host *default_host;
 
+static void __nvme_free_host(nvme_host_t h);
+static void __nvme_free_ctrl(nvme_ctrl_t c);
 static int nvme_subsystem_scan_namespace(struct nvme_subsystem *s, char *name);
 static int nvme_scan_subsystem(struct nvme_root *r, char *name,
 			       nvme_scan_filter_t f);
@@ -90,7 +92,6 @@ nvme_root_t nvme_scan_filter(nvme_scan_filter_t f)
 	}
 
 	list_head_init(&r->hosts);
-	r->refcount = 1;
 	nvme_scan_topology(r, f);
 	return r;
 }
@@ -153,7 +154,7 @@ void nvme_refresh_topology(nvme_root_t r)
 	struct nvme_host *h, *_h;
 
 	nvme_for_each_host_safe(r, h, _h)
-		nvme_free_host(h);
+		__nvme_free_host(h);
 	nvme_scan_topology(r, NULL);
 }
 
@@ -162,7 +163,7 @@ void nvme_reset_topology(nvme_root_t r)
 	struct nvme_host *h, *_h;
 
 	nvme_for_each_host_safe(r, h, _h)
-		nvme_free_host(h);
+		__nvme_free_host(h);
 	nvme_scan_topology(r, NULL);
 }
 
@@ -171,7 +172,7 @@ void nvme_free_tree(nvme_root_t r)
 	struct nvme_host *h, *_h;
 
 	nvme_for_each_host_safe(r, h, _h)
-		nvme_free_host(h);
+		__nvme_free_host(h);
 	if (r->config_file)
 		free(r->config_file);
 	free(r);
@@ -217,7 +218,7 @@ nvme_ns_t nvme_subsystem_next_ns(nvme_subsystem_t s, nvme_ns_t n)
 	return n ? list_next(&s->namespaces, n, entry) : NULL;
 }
 
-void nvme_free_ns(struct nvme_ns *n)
+static void __nvme_free_ns(struct nvme_ns *n)
 {
 	list_del_init(&n->entry);
 	close(n->fd);
@@ -226,20 +227,22 @@ void nvme_free_ns(struct nvme_ns *n)
 	free(n);
 }
 
-void nvme_free_subsystem(struct nvme_subsystem *s)
+/* Stub for SWIG */
+void nvme_free_ns(struct nvme_ns *n)
+{
+}
+
+static void __nvme_free_subsystem(struct nvme_subsystem *s)
 {
 	struct nvme_ctrl *c, *_c;
 	struct nvme_ns *n, *_n;
 
-	if (--s->refcount > 0)
-		return;
-
 	list_del_init(&s->entry);
 	nvme_subsystem_for_each_ctrl_safe(s, c, _c)
-		nvme_free_ctrl(c);
+		__nvme_free_ctrl(c);
 
 	nvme_subsystem_for_each_ns_safe(s, n, _n)
-		nvme_free_ns(n);
+		__nvme_free_ns(n);
 
 	free(s->name);
 	free(s->sysfs_dir);
@@ -251,6 +254,13 @@ void nvme_free_subsystem(struct nvme_subsystem *s)
 	if (s->firmware)
 		free(s->firmware);
 	free(s);
+}
+
+/*
+ * Stub for SWIG
+ */
+void nvme_free_subsystem(nvme_subsystem_t s)
+{
 }
 
 struct nvme_subsystem *nvme_lookup_subsystem(struct nvme_host *h,
@@ -265,7 +275,6 @@ struct nvme_subsystem *nvme_lookup_subsystem(struct nvme_host *h,
 		if (name && s->name &&
 		    strcmp(s->name, name))
 			continue;
-		s->refcount++;
 		return s;
 	}
 	s = calloc(1, sizeof(*s));
@@ -274,7 +283,6 @@ struct nvme_subsystem *nvme_lookup_subsystem(struct nvme_host *h,
 
 	s->h = h;
 	s->subsysnqn = strdup(subsysnqn);
-	s->refcount = 1;
 	list_head_init(&s->ctrls);
 	list_head_init(&s->namespaces);
 	list_node_init(&s->entry);
@@ -283,20 +291,23 @@ struct nvme_subsystem *nvme_lookup_subsystem(struct nvme_host *h,
 	return s;
 }
 
-void nvme_free_host(struct nvme_host *h)
+static void __nvme_free_host(struct nvme_host *h)
 {
 	struct nvme_subsystem *s, *_s;
 
-	if (--h->refcount > 0)
-		return;
 	list_del_init(&h->entry);
 	nvme_for_each_subsystem_safe(h, s, _s)
-		nvme_free_subsystem(s);
+		__nvme_free_subsystem(s);
 	free(h->hostnqn);
 	if (h->hostid)
 		free(h->hostid);
 	h->r->modified = true;
 	free(h);
+}
+
+/* Stub for SWIG */
+void nvme_free_host(struct nvme_host *h)
+{
 }
 
 struct nvme_host *nvme_lookup_host(nvme_root_t r, const char *hostnqn,
@@ -312,7 +323,6 @@ struct nvme_host *nvme_lookup_host(nvme_root_t r, const char *hostnqn,
 		if (hostid &&
 		    strcmp(h->hostid, hostid))
 			continue;
-		h->refcount++;
 		return h;
 	}
 	h = calloc(1,sizeof(*h));
@@ -324,7 +334,6 @@ struct nvme_host *nvme_lookup_host(nvme_root_t r, const char *hostnqn,
 	list_head_init(&h->subsystems);
 	list_node_init(&h->entry);
 	h->r = r;
-	h->refcount = 1;
 	list_add(&r->hosts, &h->entry);
 	r->modified = true;
 
@@ -428,7 +437,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, char *name,
 	nvme_subsystem_scan_ctrls(s);
 
 	if (f && !f(s)) {
-		nvme_free_subsystem(s);
+		__nvme_free_subsystem(s);
 		return -1;
 	}
 
@@ -741,13 +750,10 @@ void nvme_unlink_ctrl(nvme_ctrl_t c)
 	c->s = NULL;
 }
 
-void nvme_free_ctrl(nvme_ctrl_t c)
+static void __nvme_free_ctrl(nvme_ctrl_t c)
 {
 	struct nvme_path *p, *_p;
 	struct nvme_ns *n, *_n;
-
-	if (--c->refcount > 0)
-		return;
 
 	nvme_unlink_ctrl(c);
 
@@ -755,7 +761,7 @@ void nvme_free_ctrl(nvme_ctrl_t c)
 		nvme_free_path(p);
 
 	nvme_ctrl_for_each_ns_safe(c, n, _n)
-		nvme_free_ns(n);
+		__nvme_free_ns(n);
 
 	if (c->fd >= 0)
 		close(c->fd);
@@ -782,6 +788,11 @@ void nvme_free_ctrl(nvme_ctrl_t c)
 	free(c->sqsize);
 	free(c->transport);
 	free(c);
+}
+
+/* Stub for SWIG */
+void nvme_free_ctrl(nvme_ctrl_t c)
+{
 }
 
 #define ____stringify(x...) #x
@@ -902,7 +913,7 @@ struct nvme_ctrl *nvme_create_ctrl(const char *subsysnqn, const char *transport,
 		 !strncmp(transport, "tcp", 3)) {
 		nvme_msg(LOG_ERR, "No trsvcid specified for '%s'\n",
 			 transport);
-		nvme_free_ctrl(c);
+		__nvme_free_ctrl(c);
 		c = NULL;
 	}
 
@@ -932,14 +943,12 @@ struct nvme_ctrl *nvme_lookup_ctrl(struct nvme_subsystem *s, const char *transpo
 		if (trsvcid && c->trsvcid &&
 		    strcmp(c->trsvcid, trsvcid))
 			continue;
-		c->refcount++;
 		return c;
 	}
 	c = nvme_create_ctrl(s->subsysnqn, transport, traddr,
 			     host_traddr, host_iface, trsvcid);
 	if (c) {
 		c->s = s;
-		c->refcount = 1;
 		list_add(&s->ctrls, &c->entry);
 		s->h->r->modified = true;
 	}

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -90,6 +90,7 @@ nvme_root_t nvme_scan_filter(nvme_scan_filter_t f)
 	}
 
 	list_head_init(&r->hosts);
+	r->refcount = 1;
 	nvme_scan_topology(r, f);
 	return r;
 }
@@ -276,6 +277,7 @@ struct nvme_subsystem *nvme_lookup_subsystem(struct nvme_host *h,
 	s->refcount = 1;
 	list_head_init(&s->ctrls);
 	list_head_init(&s->namespaces);
+	list_node_init(&s->entry);
 	list_add(&h->subsystems, &s->entry);
 	h->r->modified = true;
 	return s;
@@ -525,6 +527,8 @@ static int nvme_ctrl_scan_path(struct nvme_ctrl *c, char *name)
 		free(grpid);
 	}
 
+	list_node_init(&p->nentry);
+	list_node_init(&p->entry);
 	list_add(&c->paths, &p->entry);
 	return 0;
 


### PR DESCRIPTION
The original idea of implementing refcounting turned out to be not really feasible, as without deep knowledge of SWIG and python internals it's not quite easy to see if and when refcounts would need to be acquired or dropped.
This has caused a SIGBUS error in the python interpreter when the example scripts are run.

So kill the entire refcounting idea and deallocate the internal tree on nvme_free_tree() _only_; that ensures that individual objects are always available and we don't have to worry about that.
It also means that the object deallocation methods liks nvme_free_ctrl() etc are now no-ops, and are kept purely for symmetry and to keep SWIG happy.
