### PR TITLE
build: Allow subproject meson builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -203,8 +203,7 @@ pkg.generate(
 )
 
 ################################################################################
-add_project_arguments('-include', 'config.h', language : 'c')
-add_global_arguments(['-fomit-frame-pointer', '-D_GNU_SOURCE'], language : 'c')
+add_project_arguments(['-fomit-frame-pointer', '-D_GNU_SOURCE', '-include', 'config.h'], language : 'c')
 incdir = include_directories(['.', 'ccan', 'src'])
 
 ################################################################################

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,6 +51,16 @@ libnvme_static = static_library(
     install : false
 )
 
+libnvme_shared_dep = declare_dependency(
+    include_directories: incdir,
+    link_with: libnvme_shared,
+)
+
+libnvme_static_dep = declare_dependency(
+    include_directories: incdir,
+    link_with: libnvme_static,
+)
+
 mode = ['rw-r--r--', 0, 0]
 install_headers('libnvme.h', install_mode: mode)
 install_headers([


### PR DESCRIPTION
meson has a very fancy feature called subproject. This allows bundle
third party libraries in a project. In order to be able to use this
for nvme-cli we need to drop all global config settings and declare
all dependencies.

Signed-off-by: Daniel Wagner <dwagner@suse.de>