### PR TITLE
[libnvme] Add support for retrieving Telemetry Log Page data area 4.  

### DIFF
--- a/examples/telemetry-listen.c
+++ b/examples/telemetry-listen.c
@@ -38,13 +38,13 @@ static int open_uevent(nvme_ctrl_t c)
 static void save_telemetry(nvme_ctrl_t c)
 {
 	char buf[0x1000];
-	__u32 log_size;
+	size_t log_size;
 	int ret, fd;
 	struct nvme_telemetry_log *log;
 	time_t s;
 
 	/* Clear the log (rae == false) at the end to see new telemetry events later */
-	ret = nvme_get_ctrl_telemetry(nvme_ctrl_get_fd(c), false, &log);
+	ret = nvme_get_ctrl_telemetry(nvme_ctrl_get_fd(c), false, &log, 3, &log_size);
 	if (ret)
 		return;
 
@@ -67,7 +67,7 @@ static void save_telemetry(nvme_ctrl_t c)
 	if (ret < 0)
 		printf("failed to write telemetry log\n");
 	else
-		printf("telemetry log save as %s, wrote:%d size:%d\n", buf,
+		printf("telemetry log save as %s, wrote:%d size:%ld\n", buf,
 			ret, log_size);
 	close(fd);
 	free(log);

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -176,15 +176,17 @@ int nvme_get_log_page(int fd, __u32 nsid, __u8 log_id, bool rae,
 }
 
 static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
-				  struct nvme_telemetry_log **buf)
+				  struct nvme_telemetry_log **buf, int da, size_t *size)
 {
 	static const __u32 xfer = NVME_LOG_TELEM_BLOCK_SIZE;
 
 	struct nvme_telemetry_log *telem;
 	enum nvme_cmd_get_log_lid lid;
+	struct nvme_id_ctrl id_ctrl;
 	void *log, *tmp;
-	__u32 size;
 	int err;
+
+	*size = 0;
 
 	log = malloc(xfer);
 	if (!log) {
@@ -212,9 +214,39 @@ static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
 		return 0;
 	}
 
-	/* dalb3 >= dalb2 >= dalb1 */
-	size = (le16_to_cpu(telem->dalb3) + 1) * xfer;
-	tmp = realloc(log, size);
+	switch (da) {
+	case 1:
+	case 2:
+	case 3:
+		/* dalb3 >= dalb2 >= dalb1 */
+		*size = (le16_to_cpu(telem->dalb3) + 1) * xfer;
+		break;
+	case 4:
+		err = nvme_identify_ctrl(fd, &id_ctrl);
+		if (err) {
+			perror("identify-ctrl");
+			errno = EINVAL;
+			goto free;
+		}
+
+		if ((id_ctrl.lpa & 0x40)) {
+			*size = (le32_to_cpu(telem->dalb4) + 1) * xfer;
+		}
+		else {
+			fprintf(stderr, "Data area 4 unsupported, bit 6 of Log Page Attributes not set\n");
+			errno = EINVAL;
+			err = -1;
+			goto free;
+		}
+		break;
+	default:
+		fprintf(stderr, "Invalid data area parameter - %d\n", da);
+		errno = EINVAL;
+		err = -1;
+		goto free;
+	}
+
+		tmp = realloc(log, *size);
 	if (!tmp) {
 		errno = ENOMEM;
 		err = -1;
@@ -222,7 +254,7 @@ static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
 	}
 	log = tmp;
 
-	err = nvme_get_log_page(fd, NVME_NSID_NONE, lid, rae, size, (void *)log);
+	err = nvme_get_log_page(fd, NVME_NSID_NONE, lid, rae, *size, (void *)log);
 	if (!err) {
 		*buf = log;
 		return 0;
@@ -232,19 +264,19 @@ free:
 	return err;
 }
 
-int nvme_get_ctrl_telemetry(int fd, bool rae, struct nvme_telemetry_log **log)
+int nvme_get_ctrl_telemetry(int fd, bool rae, struct nvme_telemetry_log **log, int da, size_t *size)
 {
-	return nvme_get_telemetry_log(fd, false, true, rae, log);
+	return nvme_get_telemetry_log(fd, false, true, rae, log, da, size);
 }
 
-int nvme_get_host_telemetry(int fd, struct nvme_telemetry_log **log)
+int nvme_get_host_telemetry(int fd, struct nvme_telemetry_log **log, int da, size_t *size)
 {
-	return nvme_get_telemetry_log(fd, false, false, false, log);
+	return nvme_get_telemetry_log(fd, false, false, false, log, da, size);
 }
 
-int nvme_get_new_host_telemetry(int fd, struct nvme_telemetry_log **log)
+int nvme_get_new_host_telemetry(int fd, struct nvme_telemetry_log **log, int da, size_t *size)
 {
-	return nvme_get_telemetry_log(fd, true, false, false, log);
+	return nvme_get_telemetry_log(fd, true, false, false, log, da, size);
 }
 
 int nvme_get_lba_status_log(int fd, bool rae, struct nvme_lba_status_log **log)

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -32,40 +32,49 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
  * @fd:	   File descriptor of nvme device
  * @rae:   Retain asynchronous events
  * @log:   On success, set to the value of the allocated and retreived log.
+ * @da:    log page data area, valid values: 1, 2, 3, and 4
+ * @size:  Ptr to the telemetry log size, so it can be returned
  *
  * The total size allocated can be calculated as:
- *   (&struct nvme_telemetry_log.dalb3 + 1) * %NVME_LOG_TELEM_BLOCK_SIZE.
+ *   (nvme_telemetry_log da size  + 1) * NVME_LOG_TELEM_BLOCK_SIZE.
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_ctrl_telemetry(int fd, bool rae, struct nvme_telemetry_log **log);
+int nvme_get_ctrl_telemetry(int fd, bool rae, struct nvme_telemetry_log **log,
+		int da, size_t *size);
 
 /**
  * nvme_get_host_telemetry() -
- * @fd:	 File descriptor of nvme device
- * @log: On success, set to the value of the allocated and retreived log.
+ * @fd:	  File descriptor of nvme device
+ * @log:  On success, set to the value of the allocated and retreived log.
+ * @da:   log page data area, valid values: 1, 2, 3, and 4
+ * @size: Ptr to the telemetry log size, so it can be returned
  *
  * The total size allocated can be calculated as:
- *   (&struct nvme_telemetry_log.dalb3 + 1) * %NVME_LOG_TELEM_BLOCK_SIZE.
+ *   (nvme_telemetry_log da size  + 1) * NVME_LOG_TELEM_BLOCK_SIZE.
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_host_telemetry(int fd,  struct nvme_telemetry_log **log);
+int nvme_get_host_telemetry(int fd,  struct nvme_telemetry_log **log,
+		int da, size_t *size);
 
 /**
  * nvme_get_new_host_telemetry() -
- * @fd:  File descriptor of nvme device
- * @log: On success, set to the value of the allocated and retreived log.
+ * @fd:   File descriptor of nvme device
+ * @log:  On success, set to the value of the allocated and retreived log.
+ * @da:   log page data area, valid values: 1, 2, 3, and 4
+ * @size: Ptr to the telemetry log size, so it can be returned
  *
  * The total size allocated can be calculated as:
- *   (&struct nvme_telemetry_log.dalb3 + 1) * %NVME_LOG_TELEM_BLOCK_SIZE.
+ *   (nvme_telemetry_log da size  + 1) * NVME_LOG_TELEM_BLOCK_SIZE.
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log);
+int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log,
+		int da, size_t *size);
 
 /**
  * __nvme_get_log_page() -


### PR DESCRIPTION
To add support for telemetry log page data area 4, the size ptr and data area parms where added to functions:   nvme_get_telemetry_log, nvme_get_ctrl_telemetry, nvme_get_host_telemetry, and nvme_get_new_host_telemetry.  

There is a corresponding change to the nvme cli code that is dependent on this pull request.  

Signed-off-by: Jeff Lien <jeff.lien@wdc.com>