### PR TITLE
Move 'host_traddr' and 'host_iface' into fabrics configuration

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -123,6 +123,10 @@ static int discover_err = 0;
   temp.tos = -1;
   temp.ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO;
   while (PyDict_Next($input, &pos, &key, &value)) {
+    if (!PyUnicode_CompareWithASCIIString(key, "host_traddr"))
+      temp.host_traddr = PyBytes_AsString(value);
+    if (!PyUnicode_CompareWithASCIIString(key, "host_iface"))
+      temp.host_iface = PyBytes_AsString(value);
     if (!PyUnicode_CompareWithASCIIString(key, "nr_io_queues"))
       temp.nr_io_queues = PyLong_AsLong(value);
     if (!PyUnicode_CompareWithASCIIString(key, "reconnect_delay"))
@@ -293,7 +297,6 @@ struct nvme_ctrl {
   %immutable transport;
   %immutable subsysnqn;
   %immutable traddr;
-  %immutable host_traddr;
   %immutable trsvcid;
   %immutable address;
   %immutable firmware;
@@ -307,7 +310,6 @@ struct nvme_ctrl {
   char *transport;
   char *subsysnqn;
   char *traddr;
-  char *host_traddr;
   char *trsvcid;
   char *dhchap_key;
   char *address;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -170,6 +170,8 @@ static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,
 {
 	struct nvme_fabrics_config *ctrl_cfg = nvme_ctrl_get_config(c);
 
+	UPDATE_CFG_OPTION(ctrl_cfg, cfg, host_traddr, NULL);
+	UPDATE_CFG_OPTION(ctrl_cfg, cfg, host_iface, NULL);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, nr_io_queues, 0);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, nr_write_queues, 0);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, nr_poll_queues, 0);
@@ -438,9 +440,9 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 	    add_argument(argstr, "traddr",
 			 nvme_ctrl_get_traddr(c)) ||
 	    add_argument(argstr, "host_traddr",
-			 nvme_ctrl_get_host_traddr(c)) ||
+			 cfg->host_traddr) ||
 	    add_argument(argstr, "host_iface",
-			 nvme_ctrl_get_host_iface(c)) ||
+			 cfg->host_iface) ||
 	    add_argument(argstr, "trsvcid",
 			 nvme_ctrl_get_trsvcid(c)) ||
 	    (hostnqn && add_argument(argstr, "hostnqn", hostnqn)) ||
@@ -648,7 +650,8 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 	nvme_msg(LOG_DEBUG, "lookup ctrl "
 		 "(transport: %s, traddr: %s, trsvcid %s)\n",
 		 transport, traddr, trsvcid);
