### PR TITLE
[Python]: Add init() method to class nvme_ctrl.

### DIFF
--- a/pynvme/nvme.i
+++ b/pynvme/nvme.i
@@ -502,6 +502,11 @@ struct nvme_ns {
   ~nvme_ctrl() {
     nvme_free_ctrl($self);
   }
+
+  bool init(struct nvme_host *h, int instance) {
+      return nvme_init_ctrl(h, $self, instance) == 0;
+  }
+
   void connect(struct nvme_host *h, struct nvme_fabrics_config *cfg = NULL) {
     int ret;
     const char *dev;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -143,6 +143,7 @@
 		nvme_identify_secondary_ctrl_list;
 		nvme_identify_uuid;
 		nvme_init_copy_range;
+		nvme_init_ctrl;
 		nvme_init_ctrl_list;
 		nvme_init_dsm_range;
 		nvme_init_id_ns;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -111,8 +111,6 @@ struct nvme_root {
 	bool modified;
 };
 
-int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance);
-
 int nvme_set_attr(const char *dir, const char *attr, const char *value);
 
 void json_read_config(nvme_root_t r, const char *config_file);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -854,6 +854,16 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name);
 void nvme_rescan_ctrl(nvme_ctrl_t c);
 
 /**
+ * nvme_init_ctrl() - Initialize control for an existing nvme device.
+ * @h: host
+ * @c: ctrl
+ * @instance: Instance number (e.g. 1 for nvme1)
+ *
+ * Return: The ioctl() return code. Typically 0 on success.
+ */
+int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance);
+
+/**
  * nvme_free_ctrl() -
  * @c:
  */


### PR DESCRIPTION
Make C function `nvme_init_ctrl()` available to Python as `nvme_ctrl.init()`. This allows Python programs to reuse an existing (persistent) nvme device.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>