### PR TITLE
build: Add fallback dependency for json-c

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,9 +104,9 @@ conf = configuration_data()
 libuuid = dependency('uuid', required: true)
 conf.set('CONFIG_LIBUUID', libuuid.found(), description: 'Is libuuid required?')
 
-# Check for libjson-c availability
-libjson = dependency('json-c', version: '>=0.13', required: true)
-conf.set('CONFIG_JSONC', libjson.found(), description: 'Is json-c required?')
+# Check for json-c availability
+json_c = dependency('json-c', version: '>=0.13', fallback : ['json-c', 'json_c'])
+conf.set('CONFIG_JSONC', json_c.found(), description: 'Is json-c required?')
 
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(
@@ -213,4 +213,3 @@ subdir('pynvme')
 subdir('test')
 subdir('examples')
 subdir('doc')
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,6 +51,8 @@ libnvme_priv := nvme/private.h
 libnvme_api := libnvme.h nvme/types.h nvme/ioctl.h nvme/filters.h nvme/tree.h nvme/util.h nvme/fabrics.h nvme/log.h
 libnvme_srcs := nvme/ioctl.c nvme/filters.c nvme/fabrics.c nvme/util.c nvme/tree.c nvme/log.c nvme/cleanup.c
 ifeq ($(CONFIG_JSONC),y)
+override LDFLAGS += $(shell pkg-config --libs json-c)
+override CFLAGS += $(shell pkg-config --cflags json-c)
 override libnvme_srcs += nvme/json.c
 endif
 libnvme_objs := $(patsubst %.c,%.ol,$(libnvme_srcs))

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,7 +22,7 @@ endif
 
 deps = [
     libuuid,
-    libjson,
+    json_c,
 ]
 
 source_dir = meson.current_source_dir()
@@ -43,11 +43,11 @@ libnvme = library(
 
 pkg = import('pkgconfig')
 pkg.generate(libnvme,
-  filebase: meson.project_name(),
-  name: meson.project_name(),
-  version: meson.project_version(),
-  description: 'Manage "libnvme" subsystem devices (Non-volatile Memory Express)',
-  url: 'http://github.com/linux-nvme/libnvme/',
+    filebase: meson.project_name(),
+    name: meson.project_name(),
+    version: meson.project_version(),
+    description: 'Manage "libnvme" subsystem devices (Non-volatile Memory Express)',
+    url: 'http://github.com/linux-nvme/libnvme/',
 )
 
 libnvme_dep = declare_dependency(

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -10,7 +10,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include <json-c/json.h>
+#include <json.h>
 
 #include "fabrics.h"
 #include "log.h"


### PR DESCRIPTION
meson supports embedded library build. This is very handy for system
which ship outdated an really outdated json-c library.

The include path for json.h has to be adapted. The json-c upstream
project is not clear which include prefix should be used ('#include
<json-c/json.h>" vs '#include <json.h>'. In order to support embedded
builds, we need to use the second version of the include. The source
code is added to the build, hence we use the include directory path of
the project layout. And json-c has all include files in the root
directory. This is no problem when using a installed version of json-c
as pkg-config adds '-I/usr/inlude/json-c' to the include paths:

  $pkg-config --cflags json-c
  -I/usr/include/json-c

So the simplest thing to support both build cased (external/embedded)
just drop the include prefix.

While at it also fix the 'requires' argument which expects strings not
dependencies objects.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes #65