### PR TITLE
build: Split libtool versioning from project versioning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,12 +61,28 @@
 project(
     'libnvme', ['c', 'cpp'],
     meson_version: '>= 0.47.0',
-    version: '1.0.1',
+    version: 'v0.1',
     license: 'LGPLv2+',
     default_options: [
         'buildtype=release',
         'prefix=/usr',
     ]
+)
+
+# https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+# https://autotools.io/libtool/version.html
+# The relation between libtool's current:revison:age interface versioning
+# and the .so filename, .so.x.y.z, is
+# x = current - age
+# y = age
+# z = revision
+# If libtool_soversion is updated as described in libtool's documentation,
+# x.y.z will usually *not* be equal to meson.project_version().
+libtool_soversion = [0, 0, 0]
+libnvme_version = '@0@.@1@.@2@'.format(
+  libtool_soversion[0] - libtool_soversion[2],
+  libtool_soversion[2],
+  libtool_soversion[1]
 )
 
 ################################################################################

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,7 +32,7 @@ version_script_arg = join_paths(source_dir, mapfile)
 libnvme_shared = shared_library(
     'nvme', # produces libnvme.so
     sources,
-    version: meson.project_version(),
+    version: libnvme_version,
     soversion: '1',
     link_args: ['-Wl,--version-script=' + version_script_arg],
     dependencies: deps,


### PR DESCRIPTION
As described in GNU autotools manuals, libtool versioning is not the
same as the project versioning.

The project versioning string is defined in project_version. meson
uses this string for all operations such a creating the tarball. I
decided against using something fancy as 'git describe' for it,
because meson is not supporting this kind of dynamic project
versioning.

Instead we just need to increment the version after the release and
before the first commit. With this scheme we basically know by looking
at the version string if it is an official released version. If this
is not good enough we can try to adopt the approach other project are
doing such as systemd which introduced an additional package
versioning which depends on 'git describe'.

There is little point in fighting the tool if it can be done quite
easily by the described approach from above.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See also #51 