### PR TITLE
tree: add namespace chrdev name to nvme_ns

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -182,6 +182,7 @@
 		nvme_ns_get_model;
 		nvme_ns_get_model;
 		nvme_ns_get_name;
+		nvme_ns_get_generic_name;
 		nvme_ns_get_nguid;
 		nvme_ns_get_nsid;
 		nvme_ns_get_serial;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -45,6 +45,7 @@ struct nvme_ns {
 	int fd;
 	__u32 nsid;
 	char *name;
+	char *generic_name;
 	char *sysfs_dir;
 
 	int lba_shift;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -453,6 +453,14 @@ const char *nvme_ns_get_sysfs_dir(nvme_ns_t n);
 const char *nvme_ns_get_name(nvme_ns_t n);
 
 /**
+ * nvme_ns_get_generic_name() - Returns name of generic namesapce chardev.
+ * @n: Namespace instance
+ *
+ * Return: Name of generic namespace chardev
+ */
+const char *nvme_ns_get_generic_name(nvme_ns_t n);
+
+/**
  * nvme_ns_get_firmware() -
  * @n:
  *


### PR DESCRIPTION
Namespace device node is initialized into two different nodes: block
device and character device which is a generic device used when block
device is not available due to initialization failure in the kernel.

This can be directly retrieved from the `struct nvme_ns` to print out
the generic node in somewhere like `nvme list` command in nvme-cli.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>