### PR TITLE
Remove a duplicate read() statement

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -803,7 +803,6 @@ static int uuid_from_dmi(char *system_uuid)
 		if (f < 0)
 			continue;
 		len = read(f, buf, 512);
-		len = read(f, buf, 512);
 		close(f);
 		if (len < 0)
 			continue;


### PR DESCRIPTION
Remove a duplicate read() statement. 

I checked with Hannes and he confirmed that the line was added by mistake.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>