### PR TITLE
linux: Add nvme_get_logical_block_size()

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -132,6 +132,7 @@ LIBNVME_1_0 {
 		nvme_get_log_telemetry_ctrl;
 		nvme_get_log_telemetry_host;
 		nvme_get_log_zns_changed_zones;
+		nvme_get_logical_block_size;
 		nvme_get_new_host_telemetry;
 		nvme_get_ns_attr;
 		nvme_get_nsid;

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -294,6 +294,22 @@ int nvme_get_ana_log_len(int fd, size_t *analen)
 	return 0;
 }
 
+int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize)
+{
+	struct nvme_id_ns ns;
+	int flbas;
+	int ret;
+
+	ret = nvme_identify_ns(fd, nsid, &ns);
+	if (ret)
+		return ret;
+
+	flbas = ns.flbas & NVME_NS_FLBAS_LBA_MASK;
+	*blksize = 1 << ns.lbaf[flbas].ds;
+
+	return 0;
+}
+
 static int __nvme_set_attr(const char *path, const char *value)
 {
 	int ret, fd;

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -110,6 +110,16 @@ int nvme_get_log_page(int fd, __u32 nsid, __u8 log_id, bool rae,
 int nvme_get_ana_log_len(int fd, size_t *analen);
 
 /**
+ * nvme_get_logical_block_size() - Retrieve block size
+ * @fd:		File descriptor of nvme device
+ * @blksize:	Pointer to where the block size will be set on success
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize);
+
+/**
  * nvme_get_lba_status_log() - Retreive the LBA Status log page
  * @fd:	   File descriptor of the nvme device
  * @rae:   Retain asynchronous events


### PR DESCRIPTION
Add helper to retrieve logical block size using nvme_identify_ns().

Signed-off-by: Daniel Wagner <dwagner@suse.de>