### PR TITLE
Document meson build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ rm -rf .build
 
 A few build options can be specified on the command line when invoking meson.
 
-| Option  | Values [default]    | Description                                                  |
-| ------- | ------------------- | ------------------------------------------------------------ |
+| Option | Values [default]    | Description                                                  |
+| ------ | ------------------- | ------------------------------------------------------------ |
+| man    | true, [false]       | Instruct meson to configure the project to build the `libnvme` documentation. <br />Example: `meson .build -Dman=true` |
+| python | [auto], true, false | Whether to build the Python bindings. When set to `auto`, the default, meson will check for the presence of the  tools and libraries (e.g. `swig`) required to build the Python bindings. If found, meson will configure the project to build the Python bindings. If a tool or library is missing, then the Python bindings won't be built. Setting this to `true`, forces the Python bindings to be built. When set to `false`, meson will configure the project to not build the Python bindings.<br />Example: `meson .build -Dpython=false` |
 
 ### Changing the build options from the command-line (i.e. w/o modifying any files)
 
@@ -158,8 +160,15 @@ To enable address sanitizer (advanced debugging of memory issues):
 meson .build -Db_sanitize=address
 ```
 
+This option adds `-fsanitize=address` to the gcc options. Note that when using the sanitize feature, the library `libasan.so` must be available and must be the very first library loaded when running an executable. Ensuring that `libasan.so` gets loaded first can be achieved with the `LD_PRELOAD` environment variable as follows: 
+
+```
+meson .build -Db_sanitize=address && LD_PRELOAD=/lib64/libasan.so.6 ninja -C .build test 
+```
+
 To list configuration options that are available and possible values:
 
 ```bash
 meson configure .build
 ```
+


### PR DESCRIPTION
meson provides several built-in options and a few user-defined
options. 

This patch documents these different options. It also describe how 
to use the -Db_sanitize=address option and document how to 
invoke executables with the LD_PRELOAD option when this option
is used.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>