### PR TITLE
Minor fixes for a couple of compilation failures

### DIFF
--- a/configure
+++ b/configure
@@ -228,16 +228,16 @@ print_config "cpp" "${cpp}"
 
 if test "$libuuid" = "yes"; then
   output_sym "CONFIG_LIBUUID"
-  echo "override LDFLAGS += -luuid" >> $config_host_mak
+  echo "override LIBS += -luuid" >> $config_host_mak
   echo "override LIB_DEPENDS += uuid" >> $config_host_mak 
 fi
 if test "$systemd" = "yes"; then
   output_sym "CONFIG_SYSTEMD"
-  echo "override LDFLAGS += -lsystemd" >> $config_host_mak
+  echo "override LIBS += -lsystemd" >> $config_host_mak
 fi
 if test "$libjsonc" = "yes"; then
     output_sym "CONFIG_JSONC"
-    echo "override LDFLAGS += -ljson-c" >> $config_host_mak
+    echo "override LIBS += -ljson-c" >> $config_host_mak
     echo "override LIB_DEPENDS += json-c" >> $config_host_mak
 fi
 if test "$cpp" = "yes"; then

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -12,7 +12,7 @@ all_targets += telemetry-listen display-tree display-columnar discover-loop
 all: $(all_targets)
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) -o $@ $< -lnvme ${LDFLAGS}
+	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)
 
 clean:
 	rm -f $(all_targets)

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,7 +72,7 @@ libnvme.a: $(libnvme_objs) $(libccan_objs)
 	$(QUIET_RANLIB)$(RANLIB) libnvme.a
 
 $(libname): $(libnvme_sobjs) $(libccan_sobjs) libnvme.map
-	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(LINK_FLAGS)
+	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(LINK_FLAGS) $(LIBS)
 
 install: $(all_targets)
 	$(INSTALL) -D -m 644 libnvme.a $(libdir)/libnvme.a

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -755,7 +755,7 @@ int nvme_set_features(int fd, __u8 fid, __u32 nsid, __u32 cdw11, __u32 cdw12,
 		.cdw11		= cdw11,
 		.cdw12		= cdw12,
 		.cdw14		= cdw14,
-		.cdw14		= cdw15,
+		.cdw15		= cdw15,
 	};
 
 	return nvme_submit_admin_passthru(fd, &cmd, result);

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ all: $(all_targets)
 CXXFLAGS ?= -lstdc++
 
 %: %.cc
-	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme $(LIBS)
+	$(QUIET_CC)$(CXX) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme $(LIBS)
 
 %: %.c
 	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,10 +23,10 @@ all: $(all_targets)
 CXXFLAGS ?= -lstdc++
 
 %: %.cc
-	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme
+	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme $(LIBS)
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme
+	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)
 
 clean:
 	rm -f $(all_targets)


### PR DESCRIPTION
This series includes a couple of compilation failures on my platform; the first for a link-order issue, the second for building c++ objects with plain `cc`. 

I've taken the approach of minimal change here; we may not need the full `$(LIBS)` on the `.so` link, but that's what the current build rules specify. Happy to update this if necessary.