### PR TITLE
build: Add missing json-c.wrap

### DIFF
--- a/subprojects/json-c.wrap
+++ b/subprojects/json-c.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = json-c-0.13.1
+source_url = https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13.1.tar.gz
+source_filename = json-c-0.13.1.tar.gz
+source_hash = b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873
+patch_url = https://wrapdb.mesonbuild.com/v2/json-c_0.13.1-1/get_patch
+patch_filename = json-c-0.13.1-1-wrap.zip
+patch_hash = 213a735c3c5f7ff4aa38850cd7bf236337c47fd553b9fcded64e709cab66b9fd
+


### PR DESCRIPTION
Commit 6af90f95fd1b ("build: Add fallback dependency for json-c") is
missing the wrap file.

Signed-off-by: Daniel Wagner <dwagner@suse.de>