### PR TITLE
Add 'nvme_dump_config()' function

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -48,6 +48,7 @@
 		nvme_disconnect_ctrl;
 		nvme_dsm;
 		nvme_dsm_range;
+		nvme_dump_config;
 		nvme_first_host;
 		nvme_first_subsystem;
 		nvme_flush;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -763,7 +763,7 @@ out_free_log:
 
 #define PATH_UUID_IBM	"/proc/device-tree/ibm,partition-uuid"
 
-int uuid_from_device_tree(char *system_uuid)
+static int uuid_from_device_tree(char *system_uuid)
 {
 	ssize_t len;
 	int f;
@@ -781,7 +781,7 @@ int uuid_from_device_tree(char *system_uuid)
 
 #define PATH_DMI_ENTRIES       "/sys/firmware/dmi/entries"
 
-int uuid_from_dmi(char *system_uuid)
+static int uuid_from_dmi(char *system_uuid)
 {
 	int f;
 	DIR *d;

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -267,10 +267,15 @@ int json_update_config(nvme_root_t r, const char *config_file)
 			json_object_put(subsys_array);
 		json_object_array_add(json_root, host_obj);
 	}
-	if (json_object_to_file_ext(config_file, json_root,
-				    JSON_C_TO_STRING_PRETTY) < 0) {
-		nvme_msg(LOG_ERR, "Failed to write %s, %s\n",
-			config_file, json_util_get_last_err());
+	if (!config_file)
+		ret = json_object_to_fd(1, json_root, JSON_C_TO_STRING_PRETTY);
+	else
+		ret = json_object_to_file_ext(config_file, json_root,
+					      JSON_C_TO_STRING_PRETTY);
+	if (ret < 0) {
+		nvme_msg(LOG_ERR, "Failed to write to %s, %s\n",
+			 config_file ? "stdout" : config_file,
+			 json_util_get_last_err());
 		ret = -1;
 		errno = EIO;
 	}

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -111,6 +111,8 @@ struct nvme_root {
 	bool modified;
 };
 
+int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance);
+
 int nvme_set_attr(const char *dir, const char *attr, const char *value);
 
 void json_read_config(nvme_root_t r, const char *config_file);

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -675,20 +675,6 @@ const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c)
 	return c->host_iface;
 }
 
-const char *nvme_ctrl_get_hostnqn(nvme_ctrl_t c)
-{
-	if (!c->s || !c->s->h)
-		return default_host->hostnqn;
-	return c->s->h->hostnqn;
-}
-
-const char *nvme_ctrl_get_hostid(nvme_ctrl_t c)
-{
-	if (!c->s || !c->s->h)
-		return default_host->hostid;
-	return c->s->h->hostid;
-}
-
 struct nvme_fabrics_config *nvme_ctrl_get_config(nvme_ctrl_t c)
 {
 	return &c->cfg;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -130,6 +130,16 @@ int nvme_update_config(nvme_root_t r)
 #endif
 }
 
+int nvme_dump_config(nvme_root_t r)
+{
+#ifdef CONFIG_JSONC
+	return json_update_config(r, NULL);
+#else
+	errno = ENOTSUP;
+	return -1;
+#endif
+}
+
 nvme_host_t nvme_first_host(nvme_root_t r)
 {
 	return list_top(&r->hosts, struct nvme_host, entry);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -956,6 +956,14 @@ void nvme_reset_topology(nvme_root_t r);
 int nvme_update_config(nvme_root_t r);
 
 /**
+ * nvme_dump_config() -
+ * @r:
+ *
+ * Return:
+ */
+int nvme_dump_config(nvme_root_t r);
+
+/**
  * nvme_free_tree() -
  * @r:
  */

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -732,22 +732,6 @@ const char *nvme_ctrl_get_transport(nvme_ctrl_t c);
 const char *nvme_ctrl_get_subsysnqn(nvme_ctrl_t c);
 
 /**
- * nvme_ctrl_get_hostnqn() -
- * @c:
- *
- * Return: 
- */
-const char *nvme_ctrl_get_hostnqn(nvme_ctrl_t c);
-
-/**
- * nvme_ctrl_get_hostid() -
- * @c:
- *
- * Return: 
- */
-const char *nvme_ctrl_get_hostid(nvme_ctrl_t c);
-
-/**
  * nvme_ctrl_get_subsystem() -
  * @c:
  *

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -854,16 +854,6 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name);
 void nvme_rescan_ctrl(nvme_ctrl_t c);
 
 /**
- * nvme_init_ctrl() -
- * @h:
- * @c:
- * @instance:
- *
- * Return: 
- */
-int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance);
-
-/**
  * nvme_free_ctrl() -
  * @c:
  */


### PR DESCRIPTION
Add a function 'nvme_dump_config()' which will print out the internal tree to stdout.
This is required to implement a 'dump-config' operation for nvme-cli, to print out the internal tree to stdout.