### PR TITLE
Define ccan as a static library

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -6,13 +6,21 @@
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
 
-sources += files([
+sources = [
     'ccan/list/list.c',
     'ccan/str/debug.c',
     'ccan/str/str.c',
-])
+]
 
 if get_option('buildtype') == 'debug'
     add_project_arguments('-DCCAN_LIST_DEBUG=1',  language : ['c', 'cpp'])
     add_project_arguments('-DCCAN_STR_DEBUG=1',  language : ['c', 'cpp'])
 endif
+
+libccan = static_library(
+    'ccan',
+    sources,
+    install: false,
+    include_directories: [incdir, internal_incdir],
+    dependencies: config_dep,
+)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -25,4 +25,3 @@ executable(
     link_with: libnvme,
     include_directories: [incdir, internal_incdir]
 )
-

--- a/internal/meson.build
+++ b/internal/meson.build
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is part of libnvme.
+# Copyright (c) 2022 Dell Inc.
+#
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+#
+# Because libnvme is used as a subproject of nvme-cli,
+# the config.h file must be generated as a private file
+# hidden from nvme-cli.
+
+config_h = configure_file(
+    output: 'config.h',
+    configuration: conf
+)
+
+internal_incdir = include_directories('.')
+
+config_dep = declare_dependency(
+  include_directories : internal_incdir,
+  sources: config_h)

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -5,11 +5,6 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-configure_file(
-    output: 'config.h',
-    configuration: conf
-)
-
 want_python = get_option('python')
 if want_python != 'false'
     python3 = import('python').find_installation('python3')
@@ -35,8 +30,8 @@ if have_python_support
         '_nvme',
         pymod_swig[1],
         dependencies : py3_dep,
-        include_directories: incdir,
-        link_with: libnvme,
+        include_directories: [incdir, internal_incdir],
+        link_with: [libnvme, libccan],
         install: true,
         subdir: 'libnvme',
     )

--- a/meson.build
+++ b/meson.build
@@ -150,13 +150,18 @@ configure_file(
 )
 
 ################################################################################
-add_project_arguments(['-fomit-frame-pointer', '-D_GNU_SOURCE',
-                       '-include', 'libnvme/config.h'], language : 'c')
+add_project_arguments(
+    [
+        '-fomit-frame-pointer',
+        '-D_GNU_SOURCE',
+        '-include', 'internal/config.h',
+    ],
+    language : 'c',
+)
 incdir = include_directories(['.', 'ccan', 'src'])
-internal_incdir = include_directories('libnvme')
 
 ################################################################################
-sources = []
+subdir('internal')
 subdir('ccan')
 subdir('src')
 subdir('libnvme')

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,7 +5,7 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-sources += [
+sources = [
     'nvme/cleanup.c',
     'nvme/fabrics.c',
     'nvme/filters.c',
@@ -39,6 +39,7 @@ libnvme = library(
     link_depends: mapfile,
     include_directories: [incdir, internal_incdir],
     install: true,
+    link_with: libccan,
 )
 
 pkg = import('pkgconfig')


### PR DESCRIPTION
Build ccan as a static library, which gets linked to `libnvme.so`.

NOTE: since ccan depends on `config.h`, I moved the generation of `config.h` 
to the top-level `meson.build` file. It actually makes more sense to generate
`config.h` in the top-level `meson.build` file since all `subdir` projects depend 
on that file.

Refer to the discussion on pull request: https://github.com/linux-nvme/libnvme/pull/179

Signed-off-by: Martin Belanger <martin.belanger@dell.com>