### PR TITLE
Return json parsing errors

### DIFF
--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -129,7 +129,7 @@ struct nvme_root {
 
 int nvme_set_attr(const char *dir, const char *attr, const char *value);
 
-void json_read_config(nvme_root_t r, const char *config_file);
+int json_read_config(nvme_root_t r, const char *config_file);
 
 int json_update_config(nvme_root_t r, const char *config_file);
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -145,6 +145,12 @@ int nvme_read_config(nvme_root_t r, const char *config_file)
 		err = json_read_config(r, config_file);
 		if (!err)
 			r->config_file = strdup(config_file);
+		/*
+		 * The json configuration file is optional,
+		 * so ignore errors when opening the file.
+		 */
+		if (err < 0 && errno != EPROTO)
+			err = 0;
 	}
 #else
 	errno = ENOTSUP;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -137,14 +137,19 @@ nvme_root_t nvme_create_root(FILE *fp, int log_level)
 	return r;
 }
 
-void nvme_read_config(nvme_root_t r, const char *config_file)
+int nvme_read_config(nvme_root_t r, const char *config_file)
 {
+	int err = -1;
 #ifdef CONFIG_JSONC
 	if (r && config_file) {
-		json_read_config(r, config_file);
-		r->config_file = strdup(config_file);
+		err = json_read_config(r, config_file);
+		if (!err)
+			r->config_file = strdup(config_file);
 	}
+#else
+	errno = ENOTSUP;
 #endif
+	return err;
 }
 
 nvme_root_t nvme_scan(const char *config_file)

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1040,8 +1040,10 @@ nvme_root_t nvme_scan(const char *config_file);
  *
  * Read in the contents of @config_file and merge them with
  * the elements in @r.
+ *
+ * Returns: 0 on success, -1 on failure with errno set.
  */
-void nvme_read_config(nvme_root_t r, const char *config_file);
+int nvme_read_config(nvme_root_t r, const char *config_file);
 
 /**
  * nvme_refresh_topology() -


### PR DESCRIPTION
Parsing the JSON configuration file might fail, so we should be signalling that to the caller.