### PR TITLE
build: Do not use the configurator for meson

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -11,19 +11,3 @@ sources += files([
     'ccan/str/debug.c',
     'ccan/str/str.c',
 ])
-
-configurator = executable(
-    'configurator',
-    ['tools/configurator/configurator.c'],
-    c_args: ['-D_GNU_SOURCE'],
-    include_directories: incdir,
-)
-
-config_h = custom_target(
-    'config.h',
-    output:  'config.h',
-    capture: true,
-    command: [configurator, ]
-)
-
-

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -7,7 +7,7 @@
 #
 executable(
     'telemetry-listen',
-    ['telemetry-listen.c', config_h],
+    ['telemetry-listen.c'],
     link_with: libnvme,
     include_directories: incdir)
 
@@ -19,7 +19,7 @@ executable(
 
 executable(
     'discover-loop',
-    ['discover-loop.c', config_h],
+    ['discover-loop.c'],
     link_with: libnvme,
     include_directories: incdir)
 

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -19,7 +19,7 @@ endif
 if have_python_support
     pymod_swig = custom_target(
         'nvme.py',
-        input:   ['nvme.i', config_h],
+        input:   ['nvme.i'],
         output:  ['nvme.py', 'nvme_wrap.c'],
         command: [swig, '-python', '-py3', '-o', '@OUTPUT1@', '@INPUT0@'],
         install: true,

--- a/meson.build
+++ b/meson.build
@@ -120,11 +120,6 @@ conf.set10(
     description: 'Is isblank() available?'
 )
 
-configure_file(
-    output: 'libnvme-config.h',
-    configuration: conf
-)
-
 ################################################################################
 substs = configuration_data()
 substs.set('NAME',    meson.project_name())
@@ -138,8 +133,8 @@ configure_file(
 
 ################################################################################
 add_project_arguments(['-fomit-frame-pointer', '-D_GNU_SOURCE',
-                       '-include', 'libnvme-config.h'], language : 'c')
-incdir = include_directories(['.', 'ccan', 'src'])
+                       '-include', 'config.h'], language : 'c')
+incdir = include_directories(['ccan', 'src'])
 
 ################################################################################
 sources = []

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,11 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
+configure_file(
+    output: 'config.h',
+    configuration: conf
+)
+
 sources += [
     'nvme/cleanup.c',
     'nvme/fabrics.c',
@@ -14,7 +19,6 @@ sources += [
     'nvme/log.c',
     'nvme/tree.c',
     'nvme/util.c',
-    config_h,
 ]
 
 if conf.get('CONFIG_JSONC')

--- a/test/meson.build
+++ b/test/meson.build
@@ -7,7 +7,7 @@
 #
 main = executable(
     'main-test',
-    ['test.c', config_h],
+    ['test.c'],
     dependencies: libuuid,
     link_with: libnvme,
     include_directories: incdir
@@ -22,14 +22,14 @@ cpp = executable(
 
 register = executable(
     'test-register',
-    ['register.c', config_h],
+    ['register.c'],
     link_with: libnvme,
     include_directories: incdir
 )
 
 zns = executable(
     'test-zns',
-    ['zns.c', config_h],
+    ['zns.c'],
     link_with: libnvme,
     include_directories: incdir
 )


### PR DESCRIPTION
meson does the feature detection itself and we don't have to rely on
the configurator. So don't use it.

Signed-off-by: Daniel Wagner <dwagner@suse.de>