### PR TITLE
POC: Add logging function callback

### DIFF
--- a/src/libnvme.h
+++ b/src/libnvme.h
@@ -21,7 +21,6 @@ extern "C" {
 #include "nvme/filters.h"
 #include "nvme/tree.h"
 #include "nvme/util.h"
-#include "nvme/log.h"
 
 #ifdef __cplusplus
 }

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,7 +1,5 @@
 LIBNVME_1_0 {
 	global:
-		__nvme_get_log_page;
-		__nvme_msg;
 		nvme_admin_passthru64;
 		nvme_admin_passthru;
 		nvme_attach_ns;

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -161,7 +161,7 @@ void json_read_config(nvme_root_t r, const char *config_file)
 
 	json_root = json_object_from_file(config_file);
 	if (!json_root) {
-		nvme_msg(LOG_DEBUG, "Failed to read %s, %s\n",
+		nvme_msg_n(r, LOG_DEBUG, "Failed to read %s, %s\n",
 			config_file, json_util_get_last_err());
 		return;
 	}
@@ -292,7 +292,7 @@ int json_update_config(nvme_root_t r, const char *config_file)
 		ret = json_object_to_file_ext(config_file, json_root,
 					      JSON_C_TO_STRING_PRETTY);
 	if (ret < 0) {
-		nvme_msg(LOG_ERR, "Failed to write to %s, %s\n",
+		nvme_msg_n(r, LOG_ERR, "Failed to write to %s, %s\n",
 			 config_file ? "stdout" : config_file,
 			 json_util_get_last_err());
 		ret = -1;

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -8,6 +8,8 @@
 #include <stdbool.h>
 #include <syslog.h>
 
+#include "private.h"	// This cannot be here, need to use opaque type ...
+
 #ifndef MAX_LOGLEVEL
 #  define MAX_LOGLEVEL LOG_DEBUG
 #endif
@@ -36,4 +38,16 @@ __nvme_msg(int lvl, const char *func, const char *format, ...);
 				   format, ##__VA_ARGS__);		\
 	} while (0)
 
+
+#define nvme_msg_n(root_ctx, lvl, format, ...)					\
+	do {									\
+		if ((lvl) <= MAX_LOGLEVEL) {					\
+			if (root_ctx && root_ctx->log_fn)			\
+			    root_ctx->log_fn(lvl, __nvme_log_func,		\
+					format, ##__VA_ARGS__);			\
+			else							\
+			    __nvme_msg(lvl, __nvme_log_func,			\
+				   format, ##__VA_ARGS__);			\
+		}								\
+	} while (0)
 #endif /* _LOG_H */

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -121,6 +121,7 @@ struct nvme_root {
 	char *config_file;
 	struct list_head hosts;
 	bool modified;
+	void (*log_fn)(int lvl, const char *func, const char *format, ...);
 };
 
 int nvme_set_attr(const char *dir, const char *attr, const char *value);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -89,6 +89,10 @@ nvme_root_t nvme_host_get_root(nvme_host_t h);
 nvme_host_t nvme_lookup_host(nvme_root_t r, const char *hostnqn,
 			     const char *hostid);
 
+void nvme_set_log_fn(nvme_root_t r,
+	void (*log_fn)(int lvl, const char *func,
+		const char *format, ...));
+
 /**
  * nvme_host_get_hostnqn() -
  * @h:


### PR DESCRIPTION
I spent some time today exploring if have a call back function which was embedded in the `nvme_root_t` to prevent global data would be possible.  This is rough, and incomplete, and not even run once for testing.

I created a macro `nvme_msg_n` which takes an additional argument which is the `nvme_root_t` pointer.  In some cases its use is pretty clean:

```c
nvme_msg_n(r, LOG_ERR, "Failed to write to %s, %s\n", ...
```

In other cases, kind of ugly and I'm not even sure if all the embedded pointers are correctly setup for the context.

```c
nvme_msg_n(c->s->h->r, LOG_ERR, "failed to resolve host %s info\n", c->traddr);
```

In some other cases we have nothing existing to get a handle to the `nvme_root_t`, so I added an argument to the function.  In other cases I just removed the logging and returned an error code.

At the moment I'm not sure how to make this cleaner.  Thoughts, suggestions?

