### PR TITLE
linux: Add support to generate DH-HMAC-CHAP keys

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,21 @@ conf.set('CONFIG_LIBUUID', libuuid_dep.found(), description: 'Is libuuid require
 json_c_dep = dependency('json-c', version: '>=0.13', fallback : ['json-c', 'json_c_dep'])
 conf.set('CONFIG_JSONC', json_c_dep.found(), description: 'Is json-c required?')
 
+# Check for OpenSSL availability
+openssl_dep = dependency('openssl',
+                         required: get_option('openssl'),
+                         fallback : ['openssl', 'openssl_dep'])
+if openssl_dep.found()
+  conf.set('CONFIG_OPENSSL', true, description: 'Is OpenSSL available?')
+  conf.set('CONFIG_OPENSSL_1',
+           openssl_dep.version().version_compare('<2.0.0') and
+           openssl_dep.version().version_compare('>=1.1.0'),
+           description: 'OpenSSL version 1.x')
+  conf.set('CONFIG_OPENSSL_3',
+           openssl_dep.version().version_compare('>=3.0.0'),
+           description: 'OpenSSL version 3.x')
+endif
+
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(
     'HAVE_BUILTIN_TYPES_COMPATIBLE_P',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('pkgconfiglibdir', type : 'string', value : '', description : 'directory 
 
 option('man', type : 'boolean', value : false, description : 'build and install man pages (requires sphinx-build)')
 option('python', type : 'combo', choices : ['auto', 'true', 'false'], description : 'Generate libnvme python bindings')
+option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL support')

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -68,6 +68,7 @@ LIBNVME_1_0 {
 		nvme_fw_commit;
 		nvme_fw_download;
 		nvme_fw_download_seq;
+		nvme_gen_dhchap_key;
 		nvme_get_ana_log_len;
 		nvme_get_attr;
 		nvme_get_ctrl_attr;

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,7 @@ endif
 deps = [
     libuuid_dep,
     json_c_dep,
+    openssl_dep,
 ]
 
 source_dir = meson.current_source_dir()
@@ -51,6 +52,7 @@ pkg.generate(libnvme,
 
 libnvme_dep = declare_dependency(
     include_directories: incdir,
+    dependencies: deps,
     link_with: libnvme,
 )
 

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -153,4 +153,33 @@ int nvme_namespace_detach_ctrls(int fd, __u32 nsid, __u16 num_ctrls, __u16 *ctrl
  */
 int nvme_open(const char *name);
 
+/**
+ * enum nvme_hmac_alg - HMAC algorithm
+ * NVME_HMAC_ALG_NONE:		No HMAC algorithm
+ * NVME_HMAC_ALG_SHA2_256:	SHA2-256
+ * NVME_HMAC_ALG_SHA2_384:	SHA2-384
+ * NVME_HMAC_ALG_SHA2_512:	SHA2-512
+ */
+enum nvme_hmac_alg {
+	NVME_HMAC_ALG_NONE	= 0,
+	NVME_HMAC_ALG_SHA2_256	= 1,
+	NVME_HMAC_ALG_SHA2_384	= 2,
+	NVME_HMAC_ALG_SHA2_512	= 3,
+};
+
+/**
+ * nvme_gen_dhchap_key() - DH-HMAC-CHAP key generation
+ * @hostnqn:	Host NVMe Qualified Name
+ * @hmac:	HMAC algorithm
+ * @key_len:	Output key lenght
+ * @secret:	Secret to used for digest
+ * @key:	Generated DH-HMAC-CHAP key
+ *
+ * Return: If key generation was successful the function returns 0 or
+ * -1 with errno set otherwise.
+ */
+int nvme_gen_dhchap_key(char *hostnqn, enum nvme_hmac_alg hmac,
+			unsigned int key_len, unsigned char *secret,
+			unsigned char *key);
+
 #endif /* _LIBNVME_LINUX_H */

--- a/subprojects/openssl.wrap
+++ b/subprojects/openssl.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = openssl-1.1.1l
+source_url = https://www.openssl.org/source/openssl-1.1.1l.tar.gz
+source_filename = openssl-1.1.1l.tar.gz
+source_hash = 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
+patch_filename = openssl_1.1.1l-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openssl_1.1.1l-2/get_patch
+patch_hash = 852521fb016fa2deee8ebf9ffeeee0292c6de86a03c775cf72ac04e86f9f177e
+
+[provide]
+libcrypto = libcrypto_dep
+libssl = libssl_dep
+openssl = openssl_dep
+


### PR DESCRIPTION
Initially the DH-HMAC-CHAP key generation code was part of the
nvme-cli repository and depended on OpenSSL 1. Move the key generation
code into the library. While at it also add support for OpenSSL 3.

Signed-off-by: Daniel Wagner <dwagner@suse.de>
