### PR TITLE
recover monolithic commit 782086cc4fd590f1df171c927ebf9a2debc0a052

### DIFF
--- a/doc/libnvme.rst
+++ b/doc/libnvme.rst
@@ -6425,7 +6425,7 @@ Returns true if given offset is 64bit register, otherwise it returns false.
     __u8 nvscc;
     __u8 nwpc;
     __le16 acwu;
-    __u8 rsvd534[2];
+    __le16 ocfs;
     __le32 sgls;
     __le32 mnan;
     __u8 rsvd544[224];
@@ -6749,6 +6749,10 @@ Returns true if given offset is 64bit register, otherwise it returns false.
   all namespaces with any supported namespace format for a Compare
   and Write fused operation. This field is specified in logical
   blocks and is a 0’s based value.
+
+``ocfs``
+  Optional Copy Formats Supported, each bit n means controller supports
+  Copy Format n.
 
 ``sgls``
   SGL Support, see :c:type:`enum nvme_id_ctrl_sgls <nvme_id_ctrl_sgls>`

--- a/doc/man/struct nvme_id_ctrl.2
+++ b/doc/man/struct nvme_id_ctrl.2
@@ -152,7 +152,7 @@ struct nvme_id_ctrl {
 .br
 .BI "    __le16 acwu;"
 .br
-.BI "    __u8 rsvd534[2];"
+.BI "    __le16 ocfs;"
 .br
 .BI "    __le32 sgls;"
 .br
@@ -424,6 +424,9 @@ operation guaranteed to be written atomically to the NVM across
 all namespaces with any supported namespace format for a Compare
 and Write fused operation. This field is specified in logical
 blocks and is a 0’s based value.
+.IP "ocfs" 12
+Optional Copy Formats Supported, each bit n means controller
+supports Copy Format n.
 .IP "sgls" 12
 SGL Support, see \fIenum nvme_id_ctrl_sgls\fP
 .IP "mnan" 12

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -965,7 +965,7 @@ struct nvme_id_ctrl {
 	__u8			icsvscc;
 	__u8			nwpc;
 	__le16			acwu;
-	__u8			rsvd534[2];
+	__le16			ocfs;
 	__le32			sgls;
 	__le32			mnan;
 	__u8			maxdna[16];

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -862,6 +862,8 @@ struct nvme_id_psd {
  * 	       all namespaces with any supported namespace format for a Compare
  * 	       and Write fused operation. This field is specified in logical
  * 	       blocks and is a 0’s based value.
+ * @ocfs:      Optional Copy Formats Supported, each bit n means controller
+ *         supports Copy Format n.
  * @sgls:      SGL Support, see &enum nvme_id_ctrl_sgls
  * @mnan:      Maximum Number of Allowed Namespaces indicates the maximum
  * 	       number of namespaces supported by the NVM subsystem.


### PR DESCRIPTION
manually recovered

nvme: add optional copy format support id ctrl field

Add the OCFS field in Identify Controller Structure, as per the
Ratified TP 4065b (Simple Copy Command).

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>

https://github.com/linux-nvme/nvme-cli/commit/782086cc4fd590f1df171c927ebf9a2debc0a052