### PR TITLE
fabrics: Declare loop index at the beginning of the block

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -906,9 +906,12 @@ static int uuid_from_product_uuid(char *system_uuid)
 				20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,
 				-1 /* sentinel */
 			};
-			for (unsigned int i = 0; swaptbl[i] != -1; i++)
+			int i;
+
+			for (i = 0; swaptbl[i] != -1; i++)
 				system_uuid[i] = line[swaptbl[i]];
 			system_uuid[UUID_SIZE-1] = '\0';
+
 			ret = 0;
 		}
 


### PR DESCRIPTION
The gcc in Centos 6.10 complains with

nvme/fabrics.c:909: error: ‘for’ loop initial declarations are only allowed in C99 mode
nvme/fabrics.c:909: note: use option -std=c99 or -std=gnu99 to compileyour code

Let's declare the index at the beginning of the basic block.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: https://github.com/linux-nvme/nvme-cli/issues/1293