-	c = nvme_create_ctrl(e->subnqn, transport, traddr, NULL, NULL, trsvcid);
+	c = nvme_create_ctrl(e->subnqn, transport, traddr,
+			     cfg->host_traddr, cfg->host_iface, trsvcid);
 	if (!c) {
 		nvme_msg(LOG_DEBUG, "skipping discovery entry, "
 			 "failed to allocate %s controller with traddr %s\n",

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -18,6 +18,8 @@
 
 /**
  * struct nvme_fabrics_config - Defines all linux nvme fabrics initiator options
+ * @host_traddr:	Host transport address
+ * @host_iface:		Host interface name
  * @queue_size:		Number of IO queue entries
  * @nr_io_queues:	Number of controller IO queues to establish
  * @reconnect_delay:	Time between two consecutive reconnect attempts.
@@ -33,6 +35,8 @@
  * @data_digest:	Generate/verify data digest (TCP)
  */
 struct nvme_fabrics_config {
+	char *host_traddr;
+	char *host_iface;
 	int queue_size;
 	int nr_io_queues;
 	int reconnect_delay;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -85,8 +85,6 @@ struct nvme_ctrl {
 	char *subsysnqn;
 	char *traddr;
 	char *trsvcid;
-	char *host_traddr;
-	char *host_iface;
 	char *dhchap_key;
 	bool discovery_ctrl;
 	bool discovered;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -716,12 +716,12 @@ const char *nvme_ctrl_get_trsvcid(nvme_ctrl_t c)
 
 const char *nvme_ctrl_get_host_traddr(nvme_ctrl_t c)
 {
-	return c->host_traddr;
+	return c->cfg.host_traddr;
 }
 
 const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c)
 {
-	return c->host_iface;
+	return c->cfg.host_iface;
 }
 
 struct nvme_fabrics_config *nvme_ctrl_get_config(nvme_ctrl_t c)
@@ -866,8 +866,8 @@ static void __nvme_free_ctrl(nvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->transport);
 	FREE_CTRL_ATTR(c->subsysnqn);
 	FREE_CTRL_ATTR(c->traddr);
-	FREE_CTRL_ATTR(c->host_traddr);
-	FREE_CTRL_ATTR(c->host_iface);
+	FREE_CTRL_ATTR(c->cfg.host_traddr);
+	FREE_CTRL_ATTR(c->cfg.host_iface);
 	FREE_CTRL_ATTR(c->trsvcid);
 	free(c);
 }
@@ -917,7 +917,7 @@ void hostname2traddr(nvme_ctrl_t c, const char *host_traddr)
 	if (ret) {
 		nvme_msg(LOG_DEBUG, "failed to resolve host %s info\n",
 			 host_traddr);
-		c->host_traddr = strdup(host_traddr);
+		c->cfg.host_traddr = strdup(host_traddr);
 		return;
 	}
 
@@ -935,15 +935,15 @@ void hostname2traddr(nvme_ctrl_t c, const char *host_traddr)
 	default:
 		nvme_msg(LOG_DEBUG, "unrecognized address family (%d) %s\n",
 			 host_info->ai_family, c->traddr);
-		c->host_traddr = strdup(host_traddr);
+		c->cfg.host_traddr = strdup(host_traddr);
 		goto free_addrinfo;
 	}
 	if (!p) {
 		nvme_msg(LOG_DEBUG, "failed to get traddr for %s\n",
 			 c->traddr);
-		c->host_traddr = strdup(host_traddr);
+		c->cfg.host_traddr = strdup(host_traddr);
 	} else
-		c->host_traddr = strdup(addrstr);
+		c->cfg.host_traddr = strdup(addrstr);
 
 free_addrinfo:
 	freeaddrinfo(host_info);
@@ -991,10 +991,10 @@ struct nvme_ctrl *nvme_create_ctrl(const char *subsysnqn, const char *transport,
 		if (traddr_is_hostname(transport, host_traddr))
 			hostname2traddr(c, host_traddr);
 		else
-			c->host_traddr = strdup(host_traddr);
+			c->cfg.host_traddr = strdup(host_traddr);
 	}
 	if (host_iface)
-		c->host_iface = strdup(host_iface);
+		c->cfg.host_iface = strdup(host_iface);
 	if (trsvcid)
 		c->trsvcid = strdup(trsvcid);
 	else if (discovery)
@@ -1025,11 +1025,11 @@ struct nvme_ctrl *nvme_lookup_ctrl(struct nvme_subsystem *s, const char *transpo
 		if (traddr && c->traddr &&
 		    strcmp(c->traddr, traddr))
 			continue;
-		if (host_traddr && c->host_traddr &&
-		    strcmp(c->host_traddr, host_traddr))
+		if (host_traddr && c->cfg.host_traddr &&
+		    strcmp(c->cfg.host_traddr, host_traddr))
 			continue;
-		if (host_iface && c->host_iface &&
-		    strcmp(c->host_iface, host_iface))
+		if (host_iface && c->cfg.host_iface &&
+		    strcmp(c->cfg.host_iface, host_iface))
 			continue;
 		if (trsvcid && c->trsvcid &&
 		    strcmp(c->trsvcid, trsvcid))


### PR DESCRIPTION
Having 'host_traddr' and 'host_iface' as part of the controller
structure is technically correct, but won't work for 'connect-all'.
There we evaluate the contents of the discovery log page, and create
new controllers based on that information.
But as 'host_traddr' and 'host_iface' are Linux-only constructs, the
spec (and the discovery log page) doesn't know about them, and can't
provide us with that information.

Signed-off-by: Hannes Reinecke <hare@suse.de>