### PR TITLE
build: Set minimum version for json-c

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,10 +89,7 @@ libuuid = dependency('uuid', required: true)
 conf.set('CONFIG_LIBUUID', libuuid.found(), description: 'Is libuuid required?')
 
 # Check for libjson-c availability
-libjson = dependency('json-c', required: false)
-if not libjson.found()
-    libjson = cc.find_library('json-c', required: true)
-endif
+libjson = dependency('json-c', version: '>=0.13', required: true)
 conf.set('CONFIG_JSONC', libjson.found(), description: 'Is json-c required?')
 
 # local (cross-compilable) implementations of ccan configure steps


### PR DESCRIPTION
Set minimum version for json-c to 0.13.

libnvme uses json_util_get_last_err() which got introduced in 0.13,
released in December 2017.

While at it, drop the cc.find_library() lookup logic. First, we don't
do this for libuuid and second, dependency() is using pkg-config to
figure out the dependency, thus we can set the minimum version
number. Instead, cc.find_library() will try to link a test program
with '-libjson-c' and have no way to figure out which version it
actually is. Avoid any confusion and make the meson.build script
simpler.

See also #65

Signed-off-by: Daniel Wagner <dwagner@suse.de>