### PR TITLE
Add discovery_ctrl_set() to Python bindings

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -295,6 +295,7 @@ struct nvme_ctrl {
   %immutable serial;
   %immutable sqsize;
   %immutable persistent;
+  %immutable discovery_ctrl;
   char *transport;
   char *subsysnqn;
   char *traddr;
@@ -308,6 +309,7 @@ struct nvme_ctrl {
   char *serial;
   char *sqsize;
   bool persistent;
+  bool discovery_ctrl;
 };
 
 struct nvme_ns {
@@ -500,6 +502,10 @@ struct nvme_ns {
   }
   ~nvme_ctrl() {
     nvme_free_ctrl($self);
+  }
+
+  void discovery_ctrl_set(bool discovery) {
+      nvme_ctrl_set_discovery_ctrl($self, discovery);
   }
 
   bool init(struct nvme_host *h, int instance) {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -34,6 +34,7 @@ LIBNVME_1_0 {
 		nvme_ctrl_next_ns;
 		nvme_ctrl_next_path;
 		nvme_ctrl_reset;
+		nvme_ctrl_set_discovery_ctrl;
 		nvme_ctrl_set_persistent;
 		nvme_ctrls_filter;
 		nvme_default_host;


### PR DESCRIPTION
Add discovery_ctrl_set() to Python bindings

Following Hannes' recent TP8013 changes, we need
to add this method to the Python bindings.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>