### PR TITLE
Rework scan logic and introduce libnvme versioning

### DIFF
--- a/examples/discover-loop.c
+++ b/examples/discover-loop.c
@@ -49,6 +49,7 @@ int main()
 	struct nvmf_discovery_log *log = NULL;
 	nvme_root_t r;
 	nvme_host_t h;
+	nvme_subsystem_t s;
 	nvme_ctrl_t c;
 	int ret;
 
@@ -62,8 +63,12 @@ int main()
 		fprintf(stderr, "Failed to allocated memory\n");
 		return ENOMEM;
 	}
-	c = nvme_create_ctrl(NVME_DISC_SUBSYS_NAME, "loop",
-			     NULL, NULL, NULL, NULL);
+	s = nvme_lookup_subsystem(h, NULL, NVME_DISC_SUBSYS_NAME);
+	if (!s) {
+		fprintf(stderr, "Failed to allocate memory\n");
+		return ENOMEM;
+	}
+	c = nvme_lookup_ctrl(s, "loop", NULL, NULL, NULL, NULL);
 	if (!c) {
 		fprintf(stderr, "Failed to allocate memory\n");
 		return ENOMEM;

--- a/pynvme/nvme.i
+++ b/pynvme/nvme.i
@@ -493,10 +493,10 @@ struct nvme_ns {
 }
 
 %extend nvme_ctrl {
-  nvme_ctrl(const char *subsysnqn, const char *transport,
+  nvme_ctrl(struct nvme_subsystem *s, const char *transport,
 	    const char *traddr = NULL, const char *host_traddr = NULL,
 	    const char *host_iface = NULL, const char *trsvcid = NULL) {
-    return nvme_create_ctrl(subsysnqn, transport, traddr,
+    return nvme_lookup_ctrl(s, transport, traddr,
 			    host_traddr, host_iface, trsvcid);
   }
   ~nvme_ctrl() {

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,8 +23,8 @@ SED ?= sed
 INSTALL ?= install
 
 soname=$(NAME).so.1
-minor=0
-micro=2
+minor=1
+micro=0
 libname=$(soname).$(minor).$(micro)
 all_targets += $(NAME).a
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ INSTALL ?= install
 
 soname=$(NAME).so.1
 minor=0
-micro=1
+micro=2
 libname=$(soname).$(minor).$(micro)
 all_targets += $(NAME).a
 

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,4 +1,4 @@
-{
+LIBNVME_1.0 {
 	global:
 		__nvme_get_log_page;
 		__nvme_msg;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -293,3 +293,10 @@ LIBNVME_1.0 {
 	local:
 		*;
 };
+
+LIBNVME_1.1 {
+	global:
+		nvme_configure_ctrl;
+		nvme_deconfigure_ctrl;
+		nvme_scan_ctrls;
+} LIBNVME_1.0;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -7,7 +7,6 @@ LIBNVME_1.0 {
 		nvme_attach_ns;
 		nvme_compare;
 		nvme_copy;
-		nvme_create_ctrl;
 		nvme_ctrl_disconnect;
 		nvme_ctrl_first_ns;
 		nvme_ctrl_first_path;

--- a/src/nvme/filters.c
+++ b/src/nvme/filters.c
@@ -105,6 +105,12 @@ int nvme_scan_subsystem_namespaces(nvme_subsystem_t s, struct dirent ***namespac
 		       nvme_namespace_filter, alphasort);
 }
 
+int nvme_scan_ctrls(struct dirent ***ctrls)
+{
+	return scandir(nvme_ctrl_sysfs_dir, ctrls, nvme_ctrls_filter,
+		       alphasort);
+}
+
 int nvme_scan_ctrl_namespace_paths(nvme_ctrl_t c, struct dirent ***namespaces)
 {
 	return scandir(nvme_ctrl_get_sysfs_dir(c), namespaces,

--- a/src/nvme/filters.h
+++ b/src/nvme/filters.h
@@ -71,6 +71,14 @@ int nvme_scan_subsystem_ctrls(nvme_subsystem_t s, struct dirent ***ctrls);
 int nvme_scan_subsystem_namespaces(nvme_subsystem_t s, struct dirent ***namespaces);
 
 /**
+ * nvme_scan_ctrls() -
+ * @ctrls:
+ *
+ * Return: 
+ */
+int nvme_scan_ctrls(struct dirent ***ctrls);
+
+/**
  * nvme_scan_ctrl_namespace_paths() -
  * @c:
  * @namespaces:

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -224,22 +224,6 @@ nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 
 
 /**
- * nvme_create_ctrl() -
- * @subsysnqn:
- * @transport:
- * @traddr:
- * @host_traddr:
- * @host_iface:
- * @trsvcid:
- *
- * Return: 
- */
-nvme_ctrl_t nvme_create_ctrl(const char *subsysnqn, const char *transport,
-			     const char *traddr, const char *host_traddr,
-			     const char *host_iface, const char *trsvcid);
-
-
-/**
  * nvme_subsystem_first_ns() -
  * @s:
  *

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -224,6 +224,22 @@ nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 
 
 /**
+ * nvme_configure_ctrl() -
+ * @c:
+ * @path:
+ * @name:
+ *
+ * Return: 
+ */
+int nvme_configure_ctrl(nvme_ctrl_t c, const char *path, const char *name);
+
+/**
+ * nvme_deconfigure_ctrl() -
+ * @c:
+ */
+void nvme_deconfigure_ctrl(nvme_ctrl_t c);
+
+/**
  * nvme_subsystem_first_ns() -
  * @s:
  *


### PR DESCRIPTION
This patchset reworks the scanning logic to iterate over controllers, and not subsystems. Iterating over subsystems has the drawback that the host is only specified by controller attributes, so trying to enumerate controllers from subsystems may refer to the wrong host.

To accomodate for the change in behaviour this patchset also introduces libnvme symbol versioning, starting with version 1.0.1 and updating the version to 1.1.0 with this patchset.