### PR TITLE
libnvme.map: Add nvme_get_attr

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -59,6 +59,7 @@
 		nvme_fw_download;
 		nvme_fw_download_seq;
 		nvme_get_ana_log_len;
+		nvme_get_attr;
 		nvme_get_ctrl_attr;
 		nvme_get_ctrl_telemetry;
 		nvme_get_directive_receive_length;


### PR DESCRIPTION
nvme_get_attr is missing in the export.

Signed-off-by: Daniel Wagner <dwagner@suse.de>