### PR TITLE
Fix python unit tests when run as a subproject of another project

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -26,4 +26,4 @@ jobs:
         if: failure()
         with:
           name: Linux_Meson_Testlog
-          path: .build/meson-logs/testlog.txt
+          path: build/meson-logs/testlog.txt

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -20,3 +20,10 @@ jobs:
       - uses: BSFishy/meson-build@v1.0.3
         with:
           action: test
+          options: --verbose
+      # Preserve meson's log file on failure
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: Linux_Meson_Testlog
+          path: .build/meson-logs/testlog.txt

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -54,7 +54,7 @@ if have_python_support
     # tests directly from the build directory.
     test_env = environment()
     test_env.append('MALLOC_PERTURB_', '0')
-    test_env.append('PYTHONPATH', meson.build_root())
+    test_env.append('PYTHONPATH', join_paths(meson.current_build_dir(), '..'))
 
     # Test section
     test('[Python] import libnvme', python3, args: ['-c', 'from libnvme import nvme'], env: test_env)


### PR DESCRIPTION
This is related to this issue:https://github.com/linux-nvme/libnvme/issues/90#issuecomment-957539757

When the CI tests are run from another project (i.e. `libnvme` is the subproject of another project, for example `nvme-cli`), then the Python tests are failing.

I'm not sure what the problem is exactly. I think it may have something to do with the `PYTHONPATH`. This patch uses a relative path instead of an absolute one to see if that will make a difference. 

I also changed the workflow script to collect the meson test log file on failure. This should give us more info in case of failure. 

Signed-off-by: Martin Belanger <martin.belanger@dell.com>