### PR TITLE
util: modify flbas rsvd bits to be used

### DIFF
--- a/doc/libnvme.rst
+++ b/doc/libnvme.rst
@@ -7745,9 +7745,9 @@ Returns true if given offset is 64bit register, otherwise it returns false.
 
 **Constants**
 
-``NVME_NS_FLBAS_LBA_MASK``
-  Mask to get the index of one of the 16 supported
-  LBA Formats indicated in :c:type:`struct nvme_id_ns <nvme_id_ns>`.lbaf.
+``NVME_NS_FLBAS_LOWER_MASK``
+  Mask to get the index of one of the supported LBA Formats's least significant
+  4bits indicated in :c:type:`struct nvme_id_ns <nvme_id_ns>`.lbaf.
 
 ``NVME_NS_FLBAS_META_EXT``
   Applicable only if format contains metadata. If
@@ -7757,7 +7757,9 @@ Returns true if given offset is 64bit register, otherwise it returns false.
   of the metadata for a command is transferred as a
   separate contiguous buffer of data.
 
-
+``NVME_NS_FLBAS_HIGHER_MASK``
+  Mask to get the index of one of the supported LBA Formats's most significant
+  2bits indicated in :c:type:`struct nvme_id_ns <nvme_id_ns>`.lbaf.
 
 
 .. c:type:: enum nvme_id_ns_mc

--- a/doc/man/enum nvme_id_ns_flbas.2
+++ b/doc/man/enum nvme_id_ns_flbas.2
@@ -4,17 +4,21 @@ enum nvme_id_ns_flbas \- This field indicates the LBA data size & metadata size 
 .SH SYNOPSIS
 enum nvme_id_ns_flbas {
 .br
-.BI "    NVME_NS_FLBAS_LBA_MASK"
+.BI "    NVME_NS_FLBAS_LOWER_MASK"
 , 
 .br
 .br
 .BI "    NVME_NS_FLBAS_META_EXT"
-
+, 
+.br
+.br
+.BI "    NVME_NS_FLBAS_HIGHER_MASK"
 };
 .SH Constants
-.IP "NVME_NS_FLBAS_LBA_MASK" 12
-Mask to get the index of one of the 16 supported
-LBA Formats indicated in \fIstruct nvme_id_ns\fP.lbaf.
+.IP "NVME_NS_FLBAS_LOWER_MASK" 12
+Mask to get the index of one of the supported LBA Formats's
+least significant 4bits indicated in \fIstruct nvme_id_ns\fP.lbaf.
+
 .IP "NVME_NS_FLBAS_META_EXT" 12
 Applicable only if format contains metadata. If
 this bit is set, indicates that the metadata is
@@ -22,3 +26,7 @@ transferred at the end of the data LBA, creating an
 extended data LBA. If cleared, indicates that all
 of the metadata for a command is transferred as a
 separate contiguous buffer of data.
+
+.IP "NVME_NS_FLBAS_HIGHER_MASK" 12
+Mask to get the index of one of the supported LBA Formats's
+most significant 2bits indicated in \fIstruct nvme_id_ns\fP.lbaf.

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -337,14 +337,14 @@ int nvme_get_ana_log_len(int fd, size_t *analen)
 int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize)
 {
 	struct nvme_id_ns ns;
-	int flbas;
+	__u8 flbas;
 	int ret;
 
 	ret = nvme_identify_ns(fd, nsid, &ns);
 	if (ret)
 		return ret;
 
-	flbas = ns.flbas & NVME_NS_FLBAS_LBA_MASK;
+	nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &flbas);
 	*blksize = 1 << ns.lbaf[flbas].ds;
 
 	return 0;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1670,14 +1670,14 @@ static int nvme_ns_init(struct nvme_ns *n)
 	struct nvme_id_ns ns = { };
 	uint8_t buffer[NVME_IDENTIFY_DATA_SIZE] = { };
 	struct nvme_ns_id_desc *descs = (void *)buffer;
-	int flbas;
+	uint8_t flbas;
 	int ret;
 
 	ret = nvme_ns_identify(n, &ns);
 	if (ret)
 		return ret;
 
