### PR TITLE
Make Python Bindings optional

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,4 @@
 option('pkgconfiglibdir', type : 'string', value : '', description : 'directory for standard pkg-config files')
 
 option('man', type : 'boolean', value : false, description : 'build and install man pages (requires sphinx-build)')
+option('python', type : 'combo', choices : ['auto', 'true', 'false'], description : 'Generate libnvme python bindings')

--- a/pynvme/meson.build
+++ b/pynvme/meson.build
@@ -5,9 +5,18 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-python3 = import('python').find_installation('python3')
-swig = find_program('swig', required: false)
-if swig.found()
+
+want_python = get_option('python')
+if want_python != 'false'
+    python3 = import('python').find_installation('python3')
+    py3_dep = python3.dependency(required: want_python == 'true')
+    swig = find_program('swig', required: want_python == 'true')
+    have_python_support = py3_dep.found() and swig.found()
+else
+    have_python_support = false
+endif
+
+if have_python_support
     pymod_swig = custom_target(
         'nvme.py',
         input:   ['nvme.i', config_h],
@@ -20,7 +29,7 @@ if swig.found()
     pynvme_clib = python3.extension_module(
         '_nvme',
         pymod_swig[1],
-        dependencies : python3.dependency(),
+        dependencies : py3_dep,
         include_directories: incdir,
         link_with: libnvme,
         install: true,


### PR DESCRIPTION
Added a new configuration parameter "python". By default it is set to 'auto',
which means that the Python bindings will be built if all dependencies can be
found on the host. If not, Python bindings won't be built. The option can
also be set to 'true' or 'false' to force Python bindings to be built or not.

This fixes issue: https://github.com/linux-nvme/libnvme/issues/72

Signed-off-by: Martin Belanger <martin.belanger@dell.com>