### PR TITLE
Scanning fixes

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,7 +11,7 @@ all_targets += telemetry-listen display-tree display-columnar discover-loop
 
 all: $(all_targets)
 
-%: %.c
+%: %.c ../src/libnvme.a
 	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)
 
 clean:

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -560,6 +560,8 @@ static int nvme_ctrl_scan_path(struct nvme_ctrl *c, char *name)
 	p->name = strdup(name);
 	p->sysfs_dir = path;
 	p->ana_state = nvme_get_path_attr(p, "ana_state");
+	if (!p->ana_state)
+		p->ana_state = strdup("optimized");
 
 	grpid = nvme_get_path_attr(p, "ana_grpid");
 	if (grpid) {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -802,6 +802,7 @@ static void __nvme_free_ctrl(nvme_ctrl_t c)
 	nvme_deconfigure_ctrl(c);
 
 	FREE_CTRL_ATTR(c->transport);
+	FREE_CTRL_ATTR(c->subsysnqn);
 	FREE_CTRL_ATTR(c->traddr);
 	FREE_CTRL_ATTR(c->host_traddr);
 	FREE_CTRL_ATTR(c->host_iface);

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -754,8 +754,10 @@ static int __nvme_set_attr(const char *path, const char *value)
 
 	fd = open(path, O_WRONLY);
 	if (fd < 0) {
+#if 0
 		nvme_msg(LOG_DEBUG, "Failed to open %s: %s\n", path,
 			 strerror(errno));
+#endif
 		return -1;
 	}
 	ret = write(fd, value, strlen(value));
@@ -784,8 +786,10 @@ static char *__nvme_get_attr(const char *path)
 
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
+#if 0
 		nvme_msg(LOG_DEBUG, "Failed to open %s: %s\n", path,
 			 strerror(errno));
+#endif
 		return NULL;
 	}
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,10 +22,10 @@ all: $(all_targets)
 
 CXXFLAGS ?= -lstdc++
 
-%: %.cc
+%: %.cc ../src/libnvme.a
 	$(QUIET_CC)$(CXX) $(CFLAGS) $(LDFLAGS) $(CXXFLAGS) -o $@ $< -lnvme $(LIBS)
 
-%: %.c
+%: %.c ../src/libnvme.a
 	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lnvme $(LIBS)
 
 clean:


### PR DESCRIPTION
Hi all,

I've found that 'test/cpp.cc' doesn't work on older kernels, for a variety of reasons:
- It'll crash on PCIe controllers, as older kernels don't provide an 'address' sysfs attribute
- It will only display a subset of the found controllers and paths, as C++ '<<' operator silently aborts the program (!)
  if the called function returns 'NULL'.
With this patchset the 'cpp' program is fixed to return all informations.