### PR TITLE
ccan: Add *.c files to the build

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -5,6 +5,13 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
+
+sources += files([
+    'ccan/list/list.c',
+    'ccan/str/debug.c',
+    'ccan/str/str.c',
+])
+
 configurator = executable(
     'configurator',
     ['tools/configurator/configurator.c'],

--- a/meson.build
+++ b/meson.build
@@ -208,6 +208,8 @@ add_project_arguments(['-fomit-frame-pointer', '-D_GNU_SOURCE', '-include', 'con
 incdir = include_directories(['.', 'ccan', 'src'])
 
 ################################################################################
+sources = []
+subdir('ccan')
 subdir('src')
 subdir('pynvme')
 subdir('test')

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,7 +5,7 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-sources = [
+sources += [
     'nvme/cleanup.c',
     'nvme/fabrics.c',
     'nvme/filters.c',


### PR DESCRIPTION
We are missing the *.c files from the ccan code base in the build.
As we currently don't use any function implemented in the *.c files
all just works.

Signed-off-by: Daniel Wagner <dwagner@suse.de>