### PR TITLE
types: Device self-test doc strings update

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -715,7 +715,7 @@ enum nvme_directive_send_doper {
 };
 
 /**
- * enum -
+ * enum nvme_directive_send_identify_endir -
  */
 enum nvme_directive_send_identify_endir {
 	NVME_DIRECTIVE_SEND_IDENTIFY_ENDIR_DISABLE		= 0,
@@ -737,11 +737,11 @@ enum nvme_sanitize_sanact {
 };
 
 /**
- * enum nvme_dst_stc -
- * @NVME_DST_STC_SHORT:
- * @NVME_DST_STC_LONG:
- * @NVME_DST_STC_VS:
- * @NVME_DST_STC_ABORT:
+ * enum nvme_dst_stc - Action taken by the Device Self-test command
+ * @NVME_DST_STC_SHORT:	 Start a short device self-test operation
+ * @NVME_DST_STC_LONG:	 Start an extended device self-test operation
+ * @NVME_DST_STC_VS:	 Start a vendor specific device self-test operation
+ * @NVME_DST_STC_ABORT:	 Abort device self-test operation
  */
 enum nvme_dst_stc {
 	NVME_DST_STC_SHORT					= 0x1,


### PR DESCRIPTION
Doc strings update related to the device self-test log page retrieval and the self-test command issue.

Also proposing some API changes as included in this commit:
* renamed `NVME_ST_CODE_RESRVED` to `NVME_ST_CODE_RESERVED`
* added the `enum nvme_st_curr_op` definiton:
  * while the `enum nvme_st_curr_op` and `enum nvme_st_code` struct members are mostly similar, the former relates to the current running operation within the `struct nvme_self_test_log` structure, the latter relates to finished test results. These two are also defined separately in the nvme standard whitepaper.

Feel free to align naming of the mentioned symbols to fit the library conventions, might be just mine interpretation of the nvme specs...