### PR TITLE
Add discovery_ctrl_set() to Python bindings.

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -502,6 +502,10 @@ struct nvme_ns {
     nvme_free_ctrl($self);
   }
 
+  void discovery_ctrl_set(bool discovery) {
+      nvme_ctrl_set_discovery_ctrl($self, discovery);
+  }
+
   bool init(struct nvme_host *h, int instance) {
       return nvme_init_ctrl(h, $self, instance) == 0;
   }


### PR DESCRIPTION
Add discovery_ctrl_set() to Python bindings.

Following Hannes' recent TP8013 changes, we need
to add this method to the Python bindings.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>