### PR TITLE
Add missing function(nvme_get_log_zns_changed_zones) to map file

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -131,6 +131,7 @@ LIBNVME_1_0 {
 		nvme_get_log_supported_log_pages;
 		nvme_get_log_telemetry_ctrl;
 		nvme_get_log_telemetry_host;
+		nvme_get_log_zns_changed_zones;
 		nvme_get_new_host_telemetry;
 		nvme_get_ns_attr;
 		nvme_get_nsid;


### PR DESCRIPTION
Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>

https://github.com/linux-nvme/nvme-cli/pull/1268

it cause meson build error.

repo/nvme-cli/.build/subprojects/json-c-0.15
FAILED: nvme 
cc  -o nvme nvme.p/fabrics.c.o nvme.p/nvme.c.o nvme.p/nvme-models.c.o nvme.p/nvme-print.c.o nvme.p/nvme-rpmb.c.o nvme.p/plugin.c.o nvme.p/ccan_ccan_list_list.c.o nvme.p/ccan_ccan_str_debug.c.o nvme.p/ccan_ccan_str_str.c.o nvme.p/plugins_amzn_amzn-nvme.c.o nvme.p/plugins_dera_dera-nvme.c.o nvme.p/plugins_huawei_huawei-nvme.c.o nvme.p/plugins_intel_intel-nvme.c.o nvme.p/plugins_memblaze_memblaze-nvme.c.o nvme.p/plugins_micron_micron-nvme.c.o nvme.p/plugins_netapp_netapp-nvme.c.o nvme.p/plugins_nvidia_nvidia-nvme.c.o nvme.p/plugins_scaleflux_sfx-nvme.c.o nvme.p/plugins_seagate_seagate-nvme.c.o nvme.p/plugins_shannon_shannon-nvme.c.o nvme.p/plugins_toshiba_toshiba-nvme.c.o nvme.p/plugins_transcend_transcend-nvme.c.o nvme.p/plugins_virtium_virtium-nvme.c.o nvme.p/plugins_wdc_wdc-utils.c.o nvme.p/plugins_wdc_wdc-nvme.c.o nvme.p/plugins_ymtc_ymtc-nvme.c.o nvme.p/plugins_zns_zns.c.o nvme.p/util_argconfig.c.o nvme.p/util_cleanup.c.o nvme.p/util_json.c.o nvme.p/util_parser.c.o nvme.p/util_suffix.c.o nvme.p/util_base64.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -Wl,--start-group subprojects/libnvme/src/libnvme.so.1.0.0 subprojects/json-c-0.15/libjson-c.so /usr/lib64/libuuid.so -lm -pthread /usr/lib64/libz.so -Wl,--end-group '-Wl,-rpath,$ORIGIN/subprojects/libnvme/src:$ORIGIN/subprojects/json-c-0.15' -Wl,-rpath-link,/root/Desktop/repo/nvme-cli/.build/subprojects/libnvme/src -Wl,-rpath-link,/root/Desktop/repo/nvme-cli/.build/subprojects/json-c-0.15
/opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: nvme.p/plugins_zns_zns.c.o: in function `changed_zone_list':
**zns.c:(.text+0x1785): undefined reference to `nvme_get_log_zns_changed_zones'**
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.