### PR TITLE
Fix compiler warning

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -689,7 +689,9 @@ char *nvmf_hostnqn_generate()
 	if (ret < 0)
 		return NULL;
 
-	asprintf(&hostnqn, "nqn.2014-08.org.nvmexpress:uuid:%s\n", uuid_str);
+	if (asprintf(&hostnqn, "nqn.2014-08.org.nvmexpress:uuid:%s\n", uuid_str) < 0)
+		return NULL;
+
 	return hostnqn;
 }
 


### PR DESCRIPTION
This fixes:
```
nvme/fabrics.c:692:2: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
  692 |  asprintf(&hostnqn, "nqn.2014-08.org.nvmexpress:uuid:%s\n", uuid_str);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```