### PR TITLE
fabrics: Remove 'UUID derived from machine-id' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,16 +142,8 @@ A few build options can be specified on the command line when invoking meson.
 
 | Option  | Values [default]    | Description                                                  |
 | ------- | ------------------- | ------------------------------------------------------------ |
-| systemd | [auto], true, false | Whether to link libsystemd to libnvme. When set to `auto`, the default, meson will check for the presence of library and will only link to it if it is found. When set to `true`, meson will make this library a mandatory dependency. When set to `false`, meson will not link the library to libnvme, even if the library is available. |
 
 ### Changing the build options from the command-line (i.e. w/o modifying any files)
-
-Here's an example where we tell meson that we do not want to link
-against the `systemd` library:
-
-```bash
-meson .build -Dsystemd=false
-```
 
 To configure a build for debugging purposes (i.e. optimization turned
 off and debug symbols enabled):

--- a/configure
+++ b/configure
@@ -27,8 +27,6 @@ for opt do
   ;;
   --datadir=*) datadir="$optarg"
   ;;
-  --disable-systemd) disable_systemd=1
-  ;;
   --disable-uuid) disable_uuid=1
   ;;
   --disable-json) disable_json=1
@@ -68,7 +66,6 @@ Options: [defaults in brackets after descriptions]
   --libdir=PATH            install libraries in PATH [$libdir]
   --mandir=PATH            install man pages in PATH [$mandir]
   --datadir=PATH           install shared data in PATH [$datadir]
-  --disable-systemd        do not link against libsystemd
   --disable-uuid           do not link against libuuid
   --disable-json           do not link against libjson-c
 EOF
@@ -198,17 +195,6 @@ fi
 print_config "libuuid" "${libuuid}"
 
 ##########################################
-# check for SystemD
-systemd="no"
-if [ -z "$disable_systemd" ] ; then
-    pkg-config --exists libsystemd --atleast-version=242
-    if [ $? -eq 0 ]; then
-	systemd="yes"
-    fi
-fi
-print_config "systemd" "${systemd}"
-
-##########################################
 # check for libjson-c
 libjsonc="no"
 if [ -z "$disable_json" ] ; then
@@ -233,10 +219,6 @@ if test "$libuuid" = "yes"; then
   output_sym "CONFIG_LIBUUID"
   echo "override LIBS += -luuid" >> $config_host_mak
   echo "override LIB_DEPENDS += uuid" >> $config_host_mak 
-fi
-if test "$systemd" = "yes"; then
-  output_sym "CONFIG_SYSTEMD"
-  echo "override LIBS += -lsystemd" >> $config_host_mak
 fi
 if test "$libjsonc" = "yes"; then
     output_sym "CONFIG_JSONC"

--- a/meson.build
+++ b/meson.build
@@ -95,17 +95,6 @@ if not libjson.found()
 endif
 conf.set('CONFIG_JSONC', libjson.found(), description: 'Is json-c required?')
 
-# Check for libsystemd availability
-want_systemd = get_option('systemd')
-if want_systemd != 'false'
-    libsystemd = dependency('libsystemd', required: want_systemd == 'true')
-    have = libsystemd.found()
-else
-    libsystemd = []
-    have = false
-endif
-conf.set('CONFIG_SYSTEMD', have, description: 'Is libsystemd required?')
-
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(
     'HAVE_BUILTIN_TYPES_COMPATIBLE_P',
@@ -210,7 +199,7 @@ pkg.generate(
     description: 'Manage "libnvme" subsystem devices (Non-volatile Memory Express)',
     url: 'http://github.com/linux-nvme/libnvme/',
     libraries: ['-L${libdir}', '-lnvme'],
-    requires: [libuuid, libjson, libsystemd],
+    requires: [libuuid, libjson],
 )
 
 ################################################################################

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,5 +3,3 @@
 option('pkgconfiglibdir', type : 'string', value : '', description : 'directory for standard pkg-config files')
 
 option('man', type : 'boolean', value : false, description : 'build and install man pages (requires sphinx-build)')
-
-option('systemd', type : 'combo', choices : ['auto', 'true', 'false'], description : 'libsystemd support')

--- a/pynvme/setup.py
+++ b/pynvme/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup, Extension
 libnvme_module = Extension(
     '_nvme',
     sources = ['nvme_wrap.c'],
-    libraries = ['nvme', 'json-c', 'uuid', 'systemd'],
+    libraries = ['nvme', 'json-c', 'uuid'],
     library_dirs = ['../src'],
     include_dirs = ['../ccan', '../src', '../src/nvme'],
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,7 +22,6 @@ endif
 
 deps = [
     libuuid,
-    libsystemd,
     libjson,
 ]
 


### PR DESCRIPTION
Commit 3e0520ecad13 ("Read system UUID from DMI and merge hostnqn
generation functions") in nvme-cli introduced the feature to create
the UUID derived from machine-id using the systemd's
sd_id128_get_machine_app_specific function. This adds many library
dependencies to libnvme.

The feature is not really necessary as we have nvme-gen-hostnqn
already in place. So drop the feature entirely.

If the feature needs to be added back, it's probably better to
reimplement this function (e.g. move the hmac_sha256 function from
nvme-cli and use this to derive the UUID from machine-id).

Fixes #62 

Signed-off-by: Daniel Wagner <dwagner@suse.de>