### PR TITLE
Support for cross-compiling libnvme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ examples/display-columnar
 examples/telemetry-listen
 examples/discover-loop
 
-ccan/config.h
 ccan/tools/configurator/configurator
 
 doc/_build

--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ SED_PROCESS = \
 	$(SED_PROCESS)
 
 install: $(NAME).pc
-	@$(MAKE) -C src install prefix=$(DESTDIR)$(prefix) includedir=$(DESTDIR)$(includedir) libdir=$(DESTDIR)$(libdir)
+	@$(MAKE) -C src install
 	$(INSTALL) -D -m 644 $(NAME).pc $(DESTDIR)$(libdir)/pkgconfig/$(NAME).pc
 	$(INSTALL) -m 755 -d $(DESTDIR)$(mandir)/man2
 	$(INSTALL) -m 644 doc/man/*.2 $(DESTDIR)$(mandir)/man2
 
 install-tests:
-	@$(MAKE) -C test install prefix=$(DESTDIR)$(prefix) datadir=$(DESTDIR)$(datadir)
+	@$(MAKE) -C test install
 
 clean:
 	@rm -f config-host.mak config-host.h cscope.out $(NAME).pc

--- a/ccan/config.h
+++ b/ccan/config.h
@@ -1,0 +1,25 @@
+/* Prepopulated config.h header from libnvme; we'll be building with gcc */
+#ifndef CCAN_CONFIG_H
+#define CCAN_CONFIG_H
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* Always use GNU extensions. */
+#endif
+#define CCAN_COMPILER "cc"
+#define CCAN_CFLAGS "-g3 -ggdb -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition"
+
+#define HAVE_BSWAP_64 1
+#define HAVE_BUILTIN_TYPES_COMPATIBLE_P 1
+#define HAVE_BYTESWAP_H 1
+#define HAVE_ISBLANK 1
+#define HAVE_STATEMENT_EXPR 1
+#define HAVE_TYPEOF 1
+
+#if __BYTEORDER == __LITTLE_ENDIAN
+#define HAVE_LITTLE_ENDIAN 1
+#endif
+
+#if __BYTEORDER == __BIG_ENDIAN
+#define HAVE_BIG_ENDIAN 1
+#endif
+
+#endif /* CCAN_CONFIG_H */

--- a/configure
+++ b/configure
@@ -228,16 +228,16 @@ print_config "cpp" "${cpp}"
 
 if test "$libuuid" = "yes"; then
   output_sym "CONFIG_LIBUUID"
-  echo "override LDFLAGS += -luuid" >> $config_host_mak
+  echo "override LIBS += -luuid" >> $config_host_mak
   echo "override LIB_DEPENDS += uuid" >> $config_host_mak 
 fi
 if test "$systemd" = "yes"; then
   output_sym "CONFIG_SYSTEMD"
-  echo "override LDFLAGS += -lsystemd" >> $config_host_mak
+  echo "override LIBS += -lsystemd" >> $config_host_mak
 fi
 if test "$libjsonc" = "yes"; then
     output_sym "CONFIG_JSONC"
-    echo "override LDFLAGS += -ljson-c" >> $config_host_mak
+    echo "override LIBS += -ljson-c" >> $config_host_mak
     echo "override LIB_DEPENDS += json-c" >> $config_host_mak
 fi
 if test "$cpp" = "yes"; then

--- a/configure
+++ b/configure
@@ -219,7 +219,11 @@ print_config "libjson-c" "${libjsonc}"
 ##########################################
 # check for c++
 cpp="no"
-which g++ > /dev/null 2> /dev/null
+cpp_binary=$CXX
+if [ -z "$cpp_binary" ] ; then
+    cpp_binary=g++
+fi
+which $cpp_binary > /dev/null 2> /dev/null
 if [ $? -eq 0 ]; then
   cpp="yes"
 fi

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -12,7 +12,7 @@ all_targets += telemetry-listen display-tree display-columnar discover-loop
 all: $(all_targets)
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) -o $@ $< -lnvme ${LDFLAGS}
+	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)
 
 clean:
 	rm -f $(all_targets)

--- a/examples/display-columnar.c
+++ b/examples/display-columnar.c
@@ -10,6 +10,7 @@
  * display-columnar: Scans the nvme topology, prints each record type in a
  * column format for easy visual scanning.
  */
+#include <inttypes.h>
 #include <stdio.h>
 #include <libnvme.h>
 
