### PR TITLE
build: Enable ccan debug code for debug build

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -11,3 +11,8 @@ sources += files([
     'ccan/str/debug.c',
     'ccan/str/str.c',
 ])
+
+if get_option('buildtype') == 'debug'
+    add_project_arguments('-DCCAN_LIST_DEBUG=1',  language : ['c', 'cpp'])
+    add_project_arguments('-DCCAN_STR_DEBUG=1',  language : ['c', 'cpp'])
+endif


### PR DESCRIPTION
The ccan library has support debugging, let's enable this when
building the debug version of the library.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

As discussed in #128 