### PR TITLE
util: Define inline function as static inline

### DIFF
--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -114,8 +114,9 @@ int nvme_get_directive_receive_length(enum nvme_directive_dtype dtype,
 #define NVME_FEAT_ARB_MPW(v)		NVME_GET(v, FEAT_ARBITRATION_MPW)
 #define NVME_FEAT_ARB_HPW(v)		NVME_GET(v, FEAT_ARBITRATION_HPW)
 
-inline void nvme_feature_decode_arbitration(__u32 value, __u8 *ab, __u8 *lpw,
-	__u8 *mpw, __u8 *hpw)
+static inline void nvme_feature_decode_arbitration(__u32 value, __u8 *ab,
+						   __u8 *lpw, __u8 *mpw,
+						   __u8 *hpw)
 {
 	*ab  = NVME_FEAT_ARB_BURST(value);
 	*lpw = NVME_FEAT_ARB_LPW(value);
@@ -126,7 +127,8 @@ inline void nvme_feature_decode_arbitration(__u32 value, __u8 *ab, __u8 *lpw,
 #define NVME_FEAT_PM_PS(v)		NVME_GET(v, FEAT_PWRMGMT_PS)
 #define NVME_FEAT_PM_WH(v)		NVME_GET(v, FEAT_PWRMGMT_WH)
 
-inline void nvme_feature_decode_power_mgmt(__u32 value, __u8 *ps, __u8 *wh)
+static inline void nvme_feature_decode_power_mgmt(__u32 value, __u8 *ps,
+						  __u8 *wh)
 {
 	*ps = NVME_FEAT_PM_PS(value);
 	*wh = NVME_FEAT_PM_WH(value);
@@ -134,7 +136,7 @@ inline void nvme_feature_decode_power_mgmt(__u32 value, __u8 *ps, __u8 *wh)
 
 #define NVME_FEAT_LBAR_NR(v)		NVME_GET(v, FEAT_LBAR_NR)
 
-inline void nvme_feature_decode_lba_range(__u32 value, __u8 *num)
+static inline void nvme_feature_decode_lba_range(__u32 value, __u8 *num)
 {
 	*num = NVME_FEAT_LBAR_NR(value);
 }
@@ -143,8 +145,8 @@ inline void nvme_feature_decode_lba_range(__u32 value, __u8 *num)
 #define NVME_FEAT_TT_TMPSEL(v)		NVME_GET(v, FEAT_TT_TMPSEL)
 #define NVME_FEAT_TT_THSEL(v)		NVME_GET(v, FEAT_TT_THSEL)
 
-inline void nvme_feature_decode_temp_threshold(__u32 value, __u16 *tmpth,
-	__u8 *tmpsel, __u8 *thsel)
+static inline void nvme_feature_decode_temp_threshold(__u32 value, __u16 *tmpth,
+						      __u8 *tmpsel, __u8 *thsel)
 {
 	*tmpth	= NVME_FEAT_TT_TMPTH(value);
 	*tmpsel	= NVME_FEAT_TT_TMPSEL(value);
@@ -154,7 +156,8 @@ inline void nvme_feature_decode_temp_threshold(__u32 value, __u16 *tmpth,
 #define NVME_FEAT_ER_TLER(v)		NVME_GET(v, FEAT_ERROR_RECOVERY_TLER)
 #define NVME_FEAT_ER_DULBE(v)		NVME_GET(v, FEAT_ERROR_RECOVERY_DULBE)
 
-inline void nvme_feature_decode_error_recovery(__u32 value, __u16 *tler, bool *dulbe)
+static inline void nvme_feature_decode_error_recovery(__u32 value, __u16 *tler,
+						      bool *dulbe)
 {
 	*tler	= NVME_FEAT_ER_TLER(value);
 	*dulbe	= NVME_FEAT_ER_DULBE(value);
@@ -162,7 +165,8 @@ inline void nvme_feature_decode_error_recovery(__u32 value, __u16 *tler, bool *d
 
 #define NVME_FEAT_VWC_WCE(v)		NVME_GET(v, FEAT_VWC_WCE)
 
-inline void nvme_feature_decode_volatile_write_cache(__u32 value, bool *wce)
+static inline void nvme_feature_decode_volatile_write_cache(__u32 value,
+							    bool *wce)
 {
 	*wce	= NVME_FEAT_VWC_WCE(value);
 }
@@ -170,7 +174,9 @@ inline void nvme_feature_decode_volatile_write_cache(__u32 value, bool *wce)
 #define NVME_FEAT_NRQS_NSQR(v)		NVME_GET(v, FEAT_NRQS_NSQR)
 #define NVME_FEAT_NRQS_NCQR(v)		NVME_GET(v, FEAT_NRQS_NCQR)
 
-inline void nvme_feature_decode_number_of_queues(__u32 value, __u16 *nsqr, __u16 *ncqr)
+static inline void nvme_feature_decode_number_of_queues(__u32 value,
+							__u16 *nsqr,
+							__u16 *ncqr)
 {
 	*nsqr	= NVME_FEAT_NRQS_NSQR(value);
 	*ncqr	= NVME_FEAT_NRQS_NCQR(value);
@@ -179,7 +185,9 @@ inline void nvme_feature_decode_number_of_queues(__u32 value, __u16 *nsqr, __u16
 #define NVME_FEAT_IRQC_THR(v)		NVME_GET(v, FEAT_IRQC_THR)
 #define NVME_FEAT_IRQC_TIME(v)		NVME_GET(v, FEAT_IRQC_TIME)
 
-inline void nvme_feature_decode_interrupt_coalescing(__u32 value, __u8 *thr, __u8 *time)
+static inline void nvme_feature_decode_interrupt_coalescing(__u32 value,
+							    __u8 *thr,
+							    __u8 *time)
 {
 	*thr	= NVME_FEAT_IRQC_THR(value);
 	*time	= NVME_FEAT_IRQC_TIME(value);
@@ -188,7 +196,8 @@ inline void nvme_feature_decode_interrupt_coalescing(__u32 value, __u8 *thr, __u
 #define NVME_FEAT_ICFG_IV(v)		NVME_GET(v, FEAT_ICFG_IV)
 #define NVME_FEAT_ICFG_CD(v)		NVME_GET(v, FEAT_ICFG_CD)
 
-inline void nvme_feature_decode_interrupt_config(__u32 value, __u16 *iv, bool *cd)
+static inline void nvme_feature_decode_interrupt_config(__u32 value, __u16 *iv,
+							bool *cd)
 {
 	*iv	= NVME_FEAT_ICFG_IV(value);
 	*cd	= NVME_FEAT_ICFG_CD(value);
@@ -196,7 +205,7 @@ inline void nvme_feature_decode_interrupt_config(__u32 value, __u16 *iv, bool *c
 
 #define NVME_FEAT_WA_DN(v)		NVME_GET(v, FEAT_WA_DN)
 
-inline void nvme_feature_decode_write_atomicity(__u32 value, bool *dn)
+static inline void nvme_feature_decode_write_atomicity(__u32 value, bool *dn)
 {
 	*dn	= NVME_FEAT_WA_DN(value);
 }
@@ -210,9 +219,9 @@ inline void nvme_feature_decode_write_atomicity(__u32 value, bool *dn)
 #define NVME_FEAT_AE_LBAS(v)		NVME_GET(v, FEAT_AE_LBAS)
 #define NVME_FEAT_AE_EGA(v)		NVME_GET(v, FEAT_AE_EGA)
 
-inline void nvme_feature_decode_async_event_config(__u32 value, __u8 *smart,
-	bool *nan, bool *fw, bool *telem, bool *ana, bool *pla, bool *lbas,
-	bool *ega)
+static inline void nvme_feature_decode_async_event_config(__u32 value,
+			  __u8 *smart, bool *nan, bool *fw, bool *telem,
+			  bool *ana, bool *pla, bool *lbas, bool *ega)
 {
 	*smart	= NVME_FEAT_AE_SMART(value);
 	*nan	= NVME_FEAT_AE_NAN(value);
@@ -226,14 +235,15 @@ inline void nvme_feature_decode_async_event_config(__u32 value, __u8 *smart,
 
 #define NVME_FEAT_APST_APSTE(v)		NVME_GET(v, FEAT_APST_APSTE)
 
-inline void nvme_feature_decode_auto_power_state(__u32 value, bool *apste)
+static inline void nvme_feature_decode_auto_power_state(__u32 value,
+							bool *apste)
 {
 	*apste	= NVME_FEAT_APST_APSTE(value);
 }
 
 #define NVME_FEAT_HMEM_EHM(v)		NVME_GET(v, FEAT_HMEM_EHM)
 
-inline void nvme_feature_decode_host_memory_buffer(__u32 value, bool *ehm)
+static inline void nvme_feature_decode_host_memory_buffer(__u32 value, bool *ehm)
 {
 	*ehm	= NVME_FEAT_HMEM_EHM(value);
 }
@@ -241,7 +251,9 @@ inline void nvme_feature_decode_host_memory_buffer(__u32 value, bool *ehm)
 #define NVME_FEAT_HCTM_TMT2(v)		NVME_GET(v, FEAT_HCTM_TMT2)
 #define NVME_FEAT_HCTM_TMT1(v)		NVME_GET(v, FEAT_HCTM_TMT1)
 
-inline void nvme_feature_decode_host_thermal_mgmt(__u32 value, __u16 *tmt2, __u16 *tmt1)
+static inline void nvme_feature_decode_host_thermal_mgmt(__u32 value,
+							 __u16 *tmt2,
+							 __u16 *tmt1)
 {
 	*tmt2	= NVME_FEAT_HCTM_TMT2(value);
 	*tmt1	= NVME_FEAT_HCTM_TMT1(value);
@@ -249,28 +261,32 @@ inline void nvme_feature_decode_host_thermal_mgmt(__u32 value, __u16 *tmt2, __u1
 
 #define NVME_FEAT_NOPS_NOPPME(v)	NVME_GET(v, FEAT_NOPS_NOPPME)
 
-inline void nvme_feature_decode_non_op_power_config(__u32 value, bool *noppme)
+static inline void nvme_feature_decode_non_op_power_config(__u32 value,
+							   bool *noppme)
 {
 	*noppme	= NVME_FEAT_NOPS_NOPPME(value);
 }
 
 #define NVME_FEAT_RRL_RRL(v)		NVME_GET(v, FEAT_RRL_RRL)
 
-inline void nvme_feature_decode_read_recovery_level_config(__u32 value, __u8 *rrl)
+static inline void nvme_feature_decode_read_recovery_level_config(__u32 value,
+								  __u8 *rrl)
 {
 	*rrl	= NVME_FEAT_RRL_RRL(value);
 }
 
 #define NVME_FEAT_PLM_PLME(v)		NVME_GET(v, FEAT_PLM_PLME)
 
-inline void nvme_feature_decode_predictable_latency_mode_config(__u32 value, bool *plme)
+static inline void nvme_feature_decode_predictable_latency_mode_config(__u32 value,
+								       bool *plme)
 {
 	*plme	= NVME_FEAT_PLM_PLME(value);
 }
 
 #define NVME_FEAT_PLMW_WS(v)		NVME_GET(v, FEAT_PLMW_WS)
 
-inline void nvme_feature_decode_predictable_latency_mode_window(__u32 value, __u8 *ws)
+static inline void nvme_feature_decode_predictable_latency_mode_window(__u32 value,
+								       __u8 *ws)
 {
 	*ws	= NVME_FEAT_PLMW_WS(value);
 }
@@ -278,7 +294,9 @@ inline void nvme_feature_decode_predictable_latency_mode_window(__u32 value, __u
 #define NVME_FEAT_LBAS_LSIRI(v)		NVME_GET(v, FEAT_LBAS_LSIRI)
 #define NVME_FEAT_LBAS_LSIPI(v)		NVME_GET(v, FEAT_LBAS_LSIPI)
 
-inline void nvme_feature_decode_lba_status_attributes(__u32 value, __u16 *lsiri, __u16 *lsipi)
+static inline void nvme_feature_decode_lba_status_attributes(__u32 value,
+							     __u16 *lsiri,
+							     __u16 *lsipi)
 {
 	*lsiri	= NVME_FEAT_LBAS_LSIRI(value);
 	*lsipi	= NVME_FEAT_LBAS_LSIPI(value);
@@ -286,7 +304,7 @@ inline void nvme_feature_decode_lba_status_attributes(__u32 value, __u16 *lsiri,
 
 #define NVME_FEAT_SC_NODRM(v)		NVME_GET(v, FEAT_SC_NODRM)
 
-inline void nvme_feature_decode_sanitize_config(__u32 value, bool *nodrm)
+static inline void nvme_feature_decode_sanitize_config(__u32 value, bool *nodrm)
 {
 	*nodrm	= NVME_FEAT_SC_NODRM(value);
 }
@@ -294,7 +312,7 @@ inline void nvme_feature_decode_sanitize_config(__u32 value, bool *nodrm)
 #define NVME_FEAT_EG_ENDGID(v)		NVME_GET(v, FEAT_EG_ENDGID)
 #define NVME_FEAT_EG_EGCW(v)		NVME_GET(v, FEAT_EG_EGCW)
 
-inline void nvme_feature_decode_endurance_group_event_config(__u32 value,
+static inline void nvme_feature_decode_endurance_group_event_config(__u32 value,
 	__u16 *endgid, __u8 *endgcw)
 {
 	*endgid	= NVME_FEAT_EG_ENDGID(value);
@@ -303,14 +321,15 @@ inline void nvme_feature_decode_endurance_group_event_config(__u32 value,
 
 #define NVME_FEAT_SPM_PBSLC(v)		NVME_GET(v, FEAT_SPM_PBSLC)
 
-inline void nvme_feature_decode_software_progress_marker(__u32 value, __u8 *pbslc)
+static inline void nvme_feature_decode_software_progress_marker(__u32 value,
+								__u8 *pbslc)
 {
 	*pbslc	= NVME_FEAT_SPM_PBSLC(value);
 }
 
 #define NVME_FEAT_HOSTID_EXHID(v)	NVME_GET(v, FEAT_HOSTID_EXHID)
 
-inline void nvme_feature_decode_host_identifier(__u32 value, bool *exhid)
+static inline void nvme_feature_decode_host_identifier(__u32 value, bool *exhid)
 {
 	*exhid = NVME_FEAT_HOSTID_EXHID(value);
 }
@@ -319,8 +338,10 @@ inline void nvme_feature_decode_host_identifier(__u32 value, bool *exhid)
 #define NVME_FEAT_RM_RESREL(v)		NVME_GET(v, FEAT_RM_RESREL)
 #define NVME_FEAT_RM_RESPRE(v)		NVME_GET(v, FEAT_RM_RESPRE)
 
-inline void nvme_feature_decode_reservation_notification(__u32 value, bool *regpre,
-	bool *resrel, bool *respre)
+static inline void nvme_feature_decode_reservation_notification(__u32 value,
+								bool *regpre,
+								bool *resrel,
+								bool *respre)
 {
 	*regpre	= NVME_FEAT_RM_REGPRE(value);
 	*resrel	= NVME_FEAT_RM_RESREL(value);
@@ -329,14 +350,16 @@ inline void nvme_feature_decode_reservation_notification(__u32 value, bool *regp
 
 #define NVME_FEAT_RP_PTPL(v)		NVME_GET(v, FEAT_RP_PTPL)
 
-inline void nvme_feature_decode_reservation_persistance(__u32 value, bool *ptpl)
+static inline void nvme_feature_decode_reservation_persistance(__u32 value,
+							       bool *ptpl)
 {
 	*ptpl	= NVME_FEAT_RP_PTPL(value);
 }
 
 #define NVME_FEAT_WP_WPS(v)		NVME_GET(v, FEAT_WP_WPS)
 
-inline void nvme_feature_decode_namespace_write_protect(__u32 value, __u8 *wps)
+static inline void nvme_feature_decode_namespace_write_protect(__u32 value,
+							       __u8 *wps)
 {
 	*wps	= NVME_FEAT_WP_WPS(value);
 }


### PR DESCRIPTION
The gcc in Centos 6.10 complains with

  src/nvme/util.h:120: multiple definition of `nvme_feature_decode_arbitration'

'inline' alone does not guarantee that the function gets inlined. The
compiler is still free to decide, thus in this case it doesn't inline
and that's why we having multiple implementation with the same
name (in different compile units). 'static inline' forces the inline
which was the indent of this code.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: [#1293](https://github.com/linux-nvme/nvme-cli/issues/1293)