### PR TITLE
types: fix wrong bits nvme_id_psd apw[178:176], aps[183:182]

### DIFF
--- a/doc/libnvme.rst
+++ b/doc/libnvme.rst
@@ -6280,9 +6280,8 @@ Returns true if given offset is 64bit register, otherwise it returns false.
     __u8 ips;
     __u8 rsvd19;
     __le16 actp;
-    __u8 apw;
-    __u8 aps;
-    __u8 rsvd23[8];
+    __u8 apws;
+    __u8 rsvd23[9];
   };
 
 **Members**
@@ -6340,14 +6339,12 @@ Returns true if given offset is 64bit register, otherwise it returns false.
   NVM subsystem over a 10 second period in this power state with
   the workload indicated in the Active Power Workload field.
 
-``apw``
-  Active Power Workload indicates the workload used to calculate
+``apws``
+  Bits 7-6: Active Power Scale(APS) indicates the scale for the :c:type:`struct
+  nvme_id_psd <nvme_id_psd>`.actp, see :c:type:`enum nvme_psd_ps <nvme_psd_ps>` for decoding this value.
+  Bits 2-0: Active Power Workload(APW) indicates the workload used to calculate
   maximum power for this power state. See :c:type:`enum nvme_psd_workload <nvme_psd_workload>` for
   decoding this field.
-
-``aps``
-  Active Power Scale indicates the scale for the :c:type:`struct
-  nvme_id_psd <nvme_id_psd>`.actp, see :c:type:`enum nvme_psd_ps <nvme_psd_ps>` for decoding this value.
 
 
 

--- a/doc/man/struct nvme_id_psd.2
+++ b/doc/man/struct nvme_id_psd.2
@@ -30,11 +30,9 @@ struct nvme_id_psd {
 .br
 .BI "    __le16 actp;"
 .br
-.BI "    __u8 apw;"
+.BI "    __u8 apws;"
 .br
-.BI "    __u8 aps;"
-.br
-.BI "    __u8 rsvd23[8];"
+.BI "    __u8 rsvd23[9];"
 .br
 .BI "
 };
@@ -83,10 +81,9 @@ see \fIenum nvme_psd_ps\fP for decoding this field.
 Active Power indicates the largest average power consumed by the
 NVM subsystem over a 10 second period in this power state with
 the workload indicated in the Active Power Workload field.
-.IP "apw" 12
-Active Power Workload indicates the workload used to calculate
+.IP "apws" 12
+Bits 7-6: Active Power Scale(APS) indicates the scale for the \fIstruct
+nvme_id_psd\fP.actp, see \fIenum nvme_psd_ps\fP for decoding this value.
+Bits 2-0: Active Power Workload(APW) indicates the workload used to calculate
 maximum power for this power state. See \fIenum nvme_psd_workload\fP for
 decoding this field.
-.IP "aps" 12
-Active Power Scale indicates the scale for the \fIstruct
-nvme_id_psd\fP.actp, see \fIenum nvme_psd_ps\fP for decoding this value.

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -652,11 +652,11 @@ enum nvme_psd_workload {
  * @actp:  Active Power indicates the largest average power consumed by the
  * 	   NVM subsystem over a 10 second period in this power state with
  * 	   the workload indicated in the Active Power Workload field.
- * @apw:   Active Power Workload indicates the workload used to calculate
- * 	   maximum power for this power state. See &enum nvme_psd_workload for
- * 	   decoding this field.
- * @aps:   Active Power Scale indicates the scale for the &struct
+ * @apws:  Bits 7-6: Active Power Scale(APS) indicates the scale for the &struct
  * 	   nvme_id_psd.actp, see &enum nvme_psd_ps for decoding this value.
+ *     Bits 2-0: Active Power Workload(APW) indicates the workload
+ * 	   used to calculate maximum power for this power state.
+ *     See &enum nvme_psd_workload for decoding this field.
  */
 struct nvme_id_psd {
 	__le16			mp;
@@ -672,9 +672,8 @@ struct nvme_id_psd {
 	__u8			ips;
 	__u8			rsvd19;
 	__le16			actp;
-	__u8			apw;
-	__u8			aps;
-	__u8			rsvd23[8];
+	__u8			apws;
+	__u8			rsvd23[9];
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>

it used to be active_work_scale on nvme-cli, so rename it as apws (active power work & scale)
https://github.com/linux-nvme/nvme-cli/blob/nvme-cli-monolithic/linux/nvme.h#L258
