### PR TITLE
Display failed namespaces

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -70,9 +70,14 @@ int nvme_ns_rescan(int fd)
 
 int nvme_get_nsid(int fd, __u32 *nsid)
 {
+	int __nsid;
+
 	errno = 0;
-	*nsid = ioctl(fd, NVME_IOCTL_ID);
-	return -1 * (errno != 0);
+	__nsid = ioctl(fd, NVME_IOCTL_ID);
+	if (__nsid < 0)
+		return -errno;
+	*nsid = __nsid;
+	return 0;
 }
 
 static int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,


### PR DESCRIPTION
When a namespace is reconnecting or otherwise failed we cannot do I/O, and so the namespace initialization will fail. This patch adds a fallback to read (some) information from sysfs such that we still can display the namespace eg in 'nvme list'.