### PR TITLE
ioctl: Add Offset Type to get_log_page()

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -788,6 +788,13 @@ int nvme_zns_identify_ctrl(int fd, struct nvme_zns_id_ctrl *id);
  * @lsi:	Endurance group information
  * @rae:	Retain asynchronous events
  * @uuidx:	UUID selection, if supported
+ * @csi:        Command Set Identifier
+ * @ot:		Offset Type. If set to false, the Log Page Offset Lower
+ *		field and the Log Page Offset Upper field specify the
+ *		byte offset into the log page to be returned.
+ *		If set to true, the Log Page Offset Lower field and the
+ *		Log Page Offset Upper field specify the index into the
+ *		list of data structures in the log page to be returned.
  * @len:	Length of provided user buffer to hold the log data in bytes
  * @log:	User space destination address to transfer the data
  * @timeout:	Timeout in ms
@@ -798,13 +805,14 @@ int nvme_zns_identify_ctrl(int fd, struct nvme_zns_id_ctrl *id);
  */
 int nvme_get_log(int fd, enum nvme_cmd_get_log_lid lid, __u32 nsid, __u64 lpo,
 		 __u8 lsp, __u16 lsi, bool rae, __u8 uuidx, enum nvme_csi csi,
-		 __u32 len, void *log, __u32 timeout, __u32 *result);
+		 bool ot, __u32 len, void *log, __u32 timeout, __u32 *result);
 
 static inline int nvme_get_nsid_log(int fd, enum nvme_cmd_get_log_lid lid,
 				    __u32 nsid, __u32 len, void *log)
 {
-	return nvme_get_log(fd, lid, nsid, 0, 0, 0, false, 0, NVME_CSI_NVM, len,
-			    log, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_get_log(fd, lid, nsid, 0, 0, 0, false, 0, NVME_CSI_NVM,
+			    false, len, log, NVME_DEFAULT_IOCTL_TIMEOUT,
+			    NULL);
 }
 
 static inline int nvme_get_log_simple(int fd, enum nvme_cmd_get_log_lid lid,

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -124,7 +124,7 @@ int __nvme_get_log_page(int fd, __u32 nsid, __u8 log_id, bool rae,
 
 		ret = nvme_get_log(fd, log_id, nsid, offset, NVME_LOG_LSP_NONE,
 				   NVME_LOG_LSI_NONE, retain, NVME_UUID_NONE,
-				   NVME_CSI_NVM, xfer, ptr,
+				   NVME_CSI_NVM, false, xfer, ptr,
 				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (ret)
 			return ret;

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -114,6 +114,7 @@ enum nvme_constants {
 /**
  * enum nvme_csi - Defined command set indicators
  * @NVME_CSI_NVM:	NVM Command Set Indicator
+ * @NVME_CSI_ZNS:	Zoned Namespace Command Set
  */
 enum nvme_csi {
 	NVME_CSI_NVM			= 0,


### PR DESCRIPTION
Port of the "add get log page 2.0 spec fields" patch.

Signed-off-by: Daniel Wagner <dwagner@suse.de>