### PR TITLE
Implement nvme_errno_to_string()

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -99,45 +99,11 @@ static int discover_err = 0;
   if (connect_err == 1) {
     SWIG_exception(SWIG_AttributeError, "Existing controller connection");
   } else if (connect_err) {
-    switch (errno) {
-    case ENVME_CONNECT_RESOLVE:
-	    SWIG_exception(SWIG_RuntimeError, "failed to resolve host");
-	    break;
-    case ENVME_CONNECT_ADDRFAM:
-	    SWIG_exception(SWIG_RuntimeError, "unrecognized address family");
-	    break;
-    case ENVME_CONNECT_TRADDR:
-	    SWIG_exception(SWIG_RuntimeError, "failed to get traddr");
-	    break;
-    case ENVME_CONNECT_TARG:
-	    SWIG_exception(SWIG_RuntimeError, "need a transport (-t) argument");
-	    break;
-    case ENVME_CONNECT_AARG:
-	    SWIG_exception(SWIG_RuntimeError, "need a address (-a) argument\n");
-	    break;
-    case ENVME_CONNECT_OPEN:
-	    SWIG_exception(SWIG_RuntimeError, "failed to open nvme-fabrics device");
-	    break;
-    case ENVME_CONNECT_WRITE:
-	    SWIG_exception(SWIG_RuntimeError, "failed to write to nvme-fabrics device");
-	    break;
-    case ENVME_CONNECT_READ:
-	    SWIG_exception(SWIG_RuntimeError, "failed to read from nvme-fabrics device");
-	    break;
-    case ENVME_CONNECT_PARSE:
-	    SWIG_exception(SWIG_RuntimeError, "failed to parse ctrl info");
-	    break;
-    case ENVME_CONNECT_INVAL_TR:
-	    SWIG_exception(SWIG_RuntimeError, "invalid transport type");
-	    break;
-    case ENVME_CONNECT_LOOKUP_SUBSYS_NAME:
-	    SWIG_exception(SWIG_RuntimeError, "failed to lookup subsystem name");
-	    break;
-    case ENVME_CONNECT_LOOKUP_SUBSYS:
-	    SWIG_exception(SWIG_RuntimeError, "failed to lookup subsystem");
-	    break;
-    default:
-	SWIG_exception(SWIG_RuntimeError, "Connect failed");
+    const char *errstr = nvme_errno_to_string(errno);
+    if (errstr) {
+      SWIG_exception(SWIG_RuntimeError, errstr);
+    } else {
+      SWIG_exception(SWIG_RuntimeError, "Connect failed");
     }
   }
 }

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -56,6 +56,7 @@ LIBNVME_1_0 {
 		nvme_dsm;
 		nvme_dsm_range;
 		nvme_dump_config;
+		nvme_errno_to_string;
 		nvme_first_host;
 		nvme_first_subsystem;
 		nvme_flush;

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -24,20 +24,6 @@
 #ifndef _LINUX_NVME_IOCTL_H
 #define _LINUX_NVME_IOCTL_H
 
-/* libnvme errno error codes */
-#define ENVME_CONNECT_RESOLVE			1000 /* "failed to resolve host" */
-#define ENVME_CONNECT_ADDRFAM			1001 /* "unrecognized address family" */
-#define ENVME_CONNECT_TRADDR			1002 /* "failed to get traddr" */
-#define ENVME_CONNECT_TARG			1003 /* "need a transport (-t) argument" */
-#define ENVME_CONNECT_AARG			1004 /* "need a address (-a) argument\n" */
-#define ENVME_CONNECT_OPEN			1005 /* "failed to open nvme-fabrics device" */
-#define ENVME_CONNECT_WRITE			1006 /* "failed to write to nvme-fabrics device" */
-#define ENVME_CONNECT_READ			1007 /* "failed to read from nvme-fabrics device" */
-#define ENVME_CONNECT_PARSE			1008 /* "failed to parse ctrl info" */
-#define ENVME_CONNECT_INVAL_TR			1009 /* "invalid transport type" */
-#define ENVME_CONNECT_LOOKUP_SUBSYS_NAME	1010 /* "failed to lookup subsystem name" */
-#define ENVME_CONNECT_LOOKUP_SUBSYS		1011 /* "failed to lookup subsystem */
-
 /* '0' is interpreted by the kernel to mean 'apply the default timeout' */
 #define NVME_DEFAULT_IOCTL_TIMEOUT 0
 

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -476,3 +476,25 @@ int nvme_get_directive_receive_length(enum nvme_directive_dtype dtype,
 		return -EINVAL;
 	}
 }
