### PR TITLE
log: Make nvme_log_message thread-local

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -98,7 +98,7 @@ static int discover_err = 0;
   if (connect_err == 1) {
     SWIG_exception(SWIG_AttributeError, "Existing controller connection");
   } else if (connect_err) {
-    if (nvme_log_message)
+    if (nvme_log_message[0])
       SWIG_exception(SWIG_RuntimeError, nvme_log_message);
     else
       SWIG_exception(SWIG_RuntimeError, "Connect failed");

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -172,6 +172,8 @@ LIBNVME_1_0 {
 		nvme_lockdown;
 		nvme_log_level;
 		nvme_log_message;
+		nvme_log_pid;
+		nvme_log_timestamp;
 		nvme_lookup_host;
 		nvme_lookup_subsystem;
 		nvme_namespace_attach_ctrls;

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -35,7 +35,7 @@
 int nvme_log_level = DEFAULT_LOGLEVEL;
 bool nvme_log_timestamp;
 bool nvme_log_pid;
-char *nvme_log_message = NULL;
+__thread char nvme_log_message[NVME_LOG_MESSAGE_LEN] = {'\0'};
 
 void __attribute__((format(printf, 3, 4)))
 __nvme_msg(int lvl, const char *func, const char *format, ...)
@@ -83,9 +83,8 @@ __nvme_msg(int lvl, const char *func, const char *format, ...)
 		message = NULL;
 	va_end(ap);
 
-	if (nvme_log_message)
-		free(nvme_log_message);
-	nvme_log_message = strdup(message);
+	strncpy(nvme_log_message, message, NVME_LOG_MESSAGE_LEN - 1);
+	nvme_log_message[NVME_LOG_MESSAGE_LEN - 1] = '\0';
 
 	if (lvl <= nvme_log_level)
 		fprintf(stderr, "%s%s", header ? header : "<error>",

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -33,8 +33,8 @@
 #endif
 
 int nvme_log_level = DEFAULT_LOGLEVEL;
-bool nvme_log_timestamp;
-bool nvme_log_pid;
+bool nvme_log_timestamp = false;
+bool nvme_log_pid = false;
 __thread char nvme_log_message[NVME_LOG_MESSAGE_LEN] = {'\0'};
 
 void __attribute__((format(printf, 3, 4)))

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -21,10 +21,12 @@
 #define __nvme_log_func NULL
 #endif
 
+#define NVME_LOG_MESSAGE_LEN 512
+
 extern int nvme_log_level;
 extern bool nvme_log_timestamp;
 extern bool nvme_log_pid;
-extern char *nvme_log_message;
+extern __thread char nvme_log_message[NVME_LOG_MESSAGE_LEN];
 
 void __attribute__((format(printf, 3, 4)))
 __nvme_msg(int lvl, const char *func, const char *format, ...);


### PR DESCRIPTION
Also change it to a fixed-length buffer to avoid memory deallocation
burden on a thread exit.

----

This is my attempt to make `nvme_log_message` thread safe/aware by making the log message string thread-local. For simplicity I've changed it from dynamically allocated string to a fixed-length buffer with arbitrary size 512 (feel free to change it!) to avoid the need for explicit deallocation.

Not much tested so far, wanted to make this API change as soon before any public release.