### PR TITLE
Restore python module static linkage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ project(
     default_options: [
         'buildtype=release',
         'prefix=/usr',
+        'default_library=both',
     ]
 )
 

--- a/pynvme/meson.build
+++ b/pynvme/meson.build
@@ -31,7 +31,7 @@ if have_python_support
         pymod_swig[1],
         dependencies : py3_dep,
         include_directories: incdir,
-        link_with: libnvme,
+        link_with: libnvme.get_static_lib(),
         install: true,
         subdir: 'libnvme',
     )


### PR DESCRIPTION
Pull request https://github.com/linux-nvme/libnvme/pull/69 resulted in the python module being linked against the shared library instead of the static library. This resulted in the error below when running Python code. This pull request fixes the issue.

```
$ python -c "from libnvme import nvme"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib64/python3.9/site-packages/libnvme/nvme.py", line 13, in <module>
    from . import _nvme
ImportError: /usr/lib64/python3.9/site-packages/libnvme/_nvme.cpython-39-x86_64-linux-gnu.so: undefined symbol: nvme_log_level
```

Signed-off-by: Martin Belanger <martin.belanger@dell.com>