### PR TITLE
meson: libnvme build as static lib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ project(
         'warning_level=1',
         'buildtype=release',
         'prefix=/usr',
+        'default_library=static',
     ]
 )
 


### PR DESCRIPTION
libnvme usually wrapped with commit hash (eg nvme-cli)
since they might updated at the same time when new spec comes in
it could be override via meson .build --default-library=shared

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>