### PR TITLE
Use command argument structure to avoid overly long argument lists

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -1413,34 +1413,46 @@ int nvme_set_features_iocs_profile(int fd, __u8 iocsi, bool save)
 				   save, NULL);
 }
 
-int nvme_get_features(int fd, enum nvme_features_id fid, __u32 nsid,
-		      enum nvme_get_features_sel sel, __u32 cdw11, __u8 uuidx,
-		      __u32 data_len, void *data, __u32 timeout, __u32 *result)
+int nvme_get_features(struct nvme_get_features_args *args)
 {
-	__u32 cdw10 = NVME_SET(fid, FEATURES_CDW10_FID) |
-			NVME_SET(sel, GET_FEATURES_CDW10_SEL);
-	__u32 cdw14 = NVME_SET(uuidx, FEATURES_CDW14_UUID);
+	__u32 cdw10 = NVME_SET(args->fid, FEATURES_CDW10_FID) |
+			NVME_SET(args->sel, GET_FEATURES_CDW10_SEL);
+	__u32 cdw14 = NVME_SET(args->uuidx, FEATURES_CDW14_UUID);
 
 	struct nvme_passthru_cmd cmd = {
 		.opcode		= nvme_admin_get_features,
-		.nsid		= nsid,
-		.addr		= (__u64)(uintptr_t)data,
-		.data_len	= data_len,
+		.nsid		= args->nsid,
+		.addr		= (__u64)(uintptr_t)args->data,
+		.data_len	= args->data_len,
 		.cdw10		= cdw10,
-		.cdw11		= cdw11,
+		.cdw11		= args->cdw11,
 		.cdw14		= cdw14,
-		.timeout_ms	= timeout,
+		.timeout_ms	= args->timeout,
 	};
 
-	return nvme_submit_admin_passthru(fd, &cmd, result);
+	if (args->args_size > sizeof(*args))
+		return -EINVAL;
+	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
 }
 
 static int __nvme_get_features(int fd, enum nvme_features_id fid,
 			       enum nvme_get_features_sel sel, __u32 *result)
 {
-	return nvme_get_features(fd, fid, NVME_NSID_NONE, sel, 0,
-				 NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = fid,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_arbitration(int fd, enum nvme_get_features_sel sel,
@@ -1459,9 +1471,21 @@ int nvme_get_features_lba_range(int fd, enum nvme_get_features_sel sel,
 				struct nvme_lba_range_type *data,
 				__u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_LBA_RANGE, NVME_NSID_NONE,
-				 sel, 0, NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_LBA_RANGE,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_temp_thresh(int fd, enum nvme_get_features_sel sel,
@@ -1499,9 +1523,21 @@ int nvme_get_features_irq_coalesce(int fd, enum nvme_get_features_sel sel,
 int nvme_get_features_irq_config(int fd, enum nvme_get_features_sel sel,
 				__u16 iv, __u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_IRQ_CONFIG, NVME_NSID_NONE,
-				 sel, iv, NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_LBA_RANGE,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = iv,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_write_atomic(int fd, enum nvme_get_features_sel sel,
@@ -1520,9 +1556,21 @@ int nvme_get_features_async_event(int fd, enum nvme_get_features_sel sel,
 int nvme_get_features_auto_pst(int fd, enum nvme_get_features_sel sel,
 			       struct nvme_feat_auto_pst *apst, __u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_AUTO_PST, NVME_NSID_NONE,
-				 sel, 0, NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_LBA_RANGE,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_host_mem_buf(int fd, enum nvme_get_features_sel sel,
@@ -1534,9 +1582,21 @@ int nvme_get_features_host_mem_buf(int fd, enum nvme_get_features_sel sel,
 int nvme_get_features_timestamp(int fd,
 	enum nvme_get_features_sel sel, struct nvme_timestamp *ts)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_TIMESTAMP, NVME_NSID_NONE,
-				 sel, 0, NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_TIMESTAMP,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = sizeof(*ts),
+		.data = ts,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_kato(int fd, enum nvme_get_features_sel sel, __u32 *result)
@@ -1562,17 +1622,41 @@ int nvme_get_features_rrl(int fd, enum nvme_get_features_sel sel, __u32 *result)
 int nvme_get_features_plm_config(int fd, enum nvme_get_features_sel sel,
 	__u16 nvmsetid, struct nvme_plm_config *data, __u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_PLM_CONFIG, NVME_NSID_NONE,
-				 sel, nvmsetid, NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_PLM_CONFIG,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = nvmsetid,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_plm_window(int fd, enum nvme_get_features_sel sel,
 	__u16 nvmsetid, __u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_PLM_WINDOW, NVME_NSID_NONE,
-				 sel, nvmsetid, NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_PLM_WINDOW,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = nvmsetid,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_lba_sts_interval(int fd, enum nvme_get_features_sel sel,
@@ -1586,9 +1670,21 @@ int nvme_get_features_host_behavior(int fd, enum nvme_get_features_sel sel,
 				    struct nvme_feat_host_behavior *data,
 				    __u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_HOST_BEHAVIOR,
-				 NVME_NSID_NONE, sel, 0, NVME_UUID_NONE, 0,
-				 NULL, NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_HOST_BEHAVIOR,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_sanitize(int fd, enum nvme_get_features_sel sel,
@@ -1600,9 +1696,21 @@ int nvme_get_features_sanitize(int fd, enum nvme_get_features_sel sel,
 int nvme_get_features_endurance_event_cfg(int fd, enum nvme_get_features_sel sel,
 					  __u16 endgid, __u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_ENDURANCE_EVT_CFG,
-				 NVME_NSID_NONE, sel, 0, NVME_UUID_NONE, 0,
-				 NULL, NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_ENDURANCE_EVT_CFG,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_sw_progress(int fd, enum nvme_get_features_sel sel,
@@ -1614,9 +1722,21 @@ int nvme_get_features_sw_progress(int fd, enum nvme_get_features_sel sel,
 int nvme_get_features_host_id(int fd, enum nvme_get_features_sel sel,
 			      bool exhid, __u32 len, __u8 *hostid)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_HOST_ID, NVME_NSID_NONE, sel,
-				 !!exhid, NVME_UUID_NONE, len, hostid,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_HOST_ID,
+		.nsid = NVME_NSID_NONE,
+		.sel = sel,
+		.cdw11 = !!exhid,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = len,
+		.data = hostid,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_resv_mask(int fd, enum nvme_get_features_sel sel,
@@ -1635,9 +1755,21 @@ int nvme_get_features_write_protect(int fd, __u32 nsid,
 				    enum nvme_get_features_sel sel,
 				    __u32 *result)
 {
-	return nvme_get_features(fd, NVME_FEAT_FID_WRITE_PROTECT, nsid, sel, 0,
-				 NVME_UUID_NONE, 0, NULL,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = NVME_FEAT_FID_WRITE_PROTECT,
+		.nsid = nsid,
+		.sel = sel,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = 0,
+		.data = NULL,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 
 int nvme_get_features_iocs_profile(int fd, enum nvme_get_features_sel sel,

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -365,37 +365,49 @@ enum features {
 	NVME_FEATURES_IOCSP_IOCSCI_MASK				= 0xff,
 };
 
-int nvme_identify(int fd, enum nvme_identify_cns cns, __u32 nsid, __u16 cntid,
-		  __u16 nvmsetid, __u16 domid, __u8 uuidx, __u8 csi,
-		  void *data, __u32 timeout, __u32 *result)
+int nvme_identify(struct nvme_identify_args *args)
 {
-	__u32 cdw10 = NVME_SET(cntid, IDENTIFY_CDW10_CNTID) |
-			NVME_SET(cns, IDENTIFY_CDW10_CNS);
-	__u32 cdw11 = NVME_SET(nvmsetid, IDENTIFY_CDW11_NVMSETID) |
-			NVME_SET(domid, IDENTIFY_CDW11_DOMID) |
-			NVME_SET(csi, IDENTIFY_CDW11_CSI);
-	__u32 cdw14 = NVME_SET(uuidx, IDENTIFY_CDW14_UUID);
+	__u32 cdw10 = NVME_SET(args->cntid, IDENTIFY_CDW10_CNTID) |
+			NVME_SET(args->cns, IDENTIFY_CDW10_CNS);
+	__u32 cdw11 = NVME_SET(args->nvmsetid, IDENTIFY_CDW11_NVMSETID) |
+			NVME_SET(args->domid, IDENTIFY_CDW11_DOMID) |
+			NVME_SET(args->csi, IDENTIFY_CDW11_CSI);
+	__u32 cdw14 = NVME_SET(args->uuidx, IDENTIFY_CDW14_UUID);
 
 	struct nvme_passthru_cmd cmd = {
 		.opcode		= nvme_admin_identify,
-		.nsid		= nsid,
-		.addr		= (__u64)(uintptr_t)data,
+		.nsid		= args->nsid,
+		.addr		= (__u64)(uintptr_t)args->data,
 		.data_len	= NVME_IDENTIFY_DATA_SIZE,
 		.cdw10		= cdw10,
 		.cdw11		= cdw11,
 		.cdw14		= cdw14,
-		.timeout_ms	= timeout,
+		.timeout_ms	= args->timeout,
 	};
 
-	return nvme_submit_admin_passthru(fd, &cmd, result);
+	if (args->args_size > sizeof(*args))
+		return -EINVAL;
+	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
 }
 
 static int __nvme_identify(int fd, __u8 cns, __u32 nsid, void *data)
 {
-	return nvme_identify(fd, cns, nsid, NVME_CNTLID_NONE,
-			     NVME_NVMSETID_NONE, NVME_DOMID_NONE,
-			     NVME_UUID_NONE, NVME_CSI_NVM,
-			     data, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = cns,
+		.nsid = nsid,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = data,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
+	return nvme_identify(&args);
 }
 
 int nvme_identify_ctrl(int fd, struct nvme_id_ctrl *id)
@@ -432,20 +444,44 @@ int nvme_identify_allocated_ns_list(int fd, __u32 nsid,
 int nvme_identify_ctrl_list(int fd, __u16 cntid,
 			    struct nvme_ctrl_list *ctrlist)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_CTRL_LIST,
+		.nsid = NVME_NSID_NONE,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = ctrlist,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_ctrl_list) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_CTRL_LIST,
-			     NVME_NSID_NONE, cntid, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, NVME_CSI_NVM,
-			     ctrlist, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_nsid_ctrl_list(int fd, __u32 nsid, __u16 cntid,
 				 struct nvme_ctrl_list *ctrlist)
 {
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_NS_CTRL_LIST, nsid,
-			     cntid, NVME_NVMSETID_NONE, NVME_DOMID_NONE,
-			     NVME_UUID_NONE, NVME_CSI_NVM, ctrlist,
-			     NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_NS_CTRL_LIST,
+		.nsid = nsid,
+		.cntid = cntid,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = ctrlist,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
+	return nvme_identify(&args);
 }
 
 int nvme_identify_ns_descs(int fd, __u32 nsid, struct nvme_ns_id_desc *descs)
@@ -456,31 +492,67 @@ int nvme_identify_ns_descs(int fd, __u32 nsid, struct nvme_ns_id_desc *descs)
 int nvme_identify_nvmset_list(int fd, __u16 nvmsetid,
 	struct nvme_id_nvmset_list *nvmset)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_NVMSET_LIST,
+		.nsid = NVME_NSID_NONE,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = nvmsetid,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = nvmset,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_id_nvmset_list) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_NVMSET_LIST,
-			     NVME_NSID_NONE, NVME_CNTLID_NONE, nvmsetid,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, NVME_CSI_NVM,
-			     nvmset, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_primary_ctrl(int fd, __u16 cntid,
 	struct nvme_primary_ctrl_cap *cap)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_PRIMARY_CTRL_CAP,
+		.nsid = NVME_NSID_NONE,
+		.cntid = cntid,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = cap,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_primary_ctrl_cap) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_PRIMARY_CTRL_CAP,
-			     NVME_NSID_NONE, cntid, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, NVME_CSI_NVM,
-			     cap, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_secondary_ctrl_list(int fd, __u32 nsid, __u16 cntid,
 	struct nvme_secondary_ctrl_list *list)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_SECONDARY_CTRL_LIST,
+		.nsid = nsid,
+		.cntid = cntid,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = list,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_secondary_ctrl_list) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_SECONDARY_CTRL_LIST,
-			     nsid, cntid, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, NVME_CSI_NVM,
-			     list, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_ns_granularity(int fd,
@@ -500,86 +572,193 @@ int nvme_identify_uuid(int fd, struct nvme_id_uuid_list *list)
 
 int nvme_identify_ctrl_csi(int fd, __u8 csi, void *data)
 {
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_CSI_CTRL, NVME_NSID_NONE,
-			     NVME_CNTLID_NONE, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, csi, data,
-			     NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_CSI_CTRL,
+		.nsid = NVME_NSID_NONE,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = csi,
+		.data = data,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
+	return nvme_identify(&args);
 }
 
 int nvme_identify_ns_csi(int fd, __u32 nsid, __u8 csi, void *data)
 {
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_CSI_NS, nsid,
-			     NVME_CNTLID_NONE, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, csi, data,
-			     NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_CSI_NS,
+		.nsid = nsid,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = csi,
+		.data = data,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
+	return nvme_identify(&args);
 }
 
 int nvme_identify_active_ns_list_csi(int fd, __u32 nsid, __u8 csi,
 				     struct nvme_ns_list *list)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_NS_ACTIVE_LIST,
+		.nsid = nsid,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = csi,
+		.data = list,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_ns_list) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_CSI_NS_ACTIVE_LIST, nsid,
-			     NVME_CNTLID_NONE, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, csi, list,
-			     NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_allocated_ns_list_css(int fd, __u32 nsid, __u8 csi,
 					struct nvme_ns_list *list)
 {
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST, nsid,
-			     NVME_CNTLID_NONE, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, csi, list,
-			     NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST,
+		.nsid = nsid,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = csi,
+		.data = list,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
+	return nvme_identify(&args);
 }
 
 int nvme_identify_domain_list(int fd, __u16 domid,
 			      struct nvme_id_domain_list *list)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_DOMAIN_LIST,
+		.nsid = NVME_NSID_NONE,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = domid,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = list,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_id_domain_list) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_DOMAIN_LIST, NVME_NSID_NONE,
-			     NVME_CNTLID_NONE, NVME_NVMSETID_NONE,
-			     domid, NVME_UUID_NONE, NVME_CSI_NVM, list,
-			     NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_endurance_group_list(int fd, __u16 endgrp_id,
 				struct nvme_id_endurance_group_list *list)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_ENDURANCE_GROUP_ID,
+		.nsid = NVME_NSID_NONE,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = endgrp_id,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = list,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_id_endurance_group_list) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_ENDURANCE_GROUP_ID,
-			     NVME_NSID_NONE, NVME_CNTLID_NONE,
-			     NVME_NVMSETID_NONE, endgrp_id, NVME_UUID_NONE,
-			     NVME_CSI_NVM, list, NVME_DEFAULT_IOCTL_TIMEOUT,
-			     NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_independent_identify_ns(int fd, __u32 nsid,
 					  struct nvme_id_independent_id_ns *ns)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_CSI_INDEPENDENT_ID_NS,
+		.nsid = nsid,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = ns,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_id_independent_id_ns) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_CSI_INDEPENDENT_ID_NS,
-			     nsid, NVME_CNTLID_NONE, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, NVME_CSI_NVM,
-			     ns, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_identify_iocs(int fd, __u16 cntlid, struct nvme_id_iocs *iocs)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_COMMAND_SET_STRUCTURE,
+		.nsid = NVME_NSID_NONE,
+		.cntid = cntlid,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_NVM,
+		.data = iocs,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_id_iocs) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_COMMAND_SET_STRUCTURE,
-			     NVME_NSID_NONE, cntlid, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, NVME_CSI_NVM,
-			     iocs, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_zns_identify_ns(int fd, __u32 nsid, struct nvme_zns_id_ns *data)
 {
+	struct nvme_identify_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.cns = NVME_IDENTIFY_CNS_CSI_NS,
+		.nsid = nsid,
+		.cntid = NVME_CNTLID_NONE,
+		.nvmsetid = NVME_NVMSETID_NONE,
+		.domid = NVME_DOMID_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.csi = NVME_CSI_ZNS,
+		.data = data,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+	};
+
 	BUILD_ASSERT(sizeof(struct nvme_zns_id_ns) == 4096);
-	return nvme_identify(fd, NVME_IDENTIFY_CNS_CSI_NS, nsid,
-			     NVME_CNTLID_NONE, NVME_NVMSETID_NONE,
-			     NVME_DOMID_NONE, NVME_UUID_NONE, NVME_CSI_ZNS,
-			     data, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	return nvme_identify(&args);
 }
 
 int nvme_zns_identify_ctrl(int fd, struct nvme_zns_id_ctrl *id)

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1169,7 +1169,7 @@ int nvme_get_log_persistent_event(int fd, enum nvme_pevent_log_action action,
 				  __u32 size, void *pevent_log);
 
 /**
- * nvme_set_features() - Set a feature attribute
+ * nvme_set_features_args - Arguments for the NVMe Admin Set Feature command
  * @fd:		File descriptor of nvme device
  * @fid:	Feature identifier
  * @nsid:	Namespace ID, if applicable
@@ -1182,20 +1182,53 @@ int nvme_get_log_persistent_event(int fd, enum nvme_pevent_log_action action,
  * @data:	User address of feature data, if applicable
  * @timeout:	Timeout in ms
  * @result:	The command completion result from CQE dword0
+ */
+
+struct nvme_set_features_args {
+	int args_size;
+	int fd;
+	__u8 fid;
+	__u32 nsid;
+	__u32 cdw11;
+	__u32 cdw12;
+	bool save;
+	__u8 uuidx;
+	__u32 cdw15;
+	__u32 data_len;
+	void *data;
+	__u32 timeout;
+	__u32 *result;
+};
+
+/**
+ * nvme_set_features_args() - Set a feature attribute
+ * @args:	&struct nvme_set_features_args argument structure
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features(int fd, __u8 fid, __u32 nsid, __u32 cdw11, __u32 cdw12,
-		      bool save, __u8 uuidx, __u32 cdw15, __u32 data_len,
-		      void *data, __u32 timeout, __u32 *result);
+int nvme_set_features(struct nvme_set_features_args *args);
 
 static inline int nvme_set_features_data(int fd, __u8 fid, __u32 nsid,
 			__u32 cdw11, bool save, __u32 data_len, void *data,
 		 	__u32 *result)
 {
-	return nvme_set_features(fd, fid, nsid, cdw11, 0, save, 0, 0, data_len,
-				 data, NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_set_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = fid,
+		.nsid = nsid,
+		.cdw11 = cdw11,
+		.cdw12 = 0,
+		.save = save,
+		.uuidx = 0,
+		.cdw15 = 0,
+		.data_len = data_len,
+		.data = data,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+	return nvme_set_features(&args);
 }
 
 static inline int nvme_set_features_simple(int fd, __u8 fid, __u32 nsid,

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -374,7 +374,7 @@ int nvme_ns_rescan(int fd);
 int nvme_get_nsid(int fd, __u32 *nsid);
 
 /**
- * nvme_identify() - Send the NVMe Identify command
+ * nvme_identify_args - Arguments for the NVMe Identify command
  * @fd:		File descriptor of nvme device
  * @cns:	The Controller or Namespace structure, see @enum nvme_identify_cns
  * @nsid:	Namespace identifier, if applicable
@@ -386,6 +386,25 @@ int nvme_get_nsid(int fd, __u32 *nsid);
  * @data:	User space destination address to transfer the data
  * @timeout:	Timeout in ms (0 for default timeout)
  * @result:	The command completion result from CQE dword0
+ */
+struct nvme_identify_args {
+	int args_size;
+	int fd;
+	enum nvme_identify_cns cns;
+	__u32 nsid;
+	__u16 cntid;
+	__u16 nvmsetid;
+	__u16 domid;
+	__u8 uuidx;
+	enum nvme_csi csi;
+	void *data;
+	__u32 timeout;
+	__u32 *result;
+};
+
+/**
+ * nvme_identify() - Send the NVMe Identify command
+ * @args:	&struct nvme_identify_args argument structure
  *
  * The Identify command returns a data buffer that describes information about
  * the NVM subsystem, the controller or the namespace(s).
@@ -393,10 +412,7 @@ int nvme_get_nsid(int fd, __u32 *nsid);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_identify(int fd, enum nvme_identify_cns cns, __u32 nsid,
-		  __u16 cntid, __u16 nvmsetid, __u16 domid,
-		  __u8 uuidx, __u8 csi, void *data, __u32 timeout,
-		  __u32 *result);
+int nvme_identify(struct nvme_identify_args *args);
 
 /**
  * nvme_identify_ctrl() - Retrieves nvme identify controller

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1568,31 +1568,60 @@ int nvme_set_features_write_protect(int fd, enum nvme_feat_nswpcfg_state state,
 int nvme_set_features_iocs_profile(int fd, __u8 iocsi, bool save);
 
 /**
- * nvme_get_features() - Retrieve a feature attribute
+ * nvme_get_features_args - Arguments for the NVMe Admin Get Feature command
  * @fd:		File descriptor of nvme device
  * @fid:	Feature identifier, see &enum nvme_features_id
  * @nsid:	Namespace ID, if applicable
- * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
+ * @sel:	Select which type of attribute to return,
+ * 		see &enum nvme_get_features_sel
  * @cdw11:	Feature specific command dword11 field
  * @uuidx:	UUID Index for differentiating vendor specific encoding
  * @data_len:	Length of feature data, if applicable, in bytes
  * @data:	User address of feature data, if applicable
  * @timeout:	Timeout in ms
  * @result:	The command completion result from CQE dword0
+ */
+struct nvme_get_features_args {
+	int args_size;
+	int fd;
+	__u8 fid;
+	__u32 nsid;
+	enum nvme_get_features_sel sel;
+	__u32 cdw11;
+	__u8 uuidx;
+	__u32 data_len;
+	void *data;
+	__u32 timeout;
+	__u32 *result;
+};
+
+/**
+ * nvme_get_features() - Retrieve a feature attribute
+ * @args:	&struct nvme_get_features_args argument structure
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features(int fd, enum nvme_features_id fid, __u32 nsid,
-		      enum nvme_get_features_sel sel, __u32 cdw11, __u8 uuidx,
-		      __u32 data_len, void *data, __u32 timeout, __u32 *result);
+int nvme_get_features(struct nvme_get_features_args *args);
 
 static inline int nvme_get_features_data(int fd, enum nvme_features_id fid,
 			__u32 nsid, __u32 data_len, void *data, __u32 *result)
 {
-	return nvme_get_features(fd, fid, nsid, NVME_GET_FEATURES_SEL_CURRENT,
-				 0, 0, data_len, data,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, result);
+	struct nvme_get_features_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.fid = fid,
+		.nsid = nsid,
+		.sel = NVME_GET_FEATURES_SEL_CURRENT,
+		.cdw11 = 0,
+		.uuidx = NVME_UUID_NONE,
+		.data_len = data_len,
+		.data = data,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = result,
+	};
+
+	return nvme_get_features(&args);
 }
 static inline int nvme_get_features_simple(int fd, enum nvme_features_id fid,
 			__u32 nsid, __u32 *result)

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -104,6 +104,19 @@ int __nvme_get_log_page(int fd, __u32 nsid, __u8 log_id, bool rae,
 	bool retain = true;
 	void *ptr = data;
 	int ret;
+	struct nvme_get_log_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.nsid = nsid,
+		.lid = log_id,
+		.lsp = NVME_LOG_LSP_NONE,
+		.lsi = NVME_LOG_LSI_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+		.csi = NVME_CSI_NVM,
+		.ot = false,
+	};
 
 	/*
 	 * 4k is the smallest possible transfer unit, so restricting to 4k
@@ -122,10 +135,11 @@ int __nvme_get_log_page(int fd, __u32 nsid, __u8 log_id, bool rae,
 		if (offset + xfer == data_len)
 			retain = rae;
 
-		ret = nvme_get_log(fd, log_id, nsid, offset, NVME_LOG_LSP_NONE,
-				   NVME_LOG_LSI_NONE, retain, NVME_UUID_NONE,
-				   NVME_CSI_NVM, false, xfer, ptr,
-				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+		args.lpo = offset;
+		args.len = xfer;
+		args.log = ptr;
+		args.rae = retain;
+		ret = nvme_get_log(&args);
 		if (ret)
 			return ret;
 


### PR DESCRIPTION
Quite some functions like nvme_get_features(), nvme_set_features(), or nvme_get_log() have quite long argument lists, making it very error prone due to mixed up arguments. It also make future extension quite unwieldy as one have to modify the argument list and all derived functions.
To avoid all of that this patch introduces a function-specific argument structure with an 'args_size' as the first field, to make it easy to add new parameters to those functions and to allow for bounds-checking on the passed-in structure.
With that the function should be backwards compatible, and updating the shared library will be easy here.