+
+static const char * const libnvme_status[] = {
+	[ENVME_CONNECT_RESOLVE] = "failed to resolve host",
+	[ENVME_CONNECT_ADDRFAM] = "unrecognized address family",
+	[ENVME_CONNECT_TRADDR] = "failed to get transport address",
+	[ENVME_CONNECT_TARG] = "no transport specified",
+	[ENVME_CONNECT_AARG] = "no transport address specified",
+	[ENVME_CONNECT_OPEN] = "failed to open nvme-fabrics device",
+	[ENVME_CONNECT_WRITE] = "failed to write to nvme-fabrics device",
+	[ENVME_CONNECT_READ] = "failed to read from nvme-fabrics device",
+	[ENVME_CONNECT_PARSE] = "failed to parse ctrl info",
+	[ENVME_CONNECT_INVAL_TR] = "invalid transport type",
+	[ENVME_CONNECT_LOOKUP_SUBSYS_NAME] = "failed to lookup subsystem name",
+	[ENVME_CONNECT_LOOKUP_SUBSYS] = "failed to lookup subsystem",
+};
+
+const char *nvme_errno_to_string(int status)
+{
+	const char *s = ARGSTR(libnvme_status, status);
+
+	return s;
+}

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -11,6 +11,20 @@
 
 #include "types.h"
 
+/* nvme connect error codes */
+#define ENVME_CONNECT_RESOLVE			1000 /* "failed to resolve host" */
+#define ENVME_CONNECT_ADDRFAM			1001 /* "unrecognized address family" */
+#define ENVME_CONNECT_TRADDR			1002 /* "failed to get traddr" */
+#define ENVME_CONNECT_TARG			1003 /* "need a transport (-t) argument" */
+#define ENVME_CONNECT_AARG			1004 /* "need a address (-a) argument\n" */
+#define ENVME_CONNECT_OPEN			1005 /* "failed to open nvme-fabrics device" */
+#define ENVME_CONNECT_WRITE			1006 /* "failed to write to nvme-fabrics device" */
+#define ENVME_CONNECT_READ			1007 /* "failed to read from nvme-fabrics device" */
+#define ENVME_CONNECT_PARSE			1008 /* "failed to parse ctrl info" */
+#define ENVME_CONNECT_INVAL_TR			1009 /* "invalid transport type" */
+#define ENVME_CONNECT_LOOKUP_SUBSYS_NAME	1010 /* "failed to lookup subsystem name" */
+#define ENVME_CONNECT_LOOKUP_SUBSYS		1011 /* "failed to lookup subsystem */
+
 /**
  * nvme_status_to_errno() - Converts nvme return status to errno
  * @status:  Return status from an nvme passthrough commmand
@@ -30,6 +44,14 @@ __u8 nvme_status_to_errno(int status, bool fabrics);
  * or a standard errno string if status is < 0.
  */
 const char *nvme_status_to_string(int status, bool fabrics);
+
+/**
+ * nvme_errno_to_string() - Returns string describing nvme connect failures
+ * @err: Returned error code from nvme_add_ctrl()
+ *
+ * Return: String representation of the nvme connect error codes
+ */
+const char *nvme_errno_to_string(int err);
 
 /**
  * nvme_init_id_ns() - Initialize an Identify Namepsace structure for creation.


### PR DESCRIPTION
Add a function nvme_errno_to_string() to provide a string describing
the error from nvme_add_ctrl().

Signed-off-by: Hannes Reinecke <hare@suse.de>