### PR TITLE
meson: ssl version checking allow version >=1.1.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,7 @@ conf.set('CONFIG_JSONC', json_c_dep.found(), description: 'Is json-c required?')
 
 # Check for OpenSSL availability
 openssl_dep = dependency('openssl',
+                         version: '>=1.1.0',
                          required: get_option('openssl'),
                          fallback : ['openssl', 'openssl_dep'])
 if openssl_dep.found()


### PR DESCRIPTION
for lower version of ssl, config will be below
#define CONFIG_OPENSSL
#undef CONFIG_OPENSSL_1
#undef CONFIG_OPENSSL_3

so function nvme_gen_dhchap_key is not defined in c file

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>

#158 @igaw , I assume that you just allow version >=1.1.0, based on your meson changes