### PR TITLE
Allow control objects to be deleted.

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -830,9 +830,9 @@ static void __nvme_free_ctrl(nvme_ctrl_t c)
 	free(c);
 }
 
-/* Stub for SWIG */
 void nvme_free_ctrl(nvme_ctrl_t c)
 {
+	__nvme_free_ctrl(c);
 }
 
 #define ____stringify(x...) #x


### PR DESCRIPTION
Function `nvme_free_ctrl()` was previously defined as an empty stub. Instead, we now allow `nvme_free_ctrl()` to delete ctrl objects by calling `__nvme_free_ctrl()`.