### PR TITLE
Decode TLS1.3 transport security

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -116,6 +116,7 @@ const char *nvmf_eflags_str(__u16 eflags)
 static const char * const sectypes[] = {
 	[NVMF_TCP_SECTYPE_NONE]		= "none",
 	[NVMF_TCP_SECTYPE_TLS]		= "tls",
+	[NVMF_TCP_SECTYPE_TLS13]	= "tls13",
 };
 
 const char *nvmf_sectype_str(__u8 sectype)


### PR DESCRIPTION
Add the definition for TLS1.3 in the transport security attribute
settings (tsas) field.

Signed-off-by: Hannes Reinecke <hare@suse.de>