### PR TITLE
Fix compiler warning.

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1120,7 +1120,8 @@ int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance)
 		else
 			path = NULL;
 		if (ret < 0) {
-			nvme_msg(LOG_ERR, "Failed to init subsystem %s\n", path);
+			nvme_msg(LOG_ERR, "Failed to init subsystem %s/%s\n",
+				 nvme_subsys_sysfs_dir, subsys_name);
 			if (path)
 				free(path);
 			goto out_free_subsys;


### PR DESCRIPTION
Fix a compiler warning reported by @igaw in https://github.com/linux-nvme/libnvme/pull/43#issuecomment-937931622

The variable `path` could be  `NULL`, which the compiler warns about when we try to print it with `nvme_msg()`.

https://user-images.githubusercontent.com/1050803/136421499-a4fc35cf-face-48a3-9729-6e07cdeb7257.png

Signed-off-by: Martin Belanger <martin.belanger@dell.com>