### PR TITLE
tree: fix memory leak in nvme_ctrl_lookup_subsystem_name

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1035,7 +1035,7 @@ static char *nvme_ctrl_lookup_subsystem_name(nvme_ctrl_t c)
 		subsys_name = strdup(subsys[i]->d_name);
 		break;
 	}
-	nvme_free_dirents(subsys, i);
+	nvme_free_dirents(subsys, ret);
 	return subsys_name;
 }
 


### PR DESCRIPTION
Ensure all dirents are freed when a successful stat(2) causes an early
break out of the loop.

Reproduced with valgrind running "nvme discover" against an NVMe-oF
target:

==34612== 32 bytes in 1 blocks are definitely lost in loss record 2 of 2
==34612==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==34612==    by 0x4963A4C: __scandir64_tail (scandir-tail-common.c:69)
==34612==    by 0x16E77D: nvme_ctrl_lookup_subsystem_name.isra.0 (tree.c:1024)
==34612==    by 0x170081: nvme_init_ctrl (tree.c:1100)
==34612==    by 0x16DA1F: nvmf_add_ctrl (fabrics.c:558)
==34612==    by 0x136B03: nvmf_discover (fabrics.c:516)
==34612==    by 0x139999: handle_plugin (plugin.c:155)
==34612==    by 0x1131E9: main (nvme.c:5967)

Signed-off-by: Jonathan Teh <jonathan.teh@mayadata.io>