### PR TITLE
Redirect error messages

### DIFF
--- a/doc/libnvme.rst
+++ b/doc/libnvme.rst
@@ -5840,14 +5840,6 @@ The nvme command status if a response was received (see
 ``nvme_subsystem_t s``
 
 
-.. c:function:: nvme_root_t nvme_scan_filter (nvme_scan_filter_t f)
-
-
-**Parameters**
-
-``nvme_scan_filter_t f``
-
-
 .. c:function:: nvme_root_t nvme_scan ()
 
 

--- a/doc/man/nvme_scan_filter.2
+++ b/doc/man/nvme_scan_filter.2
@@ -1,8 +1,0 @@
-.TH "nvme_scan_filter" 2 "nvme_scan_filter" "February 2020" "libnvme Manual"
-.SH NAME
-nvme_scan_filter \- 
-.SH SYNOPSIS
-.B "nvme_root_t" nvme_scan_filter
-.BI "(nvme_scan_filter_t " f ");"
-.SH ARGUMENTS
-.IP "f" 12

--- a/examples/discover-loop.c
+++ b/examples/discover-loop.c
@@ -63,7 +63,7 @@ int main()
 		fprintf(stderr, "Failed to allocated memory\n");
 		return ENOMEM;
 	}
-	c = nvme_create_ctrl(NVME_DISC_SUBSYS_NAME, "loop",
+	c = nvme_create_ctrl(r, NVME_DISC_SUBSYS_NAME, "loop",
 			     NULL, NULL, NULL, NULL);
 	if (!c) {
 		fprintf(stderr, "Failed to allocate memory\n");

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -508,10 +508,10 @@ struct nvme_ns {
 }
 
 %extend nvme_ctrl {
-  nvme_ctrl(const char *subsysnqn, const char *transport,
+  nvme_ctrl(nvme_root_t r, const char *subsysnqn, const char *transport,
 	    const char *traddr = NULL, const char *host_traddr = NULL,
 	    const char *host_iface = NULL, const char *trsvcid = NULL) {
-    return nvme_create_ctrl(subsysnqn, transport, traddr,
+    return nvme_create_ctrl(r, subsysnqn, transport, traddr,
 			    host_traddr, host_iface, trsvcid);
   }
   ~nvme_ctrl() {

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -509,7 +509,7 @@ struct nvme_ns {
 }
 
 %extend nvme_ctrl {
-  nvme_ctrl(nvme_root_t r, const char *subsysnqn, const char *transport,
+  nvme_ctrl(struct nvme_root *r, const char *subsysnqn, const char *transport,
 	    const char *traddr = NULL, const char *host_traddr = NULL,
 	    const char *host_iface = NULL, const char *trsvcid = NULL) {
     return nvme_create_ctrl(r, subsysnqn, transport, traddr,

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -339,29 +339,30 @@ struct nvme_ns {
 
 %extend nvme_root {
   nvme_root(const char *config_file = NULL) {
-    nvme_log_level = LOG_ERR;
     return nvme_scan(config_file);
   }
   ~nvme_root() {
     nvme_free_tree($self);
   }
   void log_level(const char *level) {
+    int log_level = DEFAULT_LOGLEVEL;
     if (!strcmp(level,"debug"))
-      nvme_log_level = LOG_DEBUG;
+      log_level = LOG_DEBUG;
     else if (!strcmp(level, "info"))
-      nvme_log_level = LOG_INFO;
+      log_level = LOG_INFO;
     else if (!strcmp(level, "notice"))
-      nvme_log_level = LOG_NOTICE;
+      log_level = LOG_NOTICE;
     else if (!strcmp(level, "warning"))
-      nvme_log_level = LOG_WARNING;
+      log_level = LOG_WARNING;
     else if (!strcmp(level, "err"))
-      nvme_log_level = LOG_ERR;
+      log_level = LOG_ERR;
     else if (!strcmp(level, "crit"))
-      nvme_log_level = LOG_CRIT;
+      log_level = LOG_CRIT;
     else if (!strcmp(level, "alert"))
-      nvme_log_level = LOG_ALERT;
+      log_level = LOG_ALERT;
     else if (!strcmp(level, "emerg"))
-      nvme_log_level = LOG_EMERG;
+      log_level = LOG_EMERG;
+    nvme_init_logging($self, log_level, false, false);
   }
   struct nvme_host *hosts() {
     return nvme_first_host($self);

--- a/libnvme/tests/create-ctrl-obj.py
+++ b/libnvme/tests/create-ctrl-obj.py
@@ -11,4 +11,4 @@ subsysnqn = nvme.NVME_DISC_SUBSYS_NAME
 transport = 'loop'
 traddr    = '127.0.0.1'
 trsvcid   = '8009'
-ctrl = nvme.ctrl(subsysnqn=subsysnqn, transport=transport, traddr=traddr, trsvcid=trsvcid)
+ctrl = nvme.ctrl(root, subsysnqn=subsysnqn, transport=transport, traddr=traddr, trsvcid=trsvcid)

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -8,6 +8,7 @@ LIBNVME_1_0 {
 		nvme_capacity_mgmt;
 		nvme_compare;
 		nvme_copy;
+		nvme_create_root;
 		nvme_create_ctrl;
 		nvme_ctrl_disconnect;
 		nvme_ctrl_first_ns;
@@ -241,7 +242,7 @@ LIBNVME_1_0 {
 		nvme_scan_ctrl;
 		nvme_scan_ctrl_namespace_paths;
 		nvme_scan_ctrl_namespaces;
-		nvme_scan_filter;
+		nvme_scan_topology;
 		nvme_scan_namespace;
 		nvme_scan_subsystem_namespaces;
 		nvme_scan_subsystems;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -169,12 +169,12 @@ LIBNVME_1_0 {
 		nvme_init_ctrl;
 		nvme_init_ctrl_list;
 		nvme_init_dsm_range;
+		nvme_init_logging;
 		nvme_init_id_ns;
 		nvme_io;
 		nvme_io_passthru64;
 		nvme_io_passthru;
 		nvme_lockdown;
-		nvme_log_level;
 		nvme_lookup_host;
 		nvme_lookup_subsystem;
 		nvme_namespace_attach_ctrls;
@@ -227,6 +227,7 @@ LIBNVME_1_0 {
 		nvme_path_get_sysfs_dir;
 		nvme_paths_filter;
 		nvme_read;
+		nvme_read_config;
 		nvme_refresh_topology;
 		nvme_rescan_ctrl;
 		nvme_reset_topology;

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -163,7 +163,7 @@ void json_read_config(nvme_root_t r, const char *config_file)
 
 	json_root = json_object_from_file(config_file);
 	if (!json_root) {
-		nvme_msg(LOG_DEBUG, "Failed to read %s, %s\n",
+		nvme_msg(r, LOG_DEBUG, "Failed to read %s, %s\n",
 			config_file, json_util_get_last_err());
 		return;
 	}
@@ -295,7 +295,7 @@ int json_update_config(nvme_root_t r, const char *config_file)
 		ret = json_object_to_file_ext(config_file, json_root,
 					      JSON_C_TO_STRING_PRETTY);
 	if (ret < 0) {
-		nvme_msg(LOG_ERR, "Failed to write to %s, %s\n",
+		nvme_msg(r, LOG_ERR, "Failed to write to %s, %s\n",
 			 config_file ? "stdout" : config_file,
 			 json_util_get_last_err());
 		ret = -1;

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -25,6 +25,7 @@
 #include <time.h>
 #include <string.h>
 #define LOG_FUNCNAME 1
+#include "private.h"
 #include "log.h"
 #include "cleanup.h"
 
@@ -36,9 +37,11 @@ int nvme_log_level = DEFAULT_LOGLEVEL;
 bool nvme_log_timestamp;
 bool nvme_log_pid;
 
-void __attribute__((format(printf, 3, 4)))
-__nvme_msg(int lvl, const char *func, const char *format, ...)
+void __attribute__((format(printf, 4, 5)))
+__nvme_msg(nvme_root_t r, int lvl,
+	   const char *func, const char *format, ...)
 {
+	FILE *fp = r ? r->fp : stderr;
 	va_list ap;
 	char pidbuf[16];
 	char timebuf[32];
@@ -83,7 +86,7 @@ __nvme_msg(int lvl, const char *func, const char *format, ...)
 	va_end(ap);
 
 	if (lvl <= nvme_log_level)
-		fprintf(stderr, "%s%s", header ? header : "<error>",
+		fprintf(fp, "%s%s", header ? header : "<error>",
 			message ? message : "<error>");
 
 }

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -33,10 +33,6 @@
 #define LOG_CLOCK CLOCK_MONOTONIC
 #endif
 
-int nvme_log_level = DEFAULT_LOGLEVEL;
-bool nvme_log_timestamp;
-bool nvme_log_pid;
-
 void __attribute__((format(printf, 4, 5)))
 __nvme_msg(nvme_root_t r, int lvl,
 	   const char *func, const char *format, ...)
@@ -59,7 +55,7 @@ __nvme_msg(nvme_root_t r, int lvl,
 	char *message __cleanup__(cleanup_charp) = NULL;
 	int idx;
 
-	if (nvme_log_timestamp) {
+	if (r->log_timestamp) {
 		struct timespec now;
 
 		clock_gettime(LOG_CLOCK, &now);
@@ -68,13 +64,13 @@ __nvme_msg(nvme_root_t r, int lvl,
 	} else
 		*timebuf = '\0';
 
-	if (nvme_log_pid)
+	if (r->log_pid)
 		snprintf(pidbuf, sizeof(pidbuf), "%ld", (long)getpid());
 	else
 		*pidbuf = '\0';
 
-	idx = ((nvme_log_timestamp ? 1 : 0) << 2) |
-		((nvme_log_pid ? 1 : 0) << 1) | (func ? 1 : 0);
+	idx = ((r->log_timestamp ? 1 : 0) << 2) |
+		((r->log_pid ? 1 : 0) << 1) | (func ? 1 : 0);
 
 	if (asprintf(&header, formats[idx], timebuf, pidbuf, func ? func : "")
 	    == -1)
@@ -85,8 +81,15 @@ __nvme_msg(nvme_root_t r, int lvl,
 		message = NULL;
 	va_end(ap);
 
-	if (lvl <= nvme_log_level)
+	if (lvl <= r->log_level)
 		fprintf(fp, "%s%s", header ? header : "<error>",
 			message ? message : "<error>");
 
+}
+
+void nvme_init_logging(nvme_root_t r, int lvl, bool log_pid, bool log_tstamp)
+{
+	r->log_level = lvl;
+	r->log_pid = log_pid;
+	r->log_timestamp = log_tstamp;
 }

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -21,8 +21,6 @@
 #define __nvme_log_func NULL
 #endif
 
-extern char *nvme_log_message;
-
 void __attribute__((format(printf, 4, 5)))
 __nvme_msg(nvme_root_t r, int lvl, const char *func, const char *format, ...);
 

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -26,13 +26,13 @@ extern bool nvme_log_timestamp;
 extern bool nvme_log_pid;
 extern char *nvme_log_message;
 
-void __attribute__((format(printf, 3, 4)))
-__nvme_msg(int lvl, const char *func, const char *format, ...);
+void __attribute__((format(printf, 4, 5)))
+__nvme_msg(nvme_root_t r, int lvl, const char *func, const char *format, ...);
 
-#define nvme_msg(lvl, format, ...)					\
+#define nvme_msg(r, lvl, format, ...)					\
 	do {								\
 		if ((lvl) <= MAX_LOGLEVEL)				\
-			__nvme_msg(lvl, __nvme_log_func,		\
+			__nvme_msg(r, lvl, __nvme_log_func,		\
 				   format, ##__VA_ARGS__);		\
 	} while (0)
 

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -21,9 +21,6 @@
 #define __nvme_log_func NULL
 #endif
 
-extern int nvme_log_level;
-extern bool nvme_log_timestamp;
-extern bool nvme_log_pid;
 extern char *nvme_log_message;
 
 void __attribute__((format(printf, 4, 5)))
@@ -35,5 +32,16 @@ __nvme_msg(nvme_root_t r, int lvl, const char *func, const char *format, ...);
 			__nvme_msg(r, lvl, __nvme_log_func,		\
 				   format, ##__VA_ARGS__);		\
 	} while (0)
+
+/**
+ * nvme_init_logging() - initialize logging
+ * @r: nvme_root_t context
+ * @lvl: logging level to set
+ * @log_pid: boolean to enable logging of the PID
+ * @log_tstamp: boolean to enable logging of the timestamp
+ *
+ * Sets the default logging variables for the library.
+ */
+void nvme_init_logging(nvme_root_t r, int lvl, bool log_pid, bool log_tstamp);
 
 #endif /* _LOG_H */

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -120,6 +120,7 @@ struct nvme_host {
 struct nvme_root {
 	char *config_file;
 	struct list_head hosts;
+	FILE *fp;
 	bool modified;
 };
 

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -121,6 +121,9 @@ struct nvme_root {
 	char *config_file;
 	struct list_head hosts;
 	FILE *fp;
+	int log_level;
+	bool log_pid;
+	bool log_timestamp;
 	bool modified;
 };
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -71,10 +71,13 @@ nvme_host_t nvme_default_host(nvme_root_t r)
 	return h;
 }
 
-static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
+int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 {
 	struct dirent **subsys, **ctrls;
 	int i, num_subsys, num_ctrls, ret;
+
+	if (!r)
+		return 0;
 
 	num_ctrls = nvme_scan_ctrls(&ctrls);
 	if (num_ctrls < 0) {
@@ -118,7 +121,7 @@ static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 	return 0;
 }
 
-nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp, int log_level)
+nvme_root_t nvme_create_root(FILE *fp, int log_level)
 {
 	struct nvme_root *r = calloc(1, sizeof(*r));
 
@@ -131,7 +134,6 @@ nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp, int log_level)
 	if (fp)
 		r->fp = fp;
 	list_head_init(&r->hosts);
-	nvme_scan_topology(r, f);
 	return r;
 }
 
@@ -147,10 +149,10 @@ void nvme_read_config(nvme_root_t r, const char *config_file)
 
 nvme_root_t nvme_scan(const char *config_file)
 {
-	nvme_root_t r = nvme_scan_filter(NULL, NULL, DEFAULT_LOGLEVEL);
+	nvme_root_t r = nvme_create_root(NULL, DEFAULT_LOGLEVEL);
 
+	nvme_scan_topology(r, NULL);
 	nvme_read_config(r, config_file);
-
 	return r;
 }
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -38,10 +38,12 @@ static struct nvme_host *default_host;
 
 static void __nvme_free_host(nvme_host_t h);
 static void __nvme_free_ctrl(nvme_ctrl_t c);
-static int nvme_subsystem_scan_namespace(struct nvme_subsystem *s, char *name);
-static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
+static int nvme_subsystem_scan_namespace(nvme_root_t r,
+					 struct nvme_subsystem *s, char *name);
+static int nvme_scan_subsystem(nvme_root_t r, const char *name,
 			       nvme_scan_filter_t f);
-static int nvme_ctrl_scan_namespace(struct nvme_ctrl *c, char *name);
+static int nvme_ctrl_scan_namespace(nvme_root_t r, struct nvme_ctrl *c,
+				    char *name);
 static int nvme_ctrl_scan_path(struct nvme_ctrl *c, char *name);
 
 static inline void nvme_free_dirents(struct dirent **d, int i)
@@ -76,7 +78,7 @@ static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 
 	num_ctrls = nvme_scan_ctrls(&ctrls);
 	if (num_ctrls < 0) {
-		nvme_msg(LOG_DEBUG, "failed to scan ctrls: %s\n",
+		nvme_msg(r, LOG_DEBUG, "failed to scan ctrls: %s\n",
 			 strerror(errno));
 		return num_ctrls;
 	}
@@ -84,7 +86,7 @@ static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 	for (i = 0; i < num_ctrls; i++) {
 		nvme_ctrl_t c = nvme_scan_ctrl(r, ctrls[i]->d_name);
 		if (!c) {
-			nvme_msg(LOG_DEBUG, "failed to scan ctrl %s: %s\n",
+			nvme_msg(r, LOG_DEBUG, "failed to scan ctrl %s: %s\n",
 				 ctrls[i]->d_name, strerror(errno));
 			continue;
 		}
@@ -97,7 +99,7 @@ static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 
 	num_subsys = nvme_scan_subsystems(&subsys);
 	if (num_subsys < 0) {
-		nvme_msg(LOG_DEBUG, "failed to scan subsystems: %s\n",
+		nvme_msg(r, LOG_DEBUG, "failed to scan subsystems: %s\n",
 			 strerror(errno));
 		return num_subsys;
 	}
@@ -105,7 +107,8 @@ static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 	for (i = 0; i < num_subsys; i++) {
 		ret = nvme_scan_subsystem(r, subsys[i]->d_name, f);
 		if (ret < 0) {
-			nvme_msg(LOG_DEBUG, "failed to scan subsystem %s: %s\n",
+			nvme_msg(r, LOG_DEBUG,
+				 "failed to scan subsystem %s: %s\n",
 				 subsys[i]->d_name, strerror(errno));
 		}
 	}
@@ -115,7 +118,7 @@ static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 	return 0;
 }
 
-nvme_root_t nvme_scan_filter(nvme_scan_filter_t f)
+nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp)
 {
 	struct nvme_root *r = calloc(1, sizeof(*r));
 
@@ -123,7 +126,9 @@ nvme_root_t nvme_scan_filter(nvme_scan_filter_t f)
 		errno = ENOMEM;
 		return NULL;
 	}
-
+	r->fp = stderr;
+	if (fp)
+		r->fp = fp;
 	list_head_init(&r->hosts);
 	nvme_scan_topology(r, f);
 	return r;
@@ -131,7 +136,7 @@ nvme_root_t nvme_scan_filter(nvme_scan_filter_t f)
 
 nvme_root_t nvme_scan(const char *config_file)
 {
-	nvme_root_t r = nvme_scan_filter(NULL);
+	nvme_root_t r = nvme_scan_filter(NULL, NULL);
 
 #ifdef CONFIG_JSONC
 	if (r && config_file) {
@@ -415,23 +420,23 @@ struct nvme_host *nvme_lookup_host(nvme_root_t r, const char *hostnqn,
 	return h;
 }
 
-static int nvme_subsystem_scan_namespaces(struct nvme_subsystem *s)
+static int nvme_subsystem_scan_namespaces(nvme_root_t r, nvme_subsystem_t s)
 {
 	struct dirent **namespaces;
 	int i, num_ns, ret;
 
 	num_ns = nvme_scan_subsystem_namespaces(s, &namespaces);
 	if (num_ns < 0) {
-		nvme_msg(LOG_DEBUG,
+		nvme_msg(r, LOG_DEBUG,
 			 "failed to scan namespaces for subsys %s: %s\n",
 			 s->subsysnqn, strerror(errno));
 		return num_ns;
 	}
 
 	for (i = 0; i < num_ns; i++) {
-		ret = nvme_subsystem_scan_namespace(s, namespaces[i]->d_name);
+	  ret = nvme_subsystem_scan_namespace(r, s, namespaces[i]->d_name);
 		if (ret < 0)
-			nvme_msg(LOG_DEBUG,
+			nvme_msg(r, LOG_DEBUG,
 				 "failed to scan namespace %s: %s\n",
 				 namespaces[i]->d_name, strerror(errno));
 	}
@@ -514,7 +519,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
 			goto free_path;
 	}
 
-	nvme_subsystem_scan_namespaces(s);
+	nvme_subsystem_scan_namespaces(r, s);
 
 	if (f && !f(s)) {
 		__nvme_free_subsystem(s);
@@ -630,10 +635,13 @@ free_path:
 
 int nvme_ctrl_get_fd(nvme_ctrl_t c)
 {
+	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
+
 	if (c->fd < 0) {
 		c->fd = nvme_open(c->name);
 		if (c->fd < 0)
-			nvme_msg(LOG_ERR, "Failed to open ctrl %s, errno %d\n",
+			nvme_msg(r, LOG_ERR,
+				 "Failed to open ctrl %s, errno %d\n",
 				 c->name, errno);
 	}
 	return c->fd;
@@ -826,16 +834,17 @@ void nvme_deconfigure_ctrl(nvme_ctrl_t c)
 
 int nvme_disconnect_ctrl(nvme_ctrl_t c)
 {
+	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
 	int ret;
 
 	ret = nvme_set_attr(nvme_ctrl_get_sysfs_dir(c),
 			    "delete_controller", "1");
 	if (ret < 0) {
-		nvme_msg(LOG_ERR, "%s: failed to disconnect, error %d\n",
+		nvme_msg(r, LOG_ERR, "%s: failed to disconnect, error %d\n",
 			 c->name, errno);
 		return ret;
 	}
-	nvme_msg(LOG_INFO, "%s: disconnected\n", c->name);
+	nvme_msg(r, LOG_INFO, "%s: disconnected\n", c->name);
 	nvme_deconfigure_ctrl(c);
 	return 0;
 }
@@ -904,7 +913,8 @@ static bool traddr_is_hostname(const char *transport, const char *traddr)
 	return true;
 }
 
-struct nvme_ctrl *nvme_create_ctrl(const char *subsysnqn, const char *transport,
+struct nvme_ctrl *nvme_create_ctrl(nvme_root_t r,
+				   const char *subsysnqn, const char *transport,
 				   const char *traddr, const char *host_traddr,
 				   const char *host_iface, const char *trsvcid)
 {
@@ -912,18 +922,19 @@ struct nvme_ctrl *nvme_create_ctrl(const char *subsysnqn, const char *transport,
 	bool discovery = false;
 
 	if (!transport) {
-		nvme_msg(LOG_ERR, "No transport specified\n");
+		nvme_msg(r, LOG_ERR, "No transport specified\n");
 		errno = EINVAL;
 		return NULL;
 	}
 	if (strncmp(transport, "loop", 4) &&
 	    strncmp(transport, "pcie", 4) && !traddr) {
-               nvme_msg(LOG_ERR, "No transport address for '%s'\n", transport);
+		nvme_msg(r, LOG_ERR, "No transport address for '%s'\n",
+			 transport);
 	       errno = EINVAL;
 	       return NULL;
 	}
 	if (!subsysnqn) {
-		nvme_msg(LOG_ERR, "No subsystem NQN specified\n");
+		nvme_msg(r, LOG_ERR, "No subsystem NQN specified\n");
 		errno = EINVAL;
 		return NULL;
 	} else if (!strcmp(subsysnqn, NVME_DISC_SUBSYS_NAME))
@@ -944,7 +955,7 @@ struct nvme_ctrl *nvme_create_ctrl(const char *subsysnqn, const char *transport,
 		c->traddr = strdup(traddr);
 	if (host_traddr) {
 		if (traddr_is_hostname(transport, host_traddr))
-			c->cfg.host_traddr = hostname2traddr(host_traddr);
+			c->cfg.host_traddr = hostname2traddr(r, host_traddr);
 		if (!c->cfg.host_traddr)
 			c->cfg.host_traddr = strdup(host_traddr);
 	}
@@ -956,7 +967,7 @@ struct nvme_ctrl *nvme_create_ctrl(const char *subsysnqn, const char *transport,
 		discovery_trsvcid(c);
 	else if (!strncmp(transport, "rdma", 4) ||
 		 !strncmp(transport, "tcp", 3)) {
-		nvme_msg(LOG_ERR, "No trsvcid specified for '%s'\n",
+		nvme_msg(r, LOG_ERR, "No trsvcid specified for '%s'\n",
 			 transport);
 		errno = EINVAL;
 		__nvme_free_ctrl(c);
@@ -970,6 +981,7 @@ struct nvme_ctrl *nvme_lookup_ctrl(struct nvme_subsystem *s, const char *transpo
 				   const char *traddr, const char *host_traddr,
 				   const char *host_iface, const char *trsvcid)
 {
+	nvme_root_t r = s->h ? s->h->r : NULL;
 	struct nvme_ctrl *c;
 
 	if (!s || !transport)
@@ -991,7 +1003,7 @@ struct nvme_ctrl *nvme_lookup_ctrl(struct nvme_subsystem *s, const char *transpo
 			continue;
 		return c;
 	}
-	c = nvme_create_ctrl(s->subsysnqn, transport, traddr,
+	c = nvme_create_ctrl(r, s->subsysnqn, transport, traddr,
 			     host_traddr, host_iface, trsvcid);
 	if (c) {
 		c->s = s;
@@ -1001,7 +1013,7 @@ struct nvme_ctrl *nvme_lookup_ctrl(struct nvme_subsystem *s, const char *transpo
 	return c;
 }
 
-static int nvme_ctrl_scan_paths(struct nvme_ctrl *c)
+static int nvme_ctrl_scan_paths(nvme_root_t r, struct nvme_ctrl *c)
 {
 	struct dirent **paths;
 	int i, ret;
@@ -1017,20 +1029,21 @@ static int nvme_ctrl_scan_paths(struct nvme_ctrl *c)
 	return 0;
 }
 
-static int nvme_ctrl_scan_namespaces(struct nvme_ctrl *c)
+static int nvme_ctrl_scan_namespaces(nvme_root_t r, struct nvme_ctrl *c)
 {
 	struct dirent **namespaces;
 	int i, ret;
 
 	ret = nvme_scan_ctrl_namespaces(c, &namespaces);
 	for (i = 0; i < ret; i++)
-		nvme_ctrl_scan_namespace(c, namespaces[i]->d_name);
+		nvme_ctrl_scan_namespace(r, c, namespaces[i]->d_name);
 
 	nvme_free_dirents(namespaces, i);
 	return 0;
 }
 
-static char *nvme_ctrl_lookup_subsystem_name(const char *ctrl_name)
+static char *nvme_ctrl_lookup_subsystem_name(nvme_root_t r,
+					     const char *ctrl_name)
 {
 	struct dirent **subsys;
 	char *subsys_name = NULL;
@@ -1045,7 +1058,7 @@ static char *nvme_ctrl_lookup_subsystem_name(const char *ctrl_name)
 
 		sprintf(path, "%s/%s/%s", nvme_subsys_sysfs_dir,
 			subsys[i]->d_name, ctrl_name);
-		nvme_msg(LOG_DEBUG, "lookup subsystem %s\n", path);
+		nvme_msg(r, LOG_DEBUG, "lookup subsystem %s\n", path);
 		if (stat(path, &st) < 0)
 			continue;
 		subsys_name = strdup(subsys[i]->d_name);
@@ -1055,14 +1068,14 @@ static char *nvme_ctrl_lookup_subsystem_name(const char *ctrl_name)
 	return subsys_name;
 }
 
-static int nvme_configure_ctrl(nvme_ctrl_t c, const char *path,
+static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 			       const char *name)
 {
 	DIR *d;
 
 	d = opendir(path);
 	if (!d) {
-		nvme_msg(LOG_ERR, "Failed to open ctrl dir %s, error %d\n",
+		nvme_msg(r, LOG_ERR, "Failed to open ctrl dir %s, error %d\n",
 			 path, errno);
 		errno = ENODEV;
 		return -1;
@@ -1101,7 +1114,7 @@ int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance)
 		goto out_free_name;
 	}
 
-	ret = nvme_configure_ctrl(c, path, name);
+	ret = nvme_configure_ctrl(h->r, c, path, name);
 	if (ret < 0) {
 		free(path);
 		goto out_free_name;
@@ -1116,9 +1129,10 @@ int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance)
 		}
 	}
 
-	subsys_name = nvme_ctrl_lookup_subsystem_name(name);
+	subsys_name = nvme_ctrl_lookup_subsystem_name(h->r, name);
 	if (!subsys_name) {
-		nvme_msg(LOG_ERR, "Failed to lookup subsystem name for %s\n",
+		nvme_msg(h->r, LOG_ERR,
+			 "Failed to lookup subsystem name for %s\n",
 			 c->name);
 		errno = ENVME_CONNECT_LOOKUP_SUBSYS_NAME;
 		ret = -1;
@@ -1133,7 +1147,7 @@ int nvme_init_ctrl(nvme_host_t h, nvme_ctrl_t c, int instance)
 	if (!s->name) {
 		ret = nvme_init_subsystem(s, subsys_name);
 		if (ret < 0) {
-			nvme_msg(LOG_ERR, "Failed to init subsystem %s\n",
+			nvme_msg(h->r, LOG_ERR, "Failed to init subsystem %s\n",
 				 subsys_name);
 			goto out_free_subsys;
 		}
@@ -1149,8 +1163,8 @@ out_free_subsys:
 	return ret;
 }
 
-static nvme_ctrl_t nvme_ctrl_alloc(nvme_subsystem_t s, const char *path,
-				   const char *name)
+static nvme_ctrl_t nvme_ctrl_alloc(nvme_root_t r, nvme_subsystem_t s,
+				   const char *path, const char *name)
 {
 	nvme_ctrl_t c;
 	char *addr = NULL, *address = NULL, *a, *e;
@@ -1226,7 +1240,7 @@ skip_address:
 	c->address = addr;
 	if (s->subsystype && !strcmp(s->subsystype, "discovery"))
 		c->discovery_ctrl = true;
-	ret = nvme_configure_ctrl(c, path, name);
+	ret = nvme_configure_ctrl(r, c, path, name);
 	return (ret < 0) ? NULL : c;
 }
 
@@ -1272,7 +1286,7 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name)
 		errno = ENXIO;
 		return NULL;
 	}
-	subsysname = nvme_ctrl_lookup_subsystem_name(name);
+	subsysname = nvme_ctrl_lookup_subsystem_name(r, name);
 	s = nvme_lookup_subsystem(h, subsysname, subsysnqn);
 	free(subsysnqn);
 	if (!s) {
@@ -1280,24 +1294,25 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name)
 		errno = ENOMEM;
 		return NULL;
 	}
-	c = nvme_ctrl_alloc(s, path, name);
+	c = nvme_ctrl_alloc(r, s, path, name);
 	if (!c) {
 		free(path);
 		return NULL;
 	}
 
-	nvme_ctrl_scan_namespaces(c);
-	nvme_ctrl_scan_paths(c);
+	nvme_ctrl_scan_namespaces(r, c);
+	nvme_ctrl_scan_paths(r, c);
 	return c;
 }
 
 void nvme_rescan_ctrl(struct nvme_ctrl *c)
 {
+	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
 	if (!c->s)
 		return;
-	nvme_subsystem_scan_namespaces(c->s);
-	nvme_ctrl_scan_namespaces(c);
-	nvme_ctrl_scan_paths(c);
+	nvme_subsystem_scan_namespaces(r, c->s);
+	nvme_ctrl_scan_namespaces(r, c);
+	nvme_ctrl_scan_paths(r, c);
 }
 
 static int nvme_bytes_to_lba(nvme_ns_t n, off_t offset, size_t count,
@@ -1724,19 +1739,20 @@ nvme_ns_t nvme_scan_namespace(const char *name)
 	return __nvme_scan_namespace(nvme_ns_sysfs_dir, name);
 }
 
-static int nvme_ctrl_scan_namespace(struct nvme_ctrl *c, char *name)
+static int nvme_ctrl_scan_namespace(nvme_root_t r, struct nvme_ctrl *c,
+				    char *name)
 {
 	struct nvme_ns *n;
 
 	if (!c->s) {
-		nvme_msg(LOG_DEBUG, "%s: no subsystem for %s\n",
+		nvme_msg(r, LOG_DEBUG, "%s: no subsystem for %s\n",
 			 __func__, name);
 		errno = EINVAL;
 		return -1;
 	}
 	n = __nvme_scan_namespace(c->sysfs_dir, name);
 	if (!n) {
-		nvme_msg(LOG_DEBUG, "%s: failed to scan namespace %s\n",
+		nvme_msg(r, LOG_DEBUG, "%s: failed to scan namespace %s\n",
 			 __func__, name);
 		return -1;
 	}
@@ -1747,13 +1763,14 @@ static int nvme_ctrl_scan_namespace(struct nvme_ctrl *c, char *name)
 	return 0;
 }
 
-static int nvme_subsystem_scan_namespace(struct nvme_subsystem *s, char *name)
+static int nvme_subsystem_scan_namespace(nvme_root_t r, nvme_subsystem_t s,
+					 char *name)
 {
 	struct nvme_ns *n;
 
 	n = __nvme_scan_namespace(s->sysfs_dir, name);
 	if (!n) {
-		nvme_msg(LOG_DEBUG, "%s: failed to scan namespace %s\n",
+		nvme_msg(r, LOG_DEBUG, "%s: failed to scan namespace %s\n",
 			 __func__, name);
 		return -1;
 	}
@@ -1766,6 +1783,7 @@ static int nvme_subsystem_scan_namespace(struct nvme_subsystem *s, char *name)
 struct nvme_ns *nvme_subsystem_lookup_namespace(struct nvme_subsystem *s,
 						__u32 nsid)
 {
+	nvme_root_t r = s->h ? s->h->r : NULL;
 	struct nvme_ns *n;
 	char *name;
 	int ret;
@@ -1775,7 +1793,7 @@ struct nvme_ns *nvme_subsystem_lookup_namespace(struct nvme_subsystem *s,
 		return NULL;
 	n = __nvme_scan_namespace(s->sysfs_dir, name);
 	if (!n) {
-		nvme_msg(LOG_DEBUG, "%s: failed to scan namespace %d\n",
+		nvme_msg(r, LOG_DEBUG, "%s: failed to scan namespace %d\n",
 			 __func__, nsid);
 		free(name);
 		return NULL;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -118,7 +118,7 @@ static int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 	return 0;
 }
 
-nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp)
+nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp, int log_level)
 {
 	struct nvme_root *r = calloc(1, sizeof(*r));
 
@@ -126,6 +126,7 @@ nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp)
 		errno = ENOMEM;
 		return NULL;
 	}
+	r->log_level = log_level;
 	r->fp = stderr;
 	if (fp)
 		r->fp = fp;
@@ -134,16 +135,22 @@ nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp)
 	return r;
 }
 
-nvme_root_t nvme_scan(const char *config_file)
+void nvme_read_config(nvme_root_t r, const char *config_file)
 {
-	nvme_root_t r = nvme_scan_filter(NULL, NULL);
-
 #ifdef CONFIG_JSONC
 	if (r && config_file) {
 		json_read_config(r, config_file);
 		r->config_file = strdup(config_file);
 	}
 #endif
+}
+
+nvme_root_t nvme_scan(const char *config_file)
+{
+	nvme_root_t r = nvme_scan_filter(NULL, NULL, DEFAULT_LOGLEVEL);
+
+	nvme_read_config(r, config_file);
+
 	return r;
 }
 

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -10,6 +10,7 @@
 #ifndef _LIBNVME_TREE_H
 #define _LIBNVME_TREE_H
 
+#include <stdio.h>
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -239,17 +240,22 @@ nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 
 
 /**
- * nvme_create_ctrl() -
- * @subsysnqn:
- * @transport:
- * @traddr:
- * @host_traddr:
- * @host_iface:
- * @trsvcid:
+ * nvme_create_ctrl() - Allocate an unconnected NVMe controller
+ * @r: NVMe root element
+ * @subsysnqn: Subsystem NQN
+ * @transport: Transport type
+ * @traddr: Transport address
+ * @host_traddr: Host transport address
+ * @host_iface: Host interface name
+ * @trsvcid: Transport service ID
  *
- * Return: 
+ * Creates an unconnected nvme_ctrl_t structure to be used for
+ * nvme_add_ctrl().
+ *
+ * Return: nvme_ctrl_t structure
  */
-nvme_ctrl_t nvme_create_ctrl(const char *subsysnqn, const char *transport,
+nvme_ctrl_t nvme_create_ctrl(nvme_root_t r,
+			     const char *subsysnqn, const char *transport,
 			     const char *traddr, const char *host_traddr,
 			     const char *host_iface, const char *trsvcid);
 
@@ -961,12 +967,16 @@ const char *nvme_subsystem_get_name(nvme_subsystem_t s);
 const char *nvme_subsystem_get_type(nvme_subsystem_t s);
 
 /**
- * nvme_scan_filter() -
- * @f:
+ * nvme_scan_filter() - Scan NVMe topology and apply filter
+ * @f: filter to apply
+ * @fp: filepointer for error messages
  *
- * Return: 
+ * Scans the NVMe topology and filters out the resulting elements
+ * by applying @f.
+ *
+ * Return: nvme_root_t structure holding the resulting elements.
  */
-nvme_root_t nvme_scan_filter(nvme_scan_filter_t f);
+nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp);
 
 /**
  * nvme_host_get_hostnqn() -
@@ -999,10 +1009,10 @@ nvme_host_t nvme_default_host(nvme_root_t r);
 void nvme_free_host(nvme_host_t h);
 
 /**
- * nvme_scan() -
- * @config_file:
+ * nvme_scan() - Scan NVMe topology
+ * @config_file: configuration file
  *
- * Return: 
+ * Return: nvme_root_t structure of found elements
  */
 nvme_root_t nvme_scan(const char *config_file);
 

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -57,6 +57,23 @@ typedef struct nvme_root *nvme_root_t;
 typedef bool (*nvme_scan_filter_t)(nvme_subsystem_t);
 
 /**
+ * nvme_create_root() - Initialize root object
+ * @fp: filedescriptor for logging messages
+ * @log_level: logging level to use
+ *
+ * Return: initialized nvme_root_t structure
+ */
+nvme_root_t nvme_create_root(FILE *fp, int log_level);
+
+/**
+ * nvme_free_tree() - Free root object
+ * @r: nvme_root_t object
+ *
+ * Free an nvme_root_t object and all attached objects
+ */
+void nvme_free_tree(nvme_root_t r);
+
+/**
  * nvme_first_host() -
  * @r:
  *
@@ -967,17 +984,16 @@ const char *nvme_subsystem_get_name(nvme_subsystem_t s);
 const char *nvme_subsystem_get_type(nvme_subsystem_t s);
 
 /**
- * nvme_scan_filter() - Scan NVMe topology and apply filter
+ * nvme_scan_topology() - Scan NVMe topology and apply filter
+ * @r: nvme_root_t object
  * @f: filter to apply
- * @fp: filepointer for error messages
- * @log_level: logging level for this structure
  *
  * Scans the NVMe topology and filters out the resulting elements
  * by applying @f.
  *
- * Return: nvme_root_t structure holding the resulting elements.
+ * Return: Number of elements scanned
  */
-nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp, int log_level);
+int nvme_scan_topology(nvme_root_t r, nvme_scan_filter_t f);
 
 /**
  * nvme_host_get_hostnqn() -
@@ -1054,12 +1070,6 @@ int nvme_update_config(nvme_root_t r);
  * Return:
  */
 int nvme_dump_config(nvme_root_t r);
-
-/**
- * nvme_free_tree() -
- * @r:
- */
-void nvme_free_tree(nvme_root_t r);
 
 /**
  * nvme_get_attr() -

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -970,13 +970,14 @@ const char *nvme_subsystem_get_type(nvme_subsystem_t s);
  * nvme_scan_filter() - Scan NVMe topology and apply filter
  * @f: filter to apply
  * @fp: filepointer for error messages
+ * @log_level: logging level for this structure
  *
  * Scans the NVMe topology and filters out the resulting elements
  * by applying @f.
  *
  * Return: nvme_root_t structure holding the resulting elements.
  */
-nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp);
+nvme_root_t nvme_scan_filter(nvme_scan_filter_t f, FILE *fp, int log_level);
 
 /**
  * nvme_host_get_hostnqn() -
@@ -1015,6 +1016,16 @@ void nvme_free_host(nvme_host_t h);
  * Return: nvme_root_t structure of found elements
  */
 nvme_root_t nvme_scan(const char *config_file);
+
+/**
+ * nvme_read_config() - Read NVMe json configuration file
+ * @r: nvme_root_t object
+ * @config_file: json configuration file
+ *
+ * Read in the contents of @config_file and merge them with
+ * the elements in @r.
+ */
+void nvme_read_config(nvme_root_t r, const char *config_file);
 
 /**
  * nvme_refresh_topology() -

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -7,6 +7,7 @@
  * 	    Chaitanya Kulkarni <chaitanya.kulkarni@wdc.com>
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 
@@ -16,8 +17,10 @@
 
 #include <ccan/endian/endian.h>
 
+#include "private.h"
 #include "util.h"
 #include "log.h"
+
 static inline __u8 nvme_generic_status_to_errno(__u16 status)
 {
 	switch (status) {
@@ -503,7 +506,7 @@ const char *nvme_errno_to_string(int status)
 	return s;
 }
 
-char *hostname2traddr(const char *traddr)
+char *hostname2traddr(struct nvme_root *r, const char *traddr)
 {
 	struct addrinfo *host_info, hints = {.ai_family = AF_UNSPEC};
 	char addrstr[NVMF_TRADDR_SIZE];
@@ -513,7 +516,7 @@ char *hostname2traddr(const char *traddr)
 
 	ret = getaddrinfo(traddr, NULL, &hints, &host_info);
 	if (ret) {
-		nvme_msg(LOG_ERR, "failed to resolve host %s info\n",
+		nvme_msg(r, LOG_ERR, "failed to resolve host %s info\n",
 			 traddr);
 		return NULL;
 	}
@@ -530,13 +533,13 @@ char *hostname2traddr(const char *traddr)
 			addrstr, NVMF_TRADDR_SIZE);
 		break;
 	default:
-		nvme_msg(LOG_ERR, "unrecognized address family (%d) %s\n",
+		nvme_msg(r, LOG_ERR, "unrecognized address family (%d) %s\n",
 			 host_info->ai_family, traddr);
 		goto free_addrinfo;
 	}
 
 	if (!p) {
-		nvme_msg(LOG_ERR, "failed to get traddr for %s\n",
+		nvme_msg(r, LOG_ERR, "failed to get traddr for %s\n",
 			 traddr);
 		goto free_addrinfo;
 	}

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -11,11 +11,13 @@
 #include <errno.h>
 
 #include <sys/types.h>
+#include <arpa/inet.h>
+#include <netdb.h>
 
 #include <ccan/endian/endian.h>
 
 #include "util.h"
-
+#include "log.h"
 static inline __u8 nvme_generic_status_to_errno(__u16 status)
 {
 	switch (status) {
@@ -499,4 +501,48 @@ const char *nvme_errno_to_string(int status)
 	const char *s = ARGSTR(libnvme_status, status);
 
 	return s;
+}
+
+char *hostname2traddr(const char *traddr)
+{
+	struct addrinfo *host_info, hints = {.ai_family = AF_UNSPEC};
+	char addrstr[NVMF_TRADDR_SIZE];
+	const char *p;
+	char *ret_traddr = NULL;
+	int ret;
+
+	ret = getaddrinfo(traddr, NULL, &hints, &host_info);
+	if (ret) {
+		nvme_msg(LOG_ERR, "failed to resolve host %s info\n",
+			 traddr);
+		return NULL;
+	}
+
+	switch (host_info->ai_family) {
+	case AF_INET:
+		p = inet_ntop(host_info->ai_family,
+			&(((struct sockaddr_in *)host_info->ai_addr)->sin_addr),
+			addrstr, NVMF_TRADDR_SIZE);
+		break;
+	case AF_INET6:
+		p = inet_ntop(host_info->ai_family,
+			&(((struct sockaddr_in6 *)host_info->ai_addr)->sin6_addr),
+			addrstr, NVMF_TRADDR_SIZE);
+		break;
+	default:
+		nvme_msg(LOG_ERR, "unrecognized address family (%d) %s\n",
+			 host_info->ai_family, traddr);
+		goto free_addrinfo;
+	}
+
+	if (!p) {
+		nvme_msg(LOG_ERR, "failed to get traddr for %s\n",
+			 traddr);
+		goto free_addrinfo;
+	}
+	ret_traddr = strdup(addrstr);
+
+free_addrinfo:
+	freeaddrinfo(host_info);
+	return ret_traddr;
 }

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -392,5 +392,7 @@ static inline void nvme_id_ns_flbas_to_lbaf_inuse(__u8 flbas, __u8 *lbaf_inuse)
 		| (flbas & NVME_NS_FLBAS_LOWER_MASK));
 }
 
-char *hostname2traddr(const char *traddr);
+struct nvme_root;
+
+char *hostname2traddr(struct nvme_root *r, const char *traddr);
 #endif /* _LIBNVME_UTIL_H */

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -391,4 +391,6 @@ static inline void nvme_id_ns_flbas_to_lbaf_inuse(__u8 flbas, __u8 *lbaf_inuse)
 	*lbaf_inuse = (((flbas & NVME_NS_FLBAS_HIGHER_MASK) >> 1) \
 		| (flbas & NVME_NS_FLBAS_LOWER_MASK));
 }
+
+char *hostname2traddr(const char *traddr);
 #endif /* _LIBNVME_UTIL_H */

--- a/test/test.c
+++ b/test/test.c
@@ -318,8 +318,10 @@ int main(int argc, char **argv)
 
 	printf("Test filter for common loop back target\n");
 	nqn_match = "testnqn";
-	r = nvme_scan_filter(nvme_match_subsysnqn_filter, NULL,
-			     DEFAULT_LOGLEVEL);
+	r = nvme_create_root(NULL, DEFAULT_LOGLEVEL);
+	if (!r)
+		return 1;
+	nvme_scan_topology(r, nvme_match_subsysnqn_filter);
 	nvme_for_each_host(r, h) {
 		nvme_for_each_subsystem(h, s) {
 			printf("%s - NQN=%s\n", nvme_subsystem_get_name(s),

--- a/test/test.c
+++ b/test/test.c
@@ -318,7 +318,8 @@ int main(int argc, char **argv)
 
 	printf("Test filter for common loop back target\n");
 	nqn_match = "testnqn";
-	r = nvme_scan_filter(nvme_match_subsysnqn_filter, NULL);
+	r = nvme_scan_filter(nvme_match_subsysnqn_filter, NULL,
+			     DEFAULT_LOGLEVEL);
 	nvme_for_each_host(r, h) {
 		nvme_for_each_subsystem(h, s) {
 			printf("%s - NQN=%s\n", nvme_subsystem_get_name(s),

--- a/test/test.c
+++ b/test/test.c
@@ -318,7 +318,7 @@ int main(int argc, char **argv)
 
 	printf("Test filter for common loop back target\n");
 	nqn_match = "testnqn";
-	r = nvme_scan_filter(nvme_match_subsysnqn_filter);
+	r = nvme_scan_filter(nvme_match_subsysnqn_filter, NULL);
 	nvme_for_each_host(r, h) {
 		nvme_for_each_subsystem(h, s) {
 			printf("%s - NQN=%s\n", nvme_subsystem_get_name(s),


### PR DESCRIPTION
This patchset adds an 'nvme_root_t' argument to nvme_msg(), and allows to store a different filedescriptor than 'stderr' to store in nvme_root_t. With that applications can re-route the error messages.