### PR TITLE
TP8010 support

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -25,6 +25,10 @@
 		    "description": "NVMe host ID",
 		    "type": "string"
 		},
+		"hostsymname": {
+		    "description": "NVMe host symbolic name",
+		    "type": "string"
+		},
 		"required": [ "hostnqn" ],
 		"subsystems": {
 		    "description": "Array of NVMe subsystem properties",
@@ -151,6 +155,10 @@
 		},
 		"discovery": {
 		    "description": "Connect to a discovery controller",
+		    "type": "boolean"
+		},
+		"register": {
+		    "description": "Perform explicit registration with discovery controller",
 		    "type": "boolean"
 		}
 	    },

--- a/doc/man/nvmf_add_ctrl.2
+++ b/doc/man/nvmf_add_ctrl.2
@@ -1,9 +1,0 @@
-.TH "nvmf_add_ctrl" 2 "nvmf_add_ctrl" "February 2020" "libnvme Manual"
-.SH NAME
-nvmf_add_ctrl \- 
-.SH SYNOPSIS
-.B "nvme_ctrl_t" nvmf_add_ctrl
-.BI "(struct nvme_fabrics_config *" cfg ");"
-.SH ARGUMENTS
-.IP "cfg" 12
--- undescribed --

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -310,6 +310,7 @@ struct nvme_ctrl {
   %immutable sqsize;
   %immutable persistent;
   %immutable discovery_ctrl;
+  %immutable explicit_registration;
   char *transport;
   char *subsysnqn;
   char *traddr;
@@ -324,6 +325,7 @@ struct nvme_ctrl {
   char *sqsize;
   bool persistent;
   bool discovery_ctrl;
+  bool explicit_registration;
 };
 
 struct nvme_ns {
@@ -516,6 +518,10 @@ struct nvme_ns {
   }
   ~nvme_ctrl() {
     nvme_free_ctrl($self);
+  }
+
+  void explicit_registration_set(bool explicit_registration) {
+      nvme_ctrl_set_explicit_registration($self, explicit_registration);
   }
 
   void discovery_ctrl_set(bool discovery) {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -34,11 +34,13 @@ LIBNVME_1_0 {
 		nvme_ctrl_get_trsvcid;
 		nvme_ctrl_identify;
 		nvme_ctrl_is_discovery_ctrl;
+		nvme_ctrl_is_explicit_registration;
 		nvme_ctrl_next_ns;
 		nvme_ctrl_next_path;
 		nvme_ctrl_reset;
 		nvme_ctrl_set_dhchap_key;
 		nvme_ctrl_set_discovery_ctrl;
+		nvme_ctrl_set_explicit_registration;
 		nvme_ctrl_set_persistent;
 		nvme_ctrls_filter;
 		nvme_default_host;
@@ -146,7 +148,9 @@ LIBNVME_1_0 {
 		nvme_host_get_hostid;
 		nvme_host_get_hostnqn;
 		nvme_host_get_root;
+		nvme_host_get_symname;
 		nvme_host_set_dhchap_key;
+		nvme_host_set_symname;
 		nvme_identify;
 		nvme_identify_active_ns_list;
 		nvme_identify_allocated_ns;

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -212,6 +212,16 @@ char *nvmf_hostnqn_from_file();
 char *nvmf_hostid_from_file();
 
 /**
+ * nvmf_hostsymname_from_file() - Read the host symbolic name from the
+ * config default location in /etc/nvme.
+ *
+ * Return: The symbolic name or NULL if no symbolic name has been
+ * configured. The caller is responsible fro freeing the memory allocated
+ * by this function (if any).
+ */
+char * nvmf_hostsymname_from_file();
+
+/**
  * nvmf_connect_disc_entry() - Connect controller based on the discovery log page entry
  * @h: Host to which the controller should be connected
  * @e: Discovery log page entry

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -89,6 +89,7 @@ struct nvme_ctrl {
 	bool discovery_ctrl;
 	bool discovered;
 	bool persistent;
+	bool explicit_registration;
 	struct nvme_fabrics_config cfg;
 };
 
@@ -115,6 +116,7 @@ struct nvme_host {
 	char *hostnqn;
 	char *hostid;
 	char *dhchap_key;
+	char *symname;
 };
 
 struct nvme_root {

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -874,6 +874,41 @@ void nvme_ctrl_set_discovery_ctrl(nvme_ctrl_t c, bool discovery);
 bool nvme_ctrl_is_discovery_ctrl(nvme_ctrl_t c);
 
 /**
+ * nvme_ctrl_set_explicit_registration() - Set the 'explicit_registration'
+ * flag
+ *
+ * @c: Controller to be modified
+ * @explicit_registration: value of the explicit_registration flag
+ *
+ * Sets the 'explicit_registration' flag in @c to specify whether
+ * @c should perform explicit registration (DIM PDU) when it connects to a
+ *    discovery controller.
+ *
+ */
+void nvme_ctrl_set_explicit_registration(nvme_ctrl_t c, bool explicit_registration);
+
+/**
+ * nvme_ctrl_is_explicit_registration() - Check the 'explicit_registration'
+ * flag
+ *
+ * @c: Controller to be checked
+ *
+ * Returns the value of the 'explicit_registration' flag which specifies
+ * whether performs explicit registration (DIM PDU) when connecting to a
+ * discovery controller.
+ */
+bool nvme_ctrl_is_explicit_registration(nvme_ctrl_t c);
+
+/**
+ * nvme_ctrl_disable_sqflow() -
+ * @c:
+ * @disable_sqflow:
+ *
+ * Return:
+ */
+void nvme_ctrl_disable_sqflow(nvme_ctrl_t c, bool disable_sqflow);
+
+/**
  * nvme_ctrl_identify() -
  * @c:
  * @id:
@@ -997,6 +1032,25 @@ nvme_host_t nvme_default_host(nvme_root_t r);
  * @r:
  */
 void nvme_free_host(nvme_host_t h);
+
+/**
+ * nvme_host_get_symname() - Get the host's symbolic name
+ *
+ * @h: Host for which the symbolic name should be returned.
+ *
+ * Return: The symbolic name or NULL if a symbolic name hasn't been
+ * configure.
+ */
+const char *nvme_host_get_symname(nvme_host_t h);
+
+/**
+ * nvme_host_set_symname() - Set the host's symbolic name
+ *
+ * @h: Host for which the symbolic name should be set.
+ * @symname: Symbolic name
+ * @steal: Whether @h can steal the reference to symname.
+ */
+void nvme_host_set_symname(nvme_host_t h, const char *symname, bool steal);
 
 /**
  * nvme_scan() -

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -689,6 +689,12 @@ struct nvme_id_psd {
 	__u8			rsvd23[9];
 };
 
+enum nvme_dctype {
+	NVME_DCTYPE_NOT_REPORTED = 0,
+	NVME_DCTYPE_DDC = 1,
+	NVME_DCTYPE_CDC = 2,
+};
+
 /**
  * struct nvme_id_ctrl - Identify Controller data structure
  * @vid:       PCI Vendor ID, the company vendor identifier that is assigned by
@@ -887,6 +893,9 @@ struct nvme_id_psd {
  * 	       that a host is allowed to place in a capsule. A value of 0h
  * 	       indicates no limit.
  * @ofcs:      Optional Fabric Commands Support, see &enum nvme_id_ctrl_ofcs.
+ * @dctype:    Discovery Controller Type (DCTYPE). This field indicates what
+ *             type of Discovery controller the controller is (see enum
+ *             nvme_dctype)
  * @psd:       Power State Descriptors, see &struct nvme_id_psd.
  * @vs:	       Vendor Specific
  */
@@ -984,7 +993,8 @@ struct nvme_id_ctrl {
 	__u8			fcatt;
 	__u8			msdbd;
 	__le16			ofcs;
-	__u8			rsvd1806[242];
+	__u8			dctype;
+	__u8			rsvd1807[241];
 
 	struct nvme_id_psd	psd[32];
 	__u8			vs[1024];
@@ -5163,6 +5173,14 @@ enum nvme_status_field {
 	NVME_SC_INVALID_IOCS			= 0x2c,
 	NVME_SC_ID_UNAVAILABLE			= 0x2d,
 
+	NVME_SC_NS_DISPERSED			= 0x2e,
+	NVME_SC_INVALID_DISCOVERY_INFO		= 0x2f,
+	NVME_SC_ZONING_DATA_STRUCT_LOCKED	= 0x30,
+	NVME_SC_ZONING_DATA_STRUCT_NOT_FOUND	= 0x31,
+	NVME_SC_INSUFFICIENT_DISC_RESOURCES	= 0x32,
+	NVME_SC_REQUESTED_FUNCTION_DISABLED	= 0x33,
+	NVME_SC_ZONEGRP_ORIGINATOR_INVALID	= 0x34,
+
 	/*
 	 * I/O Command Set Specific - NVM commands:
 	 */
@@ -5316,6 +5334,7 @@ enum nvme_admin_opcode {
 	nvme_admin_security_recv	= 0x82,
 	nvme_admin_sanitize_nvm		= 0x84,
 	nvme_admin_get_lba_status	= 0x86,
+	nvme_admin_discovery_info_mgmt	= 0x21,
 };
 
 /**


### PR DESCRIPTION
TP8010 defines the Central Discovery Controller (CDC). To tell a CDC apart from a DDC (Direct Discovery Controller), the Identify response now carries a Discovery Controller Type (dctype) attribute.

TP8010 also defines a new Discovery Information Management (DIM) PDU which is used to perform explicit registration with CDCs and DDCs. This new PDU carries extra information such as the Entity Name (ENAME), the Entity Version (EVER), the Symbolic Name, etc.

This adds support for TP8010 as follows:
- Add the dctype to struct nvme_id_ctrl
- Add the "register" argument - This is used to tell the kernel that the user wants to perform explicit registration using the DIM PDU. Without this, the driver will operate as it did before.
- Add the "hostsymname" argument - This is used to specify an optional Symbolic Name. The Symbolic name is configured with the file `"/etc/nvme/hostsymname"`.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>