-	flbas = ns.flbas & NVME_NS_FLBAS_LBA_MASK;
+	nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &flbas);
 	n->lba_shift = ns.lbaf[flbas].ds;
 	n->lba_size = 1 << n->lba_shift;
 	n->lba_count = le64_to_cpu(ns.nsze);

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -1700,18 +1700,25 @@ enum nvme_id_nsfeat {
  * enum nvme_id_ns_flbas - This field indicates the LBA data size & metadata
  * 			   size combination that the namespace has been
  * 			   formatted with
- * @NVME_NS_FLBAS_LBA_MASK: Mask to get the index of one of the 16 supported
- * 			    LBA Formats indicated in &struct nvme_id_ns.lbaf.
- * @NVME_NS_FLBAS_META_EXT: Applicable only if format contains metadata. If
- * 			    this bit is set, indicates that the metadata is
- * 			    transferred at the end of the data LBA, creating an
- * 			    extended data LBA. If cleared, indicates that all
- * 			    of the metadata for a command is transferred as a
- * 			    separate contiguous buffer of data.
+ * @NVME_NS_FLBAS_LOWER_MASK:	Mask to get the index of one of the supported
+ *				LBA Formats's least significant
+ *				4bits indicated in
+ *				:c:type:`struct nvme_id_ns <nvme_id_ns>`.lbaf.
+ * @NVME_NS_FLBAS_META_EXT:	Applicable only if format contains metadata. If
+ *				this bit is set, indicates that the metadata is
+ *				transferred at the end of the data LBA, creating an
+ *				extended data LBA. If cleared, indicates that all
+ *				of the metadata for a command is transferred as a
+ *				separate contiguous buffer of data.
+ * @NVME_NS_FLBAS_HIGHER_MASK:  Mask to get the index of one of
+ *				the supported LBA Formats's most significant
+ *				2bits indicated in
+ *				:c:type:`struct nvme_id_ns <nvme_id_ns>`.lbaf.
  */
 enum nvme_id_ns_flbas {
-	NVME_NS_FLBAS_LBA_MASK		= 15 << 0,
+	NVME_NS_FLBAS_LOWER_MASK	= 15 << 0,
 	NVME_NS_FLBAS_META_EXT		= 1 << 4,
+	NVME_NS_FLBAS_HIGHER_MASK	= 3 << 5,
 };
 
 /**

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -363,4 +363,10 @@ static inline void nvme_feature_decode_namespace_write_protect(__u32 value,
 {
 	*wps	= NVME_FEAT_WP_WPS(value);
 }
+
+static inline void nvme_id_ns_flbas_to_lbaf_inuse(__u8 flbas, __u8 *lbaf_inuse)
+{
+	*lbaf_inuse = (((flbas & NVME_NS_FLBAS_HIGHER_MASK) >> 1) \
+		| (flbas & NVME_NS_FLBAS_LOWER_MASK));
+}
 #endif /* _LIBNVME_UTIL_H */

--- a/test/test.c
+++ b/test/test.c
@@ -267,13 +267,15 @@ static int test_namespace(nvme_ns_t n)
 	struct nvme_id_ns ns = { 0 }, allocated = { 0 };
 	struct nvme_ns_id_desc descs = { 0 };
 	__u32 result = 0;
+	__u8 flbas;
 
 	ret = nvme_ns_identify(n, &ns);
 	if (ret)
 		return ret;
 
+	nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &flbas);
 	printf("%s: nsze:%lx lba size:%d\n", nvme_ns_get_name(n), le64_to_cpu(ns.nsze),
-		1 << ns.lbaf[ns.flbas & NVME_NS_FLBAS_LBA_MASK].ds);
+		1 << ns.lbaf[flbas].ds);
 
 	ret = nvme_identify_allocated_ns(fd, nsid, &allocated);
 	if (!ret)


### PR DESCRIPTION
flbas Bits 6:5 indicate the most significant 2 bits of
the Format Index of the supported LBA Format indicated
in this data structure that was used to format the namespace