### PR TITLE
build: Add __nvme_msg back to exported symbols

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,6 +1,7 @@
 LIBNVME_1_0 {
 	global:
 		__nvme_get_log_page;
+		__nvme_msg;
 		nvme_admin_passthru64;
 		nvme_admin_passthru;
 		nvme_attach_ns;


### PR DESCRIPTION
nvme_msg() is a macro which call __nvme_msg(). The naming scheme is
not great but until we figured it out, add it back to the list of
exported symbols.

Signed-off-by: Daniel Wagner <dwagner@suse.de>