### PR TITLE
Fix error building the man pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,7 @@
 project = 'libnvme'
 copyright = '2020, Keith Busch'
 author = 'Keith Busch <kbusch@kernel.org>'
+master_doc = 'libnvme'
 
 # The full version, including alpha/beta/rc tags
 release = '0.1'


### PR DESCRIPTION
Fix for issue https://github.com/linux-nvme/libnvme/issues/165

I'm not familiar with Sphinx. By looking up the issue on Google, I found that by default Sphinx looks for a file named `contents.rst`. To specify a different name, in our case `libnvme.rst`, we must define it in `conf.py` as:
```
master_doc = 'libnvme'
```
This seems to fix the issue reported in https://github.com/linux-nvme/libnvme/issues/165.