### PR TITLE
log: Introduce libnvme error codes

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -94,14 +94,51 @@ static int discover_err = 0;
 
 %exception nvme_ctrl::connect {
   connect_err = 0;
+  errno = 0;
   $action  /* $action sets connect_err to non-zero value on failure */
   if (connect_err == 1) {
     SWIG_exception(SWIG_AttributeError, "Existing controller connection");
   } else if (connect_err) {
-    if (nvme_log_message)
-      SWIG_exception(SWIG_RuntimeError, nvme_log_message);
-    else
-      SWIG_exception(SWIG_RuntimeError, "Connect failed");
+    switch (errno) {
+    case ENVME_CONNECT_RESOLVE:
+	    SWIG_exception(SWIG_RuntimeError, "failed to resolve host");
+	    break;
+    case ENVME_CONNECT_ADDRFAM:
+	    SWIG_exception(SWIG_RuntimeError, "unrecognized address family");
+	    break;
+    case ENVME_CONNECT_TRADDR:
+	    SWIG_exception(SWIG_RuntimeError, "failed to get traddr");
+	    break;
+    case ENVME_CONNECT_TARG:
+	    SWIG_exception(SWIG_RuntimeError, "need a transport (-t) argument");
+	    break;
+    case ENVME_CONNECT_AARG:
+	    SWIG_exception(SWIG_RuntimeError, "need a address (-a) argument\n");
+	    break;
+    case ENVME_CONNECT_OPEN:
+	    SWIG_exception(SWIG_RuntimeError, "failed to open nvme-fabrics device");
+	    break;
+    case ENVME_CONNECT_WRITE:
+	    SWIG_exception(SWIG_RuntimeError, "failed to write to nvme-fabrics device");
+	    break;
+    case ENVME_CONNECT_READ:
+	    SWIG_exception(SWIG_RuntimeError, "failed to read from nvme-fabrics device");
+	    break;
+    case ENVME_CONNECT_PARSE:
+	    SWIG_exception(SWIG_RuntimeError, "failed to parse ctrl info");
+	    break;
+    case ENVME_CONNECT_INVAL_TR:
+	    SWIG_exception(SWIG_RuntimeError, "invalid transport type");
+	    break;
+    case ENVME_CONNECT_LOOKUP_SUBSYS_NAME:
+	    SWIG_exception(SWIG_RuntimeError, "failed to lookup subsystem name");
+	    break;
+    case ENVME_CONNECT_LOOKUP_SUBSYS:
+	    SWIG_exception(SWIG_RuntimeError, "failed to lookup subsystem");
+	    break;
+    default:
+	SWIG_exception(SWIG_RuntimeError, "Connect failed");
+    }
   }
 }
 

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,7 +1,6 @@
 LIBNVME_1_0 {
 	global:
 		__nvme_get_log_page;
-		__nvme_msg;
 		nvme_admin_passthru64;
 		nvme_admin_passthru;
 		nvme_attach_ns;
@@ -174,7 +173,6 @@ LIBNVME_1_0 {
 		nvme_io_passthru;
 		nvme_lockdown;
 		nvme_log_level;
-		nvme_log_message;
 		nvme_lookup_host;
 		nvme_lookup_subsystem;
 		nvme_namespace_attach_ctrls;

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -24,6 +24,20 @@
 #ifndef _LINUX_NVME_IOCTL_H
 #define _LINUX_NVME_IOCTL_H
 
+/* libnvme errno error codes */
+#define ENVME_CONNECT_RESOLVE			1000 /* "failed to resolve host" */
+#define ENVME_CONNECT_ADDRFAM			1001 /* "unrecognized address family" */
+#define ENVME_CONNECT_TRADDR			1002 /* "failed to get traddr" */
+#define ENVME_CONNECT_TARG			1003 /* "need a transport (-t) argument" */
+#define ENVME_CONNECT_AARG			1004 /* "need a address (-a) argument\n" */
+#define ENVME_CONNECT_OPEN			1005 /* "failed to open nvme-fabrics device" */
+#define ENVME_CONNECT_WRITE			1006 /* "failed to write to nvme-fabrics device" */
+#define ENVME_CONNECT_READ			1007 /* "failed to read from nvme-fabrics device" */
+#define ENVME_CONNECT_PARSE			1008 /* "failed to parse ctrl info" */
+#define ENVME_CONNECT_INVAL_TR			1009 /* "invalid transport type" */
+#define ENVME_CONNECT_LOOKUP_SUBSYS_NAME	1010 /* "failed to lookup subsystem name" */
+#define ENVME_CONNECT_LOOKUP_SUBSYS		1011 /* "failed to lookup subsystem */
+
 /* '0' is interpreted by the kernel to mean 'apply the default timeout' */
 #define NVME_DEFAULT_IOCTL_TIMEOUT 0
 

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -35,7 +35,6 @@
 int nvme_log_level = DEFAULT_LOGLEVEL;
 bool nvme_log_timestamp;
 bool nvme_log_pid;
-char *nvme_log_message = NULL;
 
 void __attribute__((format(printf, 3, 4)))
 __nvme_msg(int lvl, const char *func, const char *format, ...)
@@ -82,10 +81,6 @@ __nvme_msg(int lvl, const char *func, const char *format, ...)
 	if (vasprintf(&message, format, ap) == -1)
 		message = NULL;
 	va_end(ap);
-
-	if (nvme_log_message)
-		free(nvme_log_message);
-	nvme_log_message = strdup(message);
 
 	if (lvl <= nvme_log_level)
 		fprintf(stderr, "%s%s", header ? header : "<error>",

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1156,7 +1156,7 @@ int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance)
 	if (strcmp(c->transport, "loop")) {
 		c->address = nvme_get_attr(path, "address");
 		if (!c->address) {
-			errno = ENXIO;
+			errno = ENVME_CONNECT_INVAL_TR;
 			ret = -1;
 			goto out_free_name;
 		}
@@ -1166,13 +1166,13 @@ int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance)
 	if (!subsys_name) {
 		nvme_msg(LOG_ERR, "Failed to lookup subsystem name for %s\n",
 			 c->name);
-		errno = ENXIO;
+		errno = ENVME_CONNECT_LOOKUP_SUBSYS_NAME;
 		ret = -1;
 		goto out_free_name;
 	}
 	s = nvme_lookup_subsystem(h, subsys_name, c->subsysnqn);
 	if (!s) {
-		errno = ENXIO;
+		errno = ENVME_CONNECT_LOOKUP_SUBSYS;
 		ret = -1;
 		goto out_free_subsys;
 	}


### PR DESCRIPTION
Add libnvme specific error codes which map to a specific error
message. The system error codes in errno are too overloaded to figure
out what is going wrong.

With this we can remove the nvme_log_message buffer. This avoids
having a global library buffer.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #160 