### PR TITLE
build: Set include dirs when buidling configurator

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -16,6 +16,7 @@ configurator = executable(
     'configurator',
     ['tools/configurator/configurator.c'],
     c_args: ['-D_GNU_SOURCE'],
+    include_directories: incdir,
 )
 
 config_h = custom_target(


### PR DESCRIPTION
The default include paths are not set when building the configurator,
hence the build fails when libnvme is consumed by an project as wrap.

Signed-off-by: Daniel Wagner <dwagner@suse.de>