### PR TITLE
Implement 'dhchap_key' host and controller attributes

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -268,6 +268,7 @@ struct nvme_host {
   %immutable hostid;
   char *hostnqn;
   char *hostid;
+  char *dhchap_key;
 };
 
 struct nvme_subsystem {
@@ -301,6 +302,7 @@ struct nvme_ctrl {
   char *traddr;
   char *host_traddr;
   char *trsvcid;
+  char *dhchap_key;
   char *address;
   char *firmware;
   char *model;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -13,6 +13,7 @@ LIBNVME_1_0 {
 		nvme_ctrl_first_ns;
 		nvme_ctrl_first_path;
 		nvme_ctrl_get_address;
+		nvme_ctrl_get_dhchap_key;
 		nvme_ctrl_get_discovery_ctrl;
 		nvme_ctrl_get_fd;
 		nvme_ctrl_get_firmware;
@@ -36,6 +37,7 @@ LIBNVME_1_0 {
 		nvme_ctrl_next_ns;
 		nvme_ctrl_next_path;
 		nvme_ctrl_reset;
+		nvme_ctrl_set_dhchap_key;
 		nvme_ctrl_set_discovery_ctrl;
 		nvme_ctrl_set_persistent;
 		nvme_ctrls_filter;
@@ -136,9 +138,11 @@ LIBNVME_1_0 {
 		nvme_get_property;
 		nvme_get_subsys_attr;
 		nvme_get_telemetry_log;
+		nvme_host_get_dhchap_key;
 		nvme_host_get_hostid;
 		nvme_host_get_hostnqn;
 		nvme_host_get_root;
+		nvme_host_set_dhchap_key;
 		nvme_identify;
 		nvme_identify_active_ns_list;
 		nvme_identify_allocated_ns;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -397,7 +397,7 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 {
 	struct nvme_fabrics_config *cfg = nvme_ctrl_get_config(c);
 	const char *transport = nvme_ctrl_get_transport(c);
-	const char *hostnqn, *hostid;
+	const char *hostnqn, *hostid, *hostkey, *ctrlkey;
 	bool discover = false, discovery_nqn = false;
 
 	if (!transport) {
@@ -431,6 +431,8 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 		discover = true;
 	hostnqn = nvme_host_get_hostnqn(h);
 	hostid = nvme_host_get_hostid(h);
+	hostkey = nvme_host_get_dhchap_key(h);
+	ctrlkey = nvme_ctrl_get_dhchap_key(c);
 	if (add_argument(argstr, "transport", transport) ||
 	    add_argument(argstr, "traddr",
 			 nvme_ctrl_get_traddr(c)) ||
@@ -444,6 +446,10 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 	    (hostid && add_argument(argstr, "hostid", hostid)) ||
 	    (discover && !discovery_nqn &&
 	     add_bool_argument(argstr, "discovery", true)) ||
+	    (!discover && hostkey &&
+	     add_argument(argstr, "dhchap_secret", hostkey)) ||
+	    (!discover && ctrlkey &&
+	     add_argument(argstr, "dhchap_ctrl_secret", ctrlkey)) ||
 	    (!discover &&
 	     add_int_argument(argstr, "nr_io_queues",
 			      cfg->nr_io_queues, false)) ||

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -87,6 +87,7 @@ struct nvme_ctrl {
 	char *trsvcid;
 	char *host_traddr;
 	char *host_iface;
+	char *dhchap_key;
 	bool discovery_ctrl;
 	bool discovered;
 	bool persistent;
@@ -115,6 +116,7 @@ struct nvme_host {
 
 	char *hostnqn;
 	char *hostid;
+	char *dhchap_key;
 };
 
 struct nvme_root {

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -106,6 +106,21 @@ const char *nvme_host_get_hostnqn(nvme_host_t h);
 const char *nvme_host_get_hostid(nvme_host_t h);
 
 /**
+ * nvme_host_get_dhchap_key() - return host key
+ * @h: Host for which the key should be returned
+ *
+ * Return: DH-HMAC-CHAP host key or NULL if not set
+ */
+const char *nvme_host_get_dhchap_key(nvme_host_t h);
+
+/**
+ * nvme_host_set_dhchap_key() - set host key
+ * @h: Host for which the key should be set
+ * @key: DH-HMAC-CHAP Key to set or NULL to clear existing key
+ */
+void nvme_host_set_dhchap_key(nvme_host_t h, const char *key);
+
+/**
  * nvme_default_host() -
  * @r:
  *
@@ -778,6 +793,21 @@ const char *nvme_ctrl_get_host_traddr(nvme_ctrl_t c);
  * Return:
  */
 const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c);
+
+/**
+ * nvme_ctrl_get_dhchap_key() - return controller key
+ * @c: controller for which the key should be returned
+ *
+ * Return: DH-HMAC-CHAP controller key or NULL if not set
+ */
+const char *nvme_ctrl_get_dhchap_key(nvme_ctrl_t c);
+
+/**
+ * nvme_ctrl_set_dhchap_key() - set controller key
+ * @c: Controller for which the key should be set
+ * @key: DH-HMAC-CHAP Key to set or NULL to clear existing key
+ */
+void nvme_ctrl_set_dhchap_key(nvme_ctrl_t c, const char *key);
 
 /**
  * nvme_ctrl_get_config() -


### PR DESCRIPTION
Implement a 'dhchap_key' attribute for the nvme_host structure to
support the 'dhchap_secret' connection argument, and a
'dhchap_key' attribute for the nvme_controller structure to support
the 'dhchap_ctrl_secret' connection argument.

Note: The kernel side is still under review, but the interface seems to have stabilized. So pulling it in now will help with testing.

Signed-off-by: Hannes Reinecke <hare@suse.de>