### PR TITLE
Fix version number for meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,7 @@
 project(
     'libnvme', ['c', 'cpp'],
     meson_version: '>= 0.47.0',
-    version: '0.1',
+    version: '1.0.1',
     license: 'LGPLv2+',
     default_options: [
         'buildtype=release',


### PR DESCRIPTION
The shared library has the version number '1.0.1', not '0.1'.

Signed-off-by: Hannes Reinecke <hare@suse.de>