### PR TITLE
src: Use PRIu64 format specifier for uint64 types

### DIFF
--- a/examples/display-columnar.c
+++ b/examples/display-columnar.c
@@ -11,6 +11,7 @@
  * column format for easy visual scanning.
  */
 #include <stdio.h>
+#include <inttypes.h>
 #include <libnvme.h>
 
 static const char dash[101] = {[0 ... 99] = '-'};
@@ -90,7 +91,7 @@ int main()
 		nvme_for_each_subsystem(h, s) {
 			nvme_subsystem_for_each_ctrl(s, c) {
 				nvme_ctrl_for_each_ns(c, n)
-					printf("%-12s %-8d %-16lu %-8d %s\n",
+					printf("%-12s %-8d %-16" PRIu64 " %-8d %s\n",
 					       nvme_ns_get_name(n),
 					       nvme_ns_get_nsid(n),
 					       nvme_ns_get_lba_count(n),
@@ -101,7 +102,7 @@ int main()
 			nvme_subsystem_for_each_ns(s, n) {
 				bool first = true;
 
-				printf("%-12s %-8d %-16lu %-8d ",
+				printf("%-12s %-8d %-16" PRIu64 " %-8d ",
 				       nvme_ns_get_name(n),
 				       nvme_ns_get_nsid(n),
 				       nvme_ns_get_lba_count(n),

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <inttypes.h>
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -778,7 +779,7 @@ int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 		}
 
 		genctr = le64_to_cpu(log->genctr);
-		nvme_msg(LOG_DEBUG, "%s: discover genctr %lu, retry\n",
+		nvme_msg(LOG_DEBUG, "%s: discover genctr %" PRIu64 ", retry\n",
 			 name, genctr);
 		ret = nvme_discovery_log(nvme_ctrl_get_fd(c), hdr, log, true);
 		if (ret) {
@@ -795,7 +796,7 @@ int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 		errno = EAGAIN;
 		ret = -1;
 	} else if (numrec != le64_to_cpu(log->numrec)) {
-		nvme_msg(LOG_INFO, "%s: could only fetch %lu of %lu records\n",
+		nvme_msg(LOG_INFO, "%s: could only fetch %" PRIu64 " of %" PRIu64 " records\n",
 			 name, numrec, le64_to_cpu(log->numrec));
 		errno = EBADSLT;
 		ret = -1;

--- a/test/test.c
+++ b/test/test.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #ifdef CONFIG_LIBUUID
 #include <uuid/uuid.h>
 #endif
@@ -274,7 +275,8 @@ static int test_namespace(nvme_ns_t n)
 		return ret;
 
 	nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &flbas);
-	printf("%s: nsze:%lx lba size:%d\n", nvme_ns_get_name(n), le64_to_cpu(ns.nsze),
+	printf("%s: nsze:%" PRIu64 " lba size:%d\n",
+		nvme_ns_get_name(n), le64_to_cpu(ns.nsze),
 		1 << ns.lbaf[flbas].ds);
 
 	ret = nvme_identify_allocated_ns(fd, nsid, &allocated);
@@ -367,7 +369,7 @@ int main(int argc, char **argv)
 					char uuid_str[40];
 					uuid_t uuid;
 #endif
-					printf("   `- %s lba size:%d lba max:%lu\n",
+					printf("   `- %s lba size:%d lba max:%" PRIu64 "\n",
 					       nvme_ns_get_name(n),
 					       nvme_ns_get_lba_size(n),
 					       nvme_ns_get_lba_count(n));
@@ -390,7 +392,7 @@ int main(int argc, char **argv)
 			}
 
 			nvme_subsystem_for_each_ns(s, n) {
-				printf(" `- %s lba size:%d lba max:%lu\n",
+				printf(" `- %s lba size:%d lba max:%" PRIu64 "\n",
 				       nvme_ns_get_name(n),
 				       nvme_ns_get_lba_size(n),
 				       nvme_ns_get_lba_count(n));


### PR DESCRIPTION
When compiling for 32bit architectures the compiler is complaining
about the wrong format specifier for uint64. Use the the PRIu64 format
specifier in this case which is supported from 32bit and 64bit.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #181 