### PR TITLE
fabrics: kill 'disable_sqflow' argument to nvmf_add_ctrl()

### DIFF
--- a/examples/discover-loop.c
+++ b/examples/discover-loop.c
@@ -69,7 +69,7 @@ int main()
 		fprintf(stderr, "Failed to allocate memory\n");
 		return ENOMEM;
 	}
-	ret = nvmf_add_ctrl(h, c, &cfg, false);
+	ret = nvmf_add_ctrl(h, c, &cfg);
 	if (ret < 0) {
 		fprintf(stderr, "no controller found\n");
 		return errno;

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -535,7 +535,7 @@ struct nvme_ns {
       connect_err = 1;
       return;
     }
-    ret = nvmf_add_ctrl(h, $self, cfg, cfg->disable_sqflow);
+    ret = nvmf_add_ctrl(h, $self, cfg);
     if (ret < 0) {
       connect_err = 2;
       return;

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -160,17 +160,19 @@ void nvmf_default_config(struct nvme_fabrics_config *cfg);
 int nvmf_add_ctrl_opts(nvme_ctrl_t c, struct nvme_fabrics_config *cfg);
 
 /**
- * nvmf_add_ctrl() -
- * @h:
- * @c:
- * @cfg:
- * @disable_sqflow:
+ * nvmf_add_ctrl() - Connect a controller and update topology
+ * @h: Host to which the controller should be attached
+ * @c: Controller to be connected
+ * @cfg: Default configuration for the controller
  *
- * Return:
+ * Issues a 'connect' command to the NVMe-oF controller and inserts @c
+ * into the topology using @h as parent.
+ * @c must be initialized and not connected to the topology.
+ *
+ * Return: 0 on success; on failure errno is set and -1 is returned.
  */
 int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
-		  const struct nvme_fabrics_config *cfg,
-		  bool disable_sqflow);
+		  const struct nvme_fabrics_config *cfg);
 
 /**
  * nvmf_get_discovery_log() -

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -749,13 +749,6 @@ void nvme_ctrl_set_dhchap_key(nvme_ctrl_t c, const char *key)
 		c->dhchap_key = strdup(key);
 }
 
-void nvme_ctrl_disable_sqflow(nvme_ctrl_t c, bool disable_sqflow)
-{
-	c->cfg.disable_sqflow = disable_sqflow;
-	if (c->s && c->s->h && c->s->h->r)
-		c->s->h->r->modified = true;
-}
-
 void nvme_ctrl_set_discovered(nvme_ctrl_t c, bool discovered)
 {
 	c->discovered = discovered;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -874,15 +874,6 @@ void nvme_ctrl_set_discovery_ctrl(nvme_ctrl_t c, bool discovery);
 bool nvme_ctrl_is_discovery_ctrl(nvme_ctrl_t c);
 
 /**
- * nvme_ctrl_disable_sqflow() -
- * @c:
- * @disable_sqflow:
- *
- * Return:
- */
-void nvme_ctrl_disable_sqflow(nvme_ctrl_t c, bool disable_sqflow);
-
-/**
  * nvme_ctrl_identify() -
  * @c:
  * @id:


### PR DESCRIPTION
The 'disable_sqflow' argument to nvmf_add_ctrl() is pointless, as
'struct fabrics_config' is exported and the caller can set it
directly there, without having to involve library functions at all.
And consequently we can also remove nvme_ctrl_disable_sqflow().

Signed-off-by: Hannes Reinecke <hare@suse.de>