@@ -90,7 +91,7 @@ int main()
 		nvme_for_each_subsystem(h, s) {
 			nvme_subsystem_for_each_ctrl(s, c) {
 				nvme_ctrl_for_each_ns(c, n)
-					printf("%-12s %-8d %-16lu %-8d %s\n",
+					printf("%-12s %-8d %-16" PRIu64 " %-8d %s\n",
 					       nvme_ns_get_name(n),
 					       nvme_ns_get_nsid(n),
 					       nvme_ns_get_lba_count(n),
@@ -101,7 +102,7 @@ int main()
 			nvme_subsystem_for_each_ns(s, n) {
 				bool first = true;
 
-				printf("%-12s %-8d %-16lu %-8d ",
+				printf("%-12s %-8d %-16" PRIu64 " %-8d ",
 				       nvme_ns_get_name(n),
 				       nvme_ns_get_nsid(n),
 				       nvme_ns_get_lba_count(n),

--- a/examples/display-tree.c
+++ b/examples/display-tree.c
@@ -10,6 +10,7 @@
  * display-tree: Scans the nvme topology, prints as an ascii tree with some
  * selected attributes for each component.
  */
+#include <inttypes.h>
 #include <stdio.h>
 #include <libnvme.h>
 
@@ -34,7 +35,7 @@ int main()
 			       nvme_subsystem_get_nqn(s));
 
 			nvme_subsystem_for_each_ns_safe(s, n, _n) {
-				printf("%c   |-- %s lba size:%d lba max:%lu\n",
+				printf("%c   |-- %s lba size:%d lba max:%" PRIu64 "\n",
 				       _s ? '|' : ' ',
 				       nvme_ns_get_name(n),
 				       nvme_ns_get_lba_size(n),
@@ -50,7 +51,7 @@ int main()
 				       nvme_ctrl_get_state(c));
 
 				nvme_ctrl_for_each_ns_safe(c, n, _n)
-					printf("%c   %c   %c-- %s lba size:%d lba max:%lu\n",
+					printf("%c   %c   %c-- %s lba size:%d lba max:%" PRIu64 "\n",
 					       _s ? '|' : ' ', _c ? '|' : ' ',
 					       _n ? '|' : '`',
 					       nvme_ns_get_name(n),

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,9 +38,6 @@ include ../Makefile.quiet
 
 all: $(all_targets)
 
-$(CCANDIR)config.h: $(CCANDIR)tools/configurator/configurator
-	$< > $@
-
 libccan_headers := $(wildcard $(CCANDIR)ccan/*/*.h)
 libccan_srcs := $(wildcard $(CCANDIR)ccan/*/*.c)
 libccan_objs := $(patsubst %.c,%.ol,$(libccan_srcs))
@@ -90,6 +87,4 @@ $(libccan_objs): $(libccan_headers) $(CCANDIR)config.h
 
 clean:
 	rm -f $(all_targets) $(libnvme_objs) $(libnvme_sobjs) $(libccan_objs) $(libccan_sobjs) $(soname).new
-	rm -f $(CCANDIR)config.h
-	rm -f $(CCANDIR)tools/configurator/configurator
 	rm -f *.so* *.a *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,8 +20,6 @@ libnvme_CFLAGS = -Wall -fPIC
 libnvme_SO_CFLAGS = $(libnvme_CFLAGS) -shared
 libnvme_L_CFLAGS = $(libnvme_CFLAGS)
 
-LINK_FLAGS= -L /usr/lib64
-LINK_FLAGS+=$(LDFLAGS)
 ENABLE_SHARED ?= 1
 SED ?= sed
 INSTALL ?= install
@@ -76,7 +74,7 @@ libnvme.a: $(libnvme_objs) $(libccan_objs)
 	$(QUIET_RANLIB)$(RANLIB) libnvme.a
 
 $(libname): $(libnvme_sobjs) $(libccan_sobjs) libnvme.map
-	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(libnvme_SO_CFLAGS) $(LINK_FLAGS) $(LIBS)
+	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(libnvme_SO_CFLAGS) $(LDFLAGS) $(LIBS)
 
 install: $(all_targets)
 	$(INSTALL) -D -m 644 libnvme.a $(DESTDIR)$(libdir)/libnvme.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,10 +12,14 @@ libdir ?= $(prefix)/lib
 
 CCANDIR=../ccan/
 
-CFLAGS ?= -g -fomit-frame-pointer -O2 -I/usr/include -Invme/ -I$(CCANDIR) -include ../config-host.h -D_GNU_SOURCE
-override CFLAGS += -Wall -fPIC
-SO_CFLAGS=-shared $(CFLAGS)
-L_CFLAGS=$(CFLAGS)
+libnvme_CPPFLAGS = -Invme/ -I$(CCANDIR) -include ../config-host.h -D_GNU_SOURCE
+
+CFLAGS ?= -g -fomit-frame-pointer -O2
+libnvme_CFLAGS = -Wall -fPIC
+
+libnvme_SO_CFLAGS = $(libnvme_CFLAGS) -shared
+libnvme_L_CFLAGS = $(libnvme_CFLAGS)
+
 LINK_FLAGS= -L /usr/lib64
 LINK_FLAGS+=$(LDFLAGS)
 ENABLE_SHARED ?= 1
@@ -58,10 +62,10 @@ libnvme_sobjs := $(patsubst %.c,%.os,$(libnvme_srcs))
 $(libnvme_objs) $(libnvme_sobjs): $(libnvme_api) $(libnvme_private) $(libccan_objs)
 
 %.os: %.c
-	$(QUIET_CC)$(CC) $(SO_CFLAGS) -c -o $@ $<
+	$(QUIET_CC)$(CC) $(libnvme_CPPFLAGS) $(CPPFLAGS) $(libnvme_SO_CFLAGS) $(CFLAGS) -c -o $@ $<
 
 %.ol: %.c
-	$(QUIET_CC)$(CC) $(L_CFLAGS) -c -o $@ $<
+	$(QUIET_CC)$(CC) $(libnvme_CPPFLAGS) $(CPPFLAGS) $(libnvme_L_CFLAGS) $(CFLAGS) -c -o $@ $<
 
 AR ?= ar
 RANLIB ?= ranlib
@@ -72,7 +76,7 @@ libnvme.a: $(libnvme_objs) $(libccan_objs)
 	$(QUIET_RANLIB)$(RANLIB) libnvme.a
 
 $(libname): $(libnvme_sobjs) $(libccan_sobjs) libnvme.map
-	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(LINK_FLAGS) $(LIBS)
+	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(libnvme_SO_CFLAGS) $(LINK_FLAGS) $(LIBS)
 
 install: $(all_targets)
 	$(INSTALL) -D -m 644 libnvme.a $(DESTDIR)$(libdir)/libnvme.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -75,12 +75,12 @@ $(libname): $(libnvme_sobjs) $(libccan_sobjs) libnvme.map
 	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(LINK_FLAGS) $(LIBS)
 
 install: $(all_targets)
-	$(INSTALL) -D -m 644 libnvme.a $(libdir)/libnvme.a
-	for i in $(libnvme_api); do $(INSTALL) -D -m 644 $$i $(includedir)/$$i; done
+	$(INSTALL) -D -m 644 libnvme.a $(DESTDIR)$(libdir)/libnvme.a
+	for i in $(libnvme_api); do $(INSTALL) -D -m 644 $$i $(DESTDIR)$(includedir)/$$i; done
 ifeq ($(ENABLE_SHARED),1)
-	$(INSTALL) -D -m 755 $(libname) $(libdir)/$(libname)
-	ln -sf $(libname) $(libdir)/$(soname)
-	ln -sf $(libname) $(libdir)/libnvme.so
+	$(INSTALL) -D -m 755 $(libname) $(DESTDIR)$(libdir)/$(libname)
+	ln -sf $(libname) $(DESTDIR)$(libdir)/$(soname)
+	ln -sf $(libname) $(DESTDIR)$(libdir)/libnvme.so
 endif
 
 $(libnvme_objs): $(libnvme_api) $(libnvme_private)

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,7 +72,7 @@ libnvme.a: $(libnvme_objs) $(libccan_objs)
 	$(QUIET_RANLIB)$(RANLIB) libnvme.a
 
 $(libname): $(libnvme_sobjs) $(libccan_sobjs) libnvme.map
-	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(LINK_FLAGS)
+	$(QUIET_CC)$(CC) $(SO_CFLAGS) -Wl,--version-script=libnvme.map -Wl,-soname=$(soname) -o $@ $(libnvme_sobjs) $(libccan_sobjs) $(LINK_FLAGS) $(LIBS)
 
 install: $(all_targets)
 	$(INSTALL) -D -m 644 libnvme.a $(libdir)/libnvme.a

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -10,6 +10,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -557,7 +558,7 @@ int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 		}
 
 		genctr = le64_to_cpu(log->genctr);
-		nvme_msg(LOG_DEBUG, "%s: discover genctr %lu, retry\n",
+		nvme_msg(LOG_DEBUG, "%s: discover genctr %" PRIu64 ", retry\n",
 			 name, genctr);
 		ret = nvme_discovery_log(nvme_ctrl_get_fd(c), hdr, log, true);
 		if (ret) {
@@ -574,7 +575,8 @@ int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 		errno = EAGAIN;
 		ret = -1;
 	} else if (numrec != le64_to_cpu(log->numrec)) {
-		nvme_msg(LOG_INFO, "%s: could only fetch %lu of %lu records\n",
+		nvme_msg(LOG_INFO,
+			 "%s: could only fetch %" PRIu64 " of %" PRIu64 " records\n",
 			 name, numrec, le64_to_cpu(log->numrec));
 		errno = EBADSLT;
 		ret = -1;

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -755,7 +755,7 @@ int nvme_set_features(int fd, __u8 fid, __u32 nsid, __u32 cdw11, __u32 cdw12,
 		.cdw11		= cdw11,
 		.cdw12		= cdw12,
 		.cdw14		= cdw14,
-		.cdw14		= cdw15,
+		.cdw15		= cdw15,
 	};
 
 	return nvme_submit_admin_passthru(fd, &cmd, result);

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -5,6 +5,7 @@
 #ifndef _LOG_H
 #define _LOG_H
 
+#include <stdbool.h>
 #include <syslog.h>
 
 #ifndef MAX_LOGLEVEL

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ all: $(all_targets)
 CXXFLAGS ?= -lstdc++
 
 %: %.cc
-	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme $(LIBS)
+	$(QUIET_CC)$(CXX) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme $(LIBS)
 
 %: %.c
 	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,10 +23,10 @@ all: $(all_targets)
 CXXFLAGS ?= -lstdc++
 
 %: %.cc
-	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme
+	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme $(LIBS)
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme
+	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)
 
 clean:
 	rm -f $(all_targets)

--- a/test/test.c
+++ b/test/test.c
@@ -15,6 +15,7 @@
  * program exists successfully; an ungraceful exit means a bug exists
  * somewhere.
  */
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
@@ -270,7 +271,7 @@ static int test_namespace(nvme_ns_t n)
 	if (ret)
 		return ret;
 
-	printf("%s: nsze:%lx lba size:%d\n", nvme_ns_get_name(n), le64_to_cpu(ns.nsze),
+	printf("%s: nsze:%" PRIx64 " lba size:%d\n", nvme_ns_get_name(n), le64_to_cpu(ns.nsze),
 		1 << ns.lbaf[ns.flbas & NVME_NS_FLBAS_LBA_MASK].ds);
 
 	ret = nvme_identify_allocated_ns(fd, nsid, &allocated);
@@ -363,7 +364,7 @@ int main(int argc, char **argv)
 					char uuid_str[40];
 					uuid_t uuid;
 #endif
-					printf("   `- %s lba size:%d lba max:%lu\n",
+					printf("   `- %s lba size:%d lba max:%" PRIu64 "\n",
 					       nvme_ns_get_name(n),
 					       nvme_ns_get_lba_size(n),
 					       nvme_ns_get_lba_count(n));
@@ -386,7 +387,7 @@ int main(int argc, char **argv)
 			}
 
 			nvme_subsystem_for_each_ns(s, n) {
-				printf(" `- %s lba size:%d lba max:%lu\n",
+				printf(" `- %s lba size:%d lba max:%" PRIu64 "\n",
 				       nvme_ns_get_name(n),
 				       nvme_ns_get_lba_size(n),
 				       nvme_ns_get_lba_count(n));


### PR DESCRIPTION
[ this is more a review request than a pull request; I'm happy to rework in response to feedback. ]

This series adds a bunch of little cleanups to enable cross-compilation of libnvme. There are a couple of assumptions and hard-coded tools/paths that we can unify to standard-ish Makefile conventions.

The other option would be to go full autoconf+automake, but I assume there's reasons for not using those, so I'll stick with this approach for now. Let me know if you'd prefer otherwise.

This is based on my `fixes` branch - the first three patches are general bugfixes; those are covered by https://github.com/linux-nvme/libnvme/pull/15 .