### PR TITLE
Add libjson version check on configure to fix build error

### DIFF
--- a/configure
+++ b/configure
@@ -199,9 +199,8 @@ print_config "libuuid" "${libuuid}"
 # check for libjson-c
 libjsonc="no"
 if [ -z "$disable_json" ] ; then
-    ${ld} -o /dev/null -ljson-c >/dev/null 2>&1
-    if [ $? -eq 0 ]; then
-	libjsonc="yes"
+    if pkg-config --atleast-version=0.13 json-c; then
+        libjsonc="yes"
     fi
 fi
 print_config "libjson-c" "${libjsonc}"


### PR DESCRIPTION
json_util_get_last_err, json_object_to_fd are supported from json-c-0.13-20171207
if json-c version is lower than 0.13, build without it

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>


if not checking the version, make will be failed with below for lower version of json-c

/opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: ../src//libnvme.a(json.ol): in function `json_read_config':
/root/Desktop/repo/libnvme_upstream/src/nvme/json.c:164: undefined reference to `json_util_get_last_err'
/opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: ../src//libnvme.a(json.ol): in function `json_update_config':
/root/Desktop/repo/libnvme_upstream/src/nvme/json.c:290: undefined reference to `json_object_to_fd'
/opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: /root/Desktop/repo/libnvme_upstream/src/nvme/json.c:295: undefined reference to `json_util_get_last_err'
/opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: /root/Desktop/repo/libnvme_upstream/src/nvme/json.c:295: undefined reference to `json_util_get_last_err'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:29: test] Error 1