### PR TITLE
fabrics: fix endless loop in connect-all for NVME_NQN_CURR

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -657,8 +657,10 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 	}
 
 	switch (e->subtype) {
-	case NVME_NQN_DISC:
 	case NVME_NQN_CURR:
+		nvme_ctrl_set_discovered(c, true);
+		break;
+	case NVME_NQN_DISC:
 		if (discover)
 			*discover = true;
 		nvme_ctrl_set_discovery_ctrl(c, true);


### PR DESCRIPTION
For a discovery log page entry that indicates the discovery controller
that returned it (i.e. itself), we need to set the controller as
discovered (because we got the discovery log page by connecting to it).

Without this connect-all goes in an endless loop keep connecting and
retrieving the log page from the same discovery subsystem port.

Fixes: 06a8f001d314 ("tree,fabrics: detect discovery loops")
Signed-off-by: Sagi Grimberg <sagi@grimberg.me>