### PR TITLE
log: we use bool, so include stdbool.h

### DIFF
--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -5,6 +5,7 @@
 #ifndef _LOG_H
 #define _LOG_H
 
+#include <stdbool.h>
 #include <syslog.h>
 
 #ifndef MAX_LOGLEVEL


### PR DESCRIPTION
The log headers use the bool type, so add an include for stdbool.h,
rather than requiring the includer to do so.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>