### PR TITLE
fabrics: add missing function documentation and mapfile update

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -319,6 +319,7 @@ LIBNVME_1_0 {
 		nvmf_subtype_str;
 		nvmf_treq_str;
 		nvmf_trtype_str;
+		nvmf_eflags_str;
 	local:
 		*;
 };

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -50,34 +50,46 @@ struct nvme_fabrics_config {
 };
 
 /**
- * nvmf_trtype_str() -
- * @trtype:
+ * nvmf_trtype_str() - Decode TRTYPE field
+ * @trtype: value to be decoded
  *
- * Return:
+ * Decode the transport type field in the discovery
+ * log page entry.
+ *
+ * Return: decoded string
  */
 const char *nvmf_trtype_str(__u8 trtype);
 
 /**
- * nvmf_adrfam_str() -
- * @adrfam:
+ * nvmf_adrfam_str() - Decode ADRFAM field
+ * @adrfam: value to be decoded
  *
- * Return:
+ * Decode the address family field in the discovery
+ * log page entry.
+ *
+ * Return: decoded string
  */
 const char *nvmf_adrfam_str(__u8 adrfam);
 
 /**
- * nvmf_subtype_str() -
- * @subtype:
+ * nvmf_subtype_str() - Decode SUBTYPE field
+ * @subtype: value to be decoded
  *
- * Return:
+ * Decode the subsystem type field in the discovery
+ * log page entry.
+ *
+ * Return: decoded string
  */
 const char *nvmf_subtype_str(__u8 subtype);
 
 /**
- * nvmf_treq_str() -
- * @treq:
+ * nvmf_treq_str() - Decode TREQ field
+ * @treq: value to be decoded
  *
- * Return:
+ * Decode the transport requirements field in the
+ * discovery log page entry.
+ *
+ * Return: decoded string
  */
 const char *nvmf_treq_str(__u8 treq);
 


### PR DESCRIPTION
Add some function documentation and the missing symbol nvmf_eflags_str
to the mapfile.

Signed-off-by: Hannes Reinecke <hare@suse.de>