### PR TITLE
build: Fix build without json-c

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ libnvme_priv := nvme/private.h
 libnvme_api := libnvme.h nvme/types.h nvme/ioctl.h nvme/filters.h nvme/tree.h nvme/util.h nvme/fabrics.h
 libnvme_srcs := nvme/ioctl.c nvme/filters.c nvme/fabrics.c nvme/util.c nvme/tree.c nvme/log.c nvme/cleanup.c
 libnvme_swig := nvme/libnvme.i
-ifneq ($(CONFIG_JSONC),0)
+ifeq ($(CONFIG_JSONC),y)
 override libnvme_srcs += nvme/json.c
 endif
 libnvme_objs := $(patsubst %.c,%.ol,$(libnvme_srcs))

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -101,10 +101,12 @@ nvme_root_t nvme_scan(const char *config_file)
 {
 	nvme_root_t r = nvme_scan_filter(NULL);
 
+#ifdef CONFIG_JSONC
 	if (r && config_file) {
 		json_read_config(r, config_file);
 		r->config_file = strdup(config_file);
 	}
+#endif
 	return r;
 }
 
@@ -112,7 +114,12 @@ int nvme_update_config(nvme_root_t r)
 {
 	if (!r->modified || !r->config_file)
 		return 0;
+#ifdef CONFIG_JSONC
 	return json_update_config(r, r->config_file);
+#else
+	errno = ENOTSUP;
+	return -1;
+#endif
 }
 
 nvme_host_t nvme_first_host(nvme_root_t r)


### PR DESCRIPTION
Minor build fixes when `json-c` is disabled during `configure`.

The `nvme_update_config()` function doesn't make much sense in that case, returning an error instead.