### PR TITLE
Fix bug in `nvme_identify_iocs`

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -497,7 +497,7 @@ int nvme_identify_ns_csi(int fd, __u32 nsid, __u8 csi, void *data)
 int nvme_identify_iocs(int fd, __u16 cntlid, struct nvme_id_iocs *iocs)
 {
 	BUILD_ASSERT(sizeof(struct nvme_id_iocs) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_CSI_CTRL, NVME_NSID_NONE,
+	return nvme_identify(fd, NVME_IDENTIFY_CNS_COMMAND_SET_STRUCTURE, NVME_NSID_NONE,
 			     cntlid, NVME_NVMSETID_NONE, NVME_UUID_NONE,
 			     NVME_CSI_NVM, iocs);
 }

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -451,6 +451,7 @@ enum nvme_admin_opcode {
  * @NVME_IDENTIFY_CNS_NS_GRANULARITY:
  * @NVME_IDENTIFY_CNS_UUID_LIST:
  * @NVME_IDENTIFY_CNS_CSI_ALLOCATED_NS:
+ * @NVME_IDENTIFY_CNS_COMMAND_SET_STRUCTURE: Base Specification 2.0a section 5.17.2.21
  */
 enum nvme_identify_cns {
 	NVME_IDENTIFY_CNS_NS					= 0x00,
@@ -469,6 +470,7 @@ enum nvme_identify_cns {
 	NVME_IDENTIFY_CNS_NS_GRANULARITY			= 0x16,
 	NVME_IDENTIFY_CNS_UUID_LIST				= 0x17,
 	NVME_IDENTIFY_CNS_CSI_ALLOCATED_NS			= 0x18, /* XXX: Placeholder until assigned */
+	NVME_IDENTIFY_CNS_COMMAND_SET_STRUCTURE			= 0x1C,
 };
 
 /**


### PR DESCRIPTION
This patch fixes a bug in `nvme_identify_iocs` where the wrong CNS value used in
the Identify Command data structure.

Signed-off-by: Andreas Hindborg <andreas.hindborg@wdc.com>