### PR TITLE
fabrics: add nvmf_default_config()

### DIFF
--- a/examples/discover-loop.c
+++ b/examples/discover-loop.c
@@ -53,10 +53,9 @@ int main()
 	nvme_host_t h;
 	nvme_ctrl_t c;
 	int ret;
+	struct nvme_fabrics_config cfg;
 
-	struct nvme_fabrics_config cfg = {
-		.tos = -1,
-	};
+	nvmf_default_config(&cfg);
 
 	r = nvme_scan(NULL);
 	h = nvme_default_host(r);

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -305,6 +305,7 @@ LIBNVME_1_0 {
 		nvmf_adrfam_str;
 		nvmf_cms_str;
 		nvmf_connect_disc_entry;
+		nvmf_default_config;
 		nvmf_get_discovery_log;
 		nvmf_hostid_from_file;
 		nvmf_hostnqn_from_file;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -155,6 +155,13 @@ const char *nvmf_cms_str(__u8 cm)
 	return arg_str(cms, ARRAY_SIZE(cms), cm);
 }
 
+void nvmf_default_config(struct nvme_fabrics_config *cfg)
+{
+	memset(cfg, 0, sizeof(*cfg));
+	cfg->tos = -1;
+	cfg->ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO;
+}
+
 #define UPDATE_CFG_OPTION(c, n, o, d)			\
 	if ((c)->o == d) (c)->o = (n)->o
 static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -125,6 +125,14 @@ const char *nvmf_qptype_str(__u8 qptype);
 const char *nvmf_cms_str(__u8 cms);
 
 /**
+ * nvmf_default_config - Default values for fabrics configuration
+ * @cfg: config values to set
+ *
+ * Initializes @cfg with default values.
+ */
+void nvmf_default_config(struct nvme_fabrics_config *cfg);
+
+/**
  * nvmf_add_ctrl_opts() -
  * @c:
  * @cfg:

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -942,7 +942,7 @@ struct nvme_ctrl *nvme_create_ctrl(const char *subsysnqn, const char *transport,
 		return NULL;
 	}
 	c->fd = -1;
-	c->cfg.tos = -1;
+	nvmf_default_config(&c->cfg);
 	list_head_init(&c->namespaces);
 	list_head_init(&c->paths);
 	list_node_init(&c->entry);


### PR DESCRIPTION
'struct nvme_fabrics_config' has some default values, and the output
functions key off these values to filter the values being printed.
So to avoid applications having to know these default values this
patch introduces a function nvmf_default_config() to ensure that
every application is using the same defaults.

Signed-off-by: Hannes Reinecke <hare@suse.de>