### PR TITLE
fabrics: add fabrics config option 'tls'

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -140,6 +140,11 @@
 		    "type": "boolean",
 		    "default": false
 		},
+		"tls": {
+		    "description": "Enable TLS encryption",
+		    "type": "boolean",
+		    "default": false
+		},
 		"persistent": {
 		    "description": "Create persistent discovery connection",
 		    "type": "boolean"

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -187,6 +187,7 @@ static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, disable_sqflow, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, data_digest, false);
+	UPDATE_CFG_OPTION(ctrl_cfg, cfg, tls, false);
 
 	return ctrl_cfg;
 }
@@ -495,7 +496,9 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 	    (!strcmp(transport, "tcp") &&
 	     add_bool_argument(argstr, "hdr_digest", cfg->hdr_digest)) ||
 	    (!strcmp(transport, "tcp") &&
-	     add_bool_argument(argstr, "data_digest", cfg->data_digest))) {
+	     add_bool_argument(argstr, "data_digest", cfg->data_digest)) ||
+	    (!strcmp(transport, "tcp") &&
+	     add_bool_argument(argstr, "tls", cfg->tls))) {
 		free(*argstr);
 		return -1;
 	}
@@ -707,6 +710,11 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 
 	if (e->treq & NVMF_TREQ_DISABLE_SQFLOW)
 		disable_sqflow = true;
+
+	if (e->trtype == NVMF_TRTYPE_TCP &&
+	    (e->treq & NVMF_TREQ_REQUIRED ||
+	     e->treq & NVMF_TREQ_NOT_REQUIRED))
+		c->cfg.tls = true;
 
 	ret = nvmf_add_ctrl(h, c, cfg, disable_sqflow);
 	if (!ret)

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -33,6 +33,7 @@
  * @disable_sqflow:	Disable controller sq flow control
  * @hdr_digest:		Generate/verify header digest (TCP)
  * @data_digest:	Generate/verify data digest (TCP)
+ * @tls:		Start TLS on the connection (TCP)
  */
 struct nvme_fabrics_config {
 	char *host_traddr;
@@ -51,6 +52,7 @@ struct nvme_fabrics_config {
 	bool disable_sqflow;
 	bool hdr_digest;
 	bool data_digest;
+	bool tls;
 };
 
 /**

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -62,6 +62,8 @@ static void json_update_attributes(nvme_ctrl_t c,
 					hdr_digest, val_obj);
 		JSON_UPDATE_BOOL_OPTION(cfg, key_str,
 					data_digest, val_obj);
+		JSON_UPDATE_BOOL_OPTION(cfg, key_str,
+					tls, val_obj);
 		if (!strcmp("persistent", key_str) &&
 		    !nvme_ctrl_is_persistent(c))
 			nvme_ctrl_set_persistent(c, true);
@@ -220,6 +222,7 @@ static void json_update_port(struct json_object *ctrl_array, nvme_ctrl_t c)
 	JSON_BOOL_OPTION(cfg, port_obj, disable_sqflow);
 	JSON_BOOL_OPTION(cfg, port_obj, hdr_digest);
 	JSON_BOOL_OPTION(cfg, port_obj, data_digest);
+	JSON_BOOL_OPTION(cfg, port_obj, tls);
 	if (nvme_ctrl_is_persistent(c))
 		json_object_add_value_bool(port_obj, "persistent", true);
 	if (nvme_ctrl_is_discovery_ctrl(c))


### PR DESCRIPTION
Add an option 'tls' to the fabrics config to start TLS encryption
on the connection.

Signed-off-by: Hannes Reinecke <hare@suse.de>