### PR TITLE
libnvme: core dump when running nvme persistent-event-log

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -2919,7 +2919,7 @@ struct nvme_persistent_event_entry {
 	__u8	rsvd14[6];
 	__le16	vsil;
 	__le16	el;
-};
+} __attribute__((packed));
 
 enum nvme_persistent_event_types {
     NVME_PEL_SMART_HEALTH_EVENT		= 0x01,


### PR DESCRIPTION
[root@ltczz405-lp2 nvme-cli]# ./nvme persistent-event-log -a 0 /dev/nvme0>out
[20748.494262] nvme[9059]: segfault (11) at 7fff8cf20007 nip 10024828 lr 10024824 code 2 in nvme[10000000+c0000]
[20748.494288] nvme[9059]: code: 3b9c0024 3b7b0001 4bfddb41 e8410018 889cffe6 7e439378 4bfddb31 e8410018
[20748.494295] nvme[9059]: code: 889cffe7 e8610068 4bfddb21 e8410018 <809cfff4> e8610070 4bfddb11 e8410018
Segmentation fault (core dumped)

Saw the segmentation fault. Also looks only the first event is good. Other events are like random stuff.

Persistent Event Log for device: nvme0
Action for Persistent Event Log: 0
Log Identifier: 13
Total Number of Events: 6963
Total Log Length : 674496
Log Revision: 1
Log Header Length: 492
Timestamp: 564586531692487
Power On Hours (POH): 5,576
Power Cycle Count: 92
PCI Vendor ID (VID): 5197
PCI Subsystem Vendor ID (SSVID): 4116
Serial Number (SN): S4WANE0N300041
Model Number (MN): PCIe4 1.6TB NVMe Flash Adapter x8
NVM Subsystem NVMe Qualified Name (SUBNQN): nqn.1994-11.com.samsung:nvme:PM1735::
HHHL:S4WANE0N300041
Supported Events Bitmap: BitMap[0] is 0xfe
BitMap[1] is 0x3f

Persistent Event Entries:
Event Type: 1
Event Type Revision: 1
Event Header Length: 21
Controller Identifier: 66
Event Timestamp: 0
Vendor Specific Information Length: 512
Event Length: 10496
Smart Health Event:
Smart Log for NVME device:nvme0 namespace-id:ffffffff
critical_warning : 0
temperature : 24°C (297 Kelvin)
available_spare : 100%
available_spare_threshold : 10%
percentage_used : 1%
endurance group critical warning summary: 0
data_units_read : 0
data_units_written

Event Type: 82 --------------->wrong event type??
Event Type Revision: 69
Event Header Length: 86
Controller Identifier: 20563
Event Timestamp: 65
Vendor Specific Information Length: 0
Event Length: 88
Reserved Event

Event Type: 242 -------->wrong event type?
Event Type Revision: 206
Event Header Length: 4
Controller Identifier: 0
Event Timestamp: 5039920509769225473
Vendor Specific Information Length: 0
Event Length: 0
Reserved Event

Signed-off-by: Wen Xiong <wenxiong@linux.ibm.com>