### PR TITLE
meson: do not build ccan configurator

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -7,7 +7,7 @@
 #
 executable(
     'telemetry-listen',
-    ['telemetry-listen.c', config_h],
+    ['telemetry-listen.c'],
     link_with: libnvme,
     include_directories: incdir)
 
@@ -19,7 +19,7 @@ executable(
 
 executable(
     'discover-loop',
-    ['discover-loop.c', config_h],
+    ['discover-loop.c'],
     link_with: libnvme,
     include_directories: incdir)
 

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -19,7 +19,7 @@ endif
 if have_python_support
     pymod_swig = custom_target(
         'nvme.py',
-        input:   ['nvme.i', config_h],
+        input:   ['nvme.i'],
         output:  ['nvme.py', 'nvme_wrap.c'],
         command: [swig, '-python', '-py3', '-o', '@OUTPUT1@', '@INPUT0@'],
         install: true,

--- a/meson.build
+++ b/meson.build
@@ -143,7 +143,6 @@ incdir = include_directories(['.', 'ccan', 'src'])
 
 ################################################################################
 sources = []
-subdir('ccan')
 subdir('src')
 subdir('libnvme')
 subdir('test')

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,6 @@ sources += [
     'nvme/log.c',
     'nvme/tree.c',
     'nvme/util.c',
-    config_h,
 ]
 
 if conf.get('CONFIG_JSONC')

--- a/test/meson.build
+++ b/test/meson.build
@@ -7,7 +7,7 @@
 #
 main = executable(
     'main-test',
-    ['test.c', config_h],
+    ['test.c'],
     dependencies: libuuid,
     link_with: libnvme,
     include_directories: incdir
@@ -22,14 +22,14 @@ cpp = executable(
 
 register = executable(
     'test-register',
-    ['register.c', config_h],
+    ['register.c'],
     link_with: libnvme,
     include_directories: incdir
 )
 
 zns = executable(
     'test-zns',
-    ['zns.c', config_h],
+    ['zns.c'],
     link_with: libnvme,
     include_directories: incdir
 )


### PR DESCRIPTION
meson _is_ a configuration tool, so there is no point in building
the ccan configurator. Especially as the generated config file is
never used anywhere.

Signed-off-by: Hannes Reinecke <hare@suse.de>