### PR TITLE
Improvements to Python bindings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -77,10 +77,10 @@ libnvme.a: $(libnvme_objs) $(libccan_objs)
 $(libname): $(libnvme_sobjs) $(libccan_sobjs) libnvme.map
 	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(LINK_FLAGS)
 
-libnvme_wrap.c: $(libnvme_swig)
+nvme/libnvme_wrap.c: $(libnvme_swig)
 	$(SWIG) -python -py3 -outdir . $<
 
-python: libnvme_wrap.c setup.py
+python: nvme/libnvme_wrap.c setup.py
 	$(PYTHON) setup.py build
 
 install: $(all_targets)
@@ -99,5 +99,5 @@ clean:
 	rm -f $(all_targets) $(libnvme_objs) $(libnvme_sobjs) $(libccan_objs) $(libccan_sobjs) $(soname).new
 	rm -f $(CCANDIR)config.h
 	rm -f $(CCANDIR)tools/configurator/configurator
-	rm -f libnvme_wrap.c
+	rm -f nvme/libnvme_wrap.c
 	rm -f *.so* *.a *.o

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -309,7 +309,8 @@ static int __nvmf_add_ctrl(const char *argstr)
 		return -1;
 	}
 
-	nvme_msg(LOG_DEBUG, "connect ctrl, '%s'\n", argstr);
+	nvme_msg(LOG_DEBUG, "connect ctrl, '%.*s'\n",
+		 (int)strcspn(argstr,"\n"), argstr);
 	ret = write(fd, argstr, len);
 	if (ret != len) {
 		nvme_msg(LOG_NOTICE, "Failed to write to %s: %s\n",
@@ -325,7 +326,8 @@ static int __nvmf_add_ctrl(const char *argstr)
 		ret = -1;
 		goto out_close;
 	}
-	nvme_msg(LOG_DEBUG, "connect ctrl, response '%s'\n", buf);
+	nvme_msg(LOG_DEBUG, "connect ctrl, response '%.*s'\n",
+		 (int)strcspn(buf, "\n"), buf);
 	buf[len] = '\0';
 	options = buf;
 	while ((p = strsep(&options, ",\n")) != NULL) {

--- a/src/nvme/libnvme.i
+++ b/src/nvme/libnvme.i
@@ -161,6 +161,10 @@ static int discover_err = 0;
   $result = PyBytes_FromStringAndSize((char *)$1, 16);
 };
 
+%typemap(newfree) struct nvmf_discovery_log * {
+   if ($1) free($1);
+}
+
 %typemap(out) struct nvmf_discovery_log * {
   struct nvmf_discovery_log *log = $1;
   int numrec = log? log->numrec : 0, i;
@@ -520,6 +524,7 @@ struct nvme_ns {
   void disconnect() {
     nvme_disconnect_ctrl($self);
   }
+  %newobject discover;
   struct nvmf_discovery_log *discover(int max_retries = 6) {
     struct nvmf_discovery_log *logp = NULL;
     int ret = 0;

--- a/src/nvme/libnvme.i
+++ b/src/nvme/libnvme.i
@@ -18,6 +18,7 @@
 #include "tree.h"
 #include "fabrics.h"
 #include "private.h"
+#include "log.h"
 
 static int host_iter_err = 0;
 static int subsys_iter_err = 0;
@@ -97,7 +98,10 @@ static int discover_err = 0;
     SWIG_exception(SWIG_AttributeError, "Existing controller connection");
   } else if (connect_err) {
     connect_err = 0;
-    SWIG_exception(SWIG_RuntimeError, "Connect failed");
+    if (nvme_log_message)
+      SWIG_exception(SWIG_RuntimeError, nvme_log_message);
+    else
+      SWIG_exception(SWIG_RuntimeError, "Connect failed");
   }
 }
 
@@ -314,10 +318,29 @@ struct nvme_ns {
 
 %extend nvme_root {
   nvme_root(const char *config_file = NULL) {
+    nvme_log_level = LOG_ERR;
     return nvme_scan(config_file);
   }
   ~nvme_root() {
     nvme_free_tree($self);
+  }
+  void log_level(const char *level) {
+    if (!strcmp(level,"debug"))
+      nvme_log_level = LOG_DEBUG;
+    else if (!strcmp(level, "info"))
+      nvme_log_level = LOG_INFO;
+    else if (!strcmp(level, "notice"))
+      nvme_log_level = LOG_NOTICE;
+    else if (!strcmp(level, "warning"))
+      nvme_log_level = LOG_WARNING;
+    else if (!strcmp(level, "err"))
+      nvme_log_level = LOG_ERR;
+    else if (!strcmp(level, "crit"))
+      nvme_log_level = LOG_CRIT;
+    else if (!strcmp(level, "alert"))
+      nvme_log_level = LOG_ALERT;
+    else if (!strcmp(level, "emerg"))
+      nvme_log_level = LOG_EMERG;
   }
   struct nvme_host *hosts() {
     return nvme_first_host($self);

--- a/src/nvme/libnvme.i
+++ b/src/nvme/libnvme.i
@@ -6,11 +6,17 @@
  * Authors: Hannes Reinecke <hare@suse.de>
  */
 
-%module libnvme
+%module nvme
 
 %include "exception.i"
 
 %allowexception;
+
+%rename(root)      nvme_root;
+%rename(host)      nvme_host;
+%rename(ctrl)      nvme_ctrl;
+%rename(subsystem) nvme_subsystem;
+%rename(ns)        nvme_ns;
 
 %{
 #include <assert.h>
@@ -29,29 +35,29 @@ static int discover_err = 0;
 %}
 
 %inline %{
-  struct nvme_host_iter {
+  struct host_iter {
     struct nvme_root *root;
     struct nvme_host *pos;
   };
 
-  struct nvme_subsystem_iter {
+  struct subsystem_iter {
     struct nvme_host *host;
     struct nvme_subsystem *pos;
   };
 
-  struct nvme_ctrl_iter {
+  struct ctrl_iter {
     struct nvme_subsystem *subsystem;
     struct nvme_ctrl *pos;
   };
 
-  struct nvme_ns_iter {
+  struct ns_iter {
     struct nvme_subsystem *subsystem;
     struct nvme_ctrl *ctrl;
     struct nvme_ns *pos;
   };
 %}
 
-%exception nvme_host_iter::__next__ {
+%exception host_iter::__next__ {
   assert(!host_iter_err);
   $action
   if (host_iter_err) {
@@ -61,7 +67,7 @@ static int discover_err = 0;
   }
 }
 
-%exception nvme_subsystem_iter::__next__ {
+%exception subsystem_iter::__next__ {
   assert(!subsys_iter_err);
   $action
   if (subsys_iter_err) {
@@ -71,7 +77,7 @@ static int discover_err = 0;
   }
 }
 
-%exception nvme_ctrl_iter::__next__ {
+%exception ctrl_iter::__next__ {
   assert(!ctrl_iter_err);
   $action
   if (ctrl_iter_err) {
@@ -81,7 +87,7 @@ static int discover_err = 0;
   }
 }
 
-%exception nvme_ns_iter::__next__ {
+%exception ns_iter::__next__ {
   assert(!ns_iter_err);
   $action
   if (ns_iter_err) {
@@ -357,8 +363,8 @@ struct nvme_ns {
   }
 }
 
-%extend nvme_host_iter {
-  struct nvme_host_iter *__iter__() {
+%extend host_iter {
+  struct host_iter *__iter__() {
     return $self;
   }
   struct nvme_host *__next__() {
@@ -389,8 +395,8 @@ struct nvme_ns {
     sprintf(tmp, "nvme_host(%s,%s)", $self->hostnqn, $self->hostid);
     return tmp;
   }
-  struct nvme_host_iter __iter__() {
-    struct nvme_host_iter ret = { .root = nvme_host_get_root($self),
+  struct host_iter __iter__() {
+    struct host_iter ret = { .root = nvme_host_get_root($self),
 				     .pos = $self };
     return ret;
   }
@@ -399,8 +405,8 @@ struct nvme_ns {
   }
 }
 
-%extend nvme_subsystem_iter {
-  struct nvme_subsystem_iter *__iter__() {
+%extend subsystem_iter {
+  struct subsystem_iter *__iter__() {
     return $self;
   }
   struct nvme_subsystem *__next__() {
@@ -415,8 +421,8 @@ struct nvme_ns {
   }
 }
 
-%extend nvme_ns_iter {
-  struct nvme_ns_iter *__iter__() {
+%extend ns_iter {
+  struct ns_iter *__iter__() {
     return $self;
   }
   struct nvme_ns *__next__() {
@@ -448,8 +454,8 @@ struct nvme_ns {
     sprintf(tmp, "nvme_subsystem(%s,%s)", $self->name,$self->subsysnqn);
     return tmp;
   }
-  struct nvme_subsystem_iter __iter__() {
-    struct nvme_subsystem_iter ret = { .host = nvme_subsystem_get_host($self),
+  struct subsystem_iter __iter__() {
+    struct subsystem_iter ret = { .host = nvme_subsystem_get_host($self),
 				       .pos = $self };
     return ret;
   }
@@ -474,8 +480,8 @@ struct nvme_ns {
   }
 %};
 
-%extend nvme_ctrl_iter {
-  struct nvme_ctrl_iter *__iter__() {
+%extend ctrl_iter {
+  struct ctrl_iter *__iter__() {
     return $self;
   }
   struct nvme_ctrl *__next__() {
@@ -545,8 +551,8 @@ struct nvme_ns {
       sprintf(tmp, "nvme_ctrl(transport=%s)", $self->transport);
     return tmp;
   }
-  struct nvme_ctrl_iter __iter__() {
-    struct nvme_ctrl_iter ret = { .subsystem = nvme_ctrl_get_subsystem($self),
+  struct ctrl_iter __iter__() {
+    struct ctrl_iter ret = { .subsystem = nvme_ctrl_get_subsystem($self),
 				  .pos = $self };
     return ret;
   }
@@ -586,8 +592,8 @@ struct nvme_ns {
     sprintf(tmp, "nvme_ns(%u)", $self->nsid);
     return tmp;
   }
-  struct nvme_ns_iter __iter__() {
-    struct nvme_ns_iter ret = { .ctrl = nvme_ns_get_ctrl($self),
+  struct ns_iter __iter__() {
+    struct ns_iter ret = { .ctrl = nvme_ns_get_ctrl($self),
 				.subsystem = nvme_ns_get_subsystem($self),
 				.pos = $self };
     return ret;

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -23,6 +23,7 @@
 extern int nvme_log_level;
 extern bool nvme_log_timestamp;
 extern bool nvme_log_pid;
+extern char *nvme_log_message;
 
 void __attribute__((format(printf, 3, 4)))
 __nvme_msg(int lvl, const char *func, const char *format, ...);

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup, Extension
 
-libnvme_module = Extension('_libnvme',
+libnvme_module = Extension('_nvme',
         sources=['nvme/libnvme_wrap.c'],
         libraries=['nvme', 'json-c', 'uuid', 'systemd'], library_dirs=['./'],
         include_dirs = ['../ccan','nvme'])
@@ -10,5 +10,5 @@ setup(name='libnvme',
       author_email='hare@suse.de',
       description='python bindings for libnvme',
       ext_modules=[libnvme_module],
-      py_modules=["libnvme"],
+      py_modules=["nvme"],
 )


### PR DESCRIPTION
This pull requests contains these items:

- Changes made by Hannes and me for improved logging
- A memory leak was fixed in the Python wrapper code (SWIG)
- The Python class names were renamed to simplify the syntax (before-and-after example below)

Python class renaming:
Before:
```
from libnvme import libnvme
root = libnvme.nvme_root()
host = libnvme.nvme_host(root)
ctrl = libnvme.nvme_ctrl(.....)
```
After:
```
from libnvme import nvme
root = nvme.root()
host = nvme.host(root)
ctrl = nvme.ctrl(.....)
```
