### PR TITLE
Restart controller lookup

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -581,9 +581,8 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
         case NVMF_TRTYPE_FC:
 		switch (e->adrfam) {
 		case NVMF_ADDR_FAMILY_FC:
-			nvme_chomp(e->traddr, NVMF_TRADDR_SIZE),
+			nvme_chomp(e->traddr, NVMF_TRADDR_SIZE);
 			traddr = e->traddr;
-			trsvcid = NULL;
 			break;
 		default:
 			nvme_msg(h->r, LOG_ERR,
@@ -593,6 +592,8 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 			return NULL;
 		}
 	case NVMF_TRTYPE_LOOP:
+		nvme_chomp(e->traddr, NVMF_TRADDR_SIZE);
+		traddr = strlen(e->traddr) ? e->traddr : NULL;
 		break;
 	default:
 		nvme_msg(h->r, LOG_ERR, "skipping unsupported transport %d\n",

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1287,7 +1287,10 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name)
 		return NULL;
 	}
 	subsysname = nvme_ctrl_lookup_subsystem_name(r, name);
+	/* subsysname might be NULL here */
 	s = nvme_lookup_subsystem(h, subsysname, subsysnqn);
+	if (subsysname)
+		free(subsysname);
 	free(subsysnqn);
 	if (!s) {
 		free(path);

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -669,7 +669,7 @@ const char *nvme_ctrl_get_subsysnqn(nvme_ctrl_t c)
 
 const char *nvme_ctrl_get_address(nvme_ctrl_t c)
 {
-	return c->address;
+	return c->address ? c->address : "";
 }
 
 const char *nvme_ctrl_get_firmware(nvme_ctrl_t c)

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -977,16 +977,18 @@ struct nvme_ctrl *nvme_create_ctrl(nvme_root_t r,
 	return c;
 }
 
-struct nvme_ctrl *nvme_lookup_ctrl(struct nvme_subsystem *s, const char *transport,
-				   const char *traddr, const char *host_traddr,
-				   const char *host_iface, const char *trsvcid)
+nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
+			     const char *traddr, const char *host_traddr,
+			     const char *host_iface, const char *trsvcid,
+			     nvme_ctrl_t p)
 {
 	nvme_root_t r = s->h ? s->h->r : NULL;
 	struct nvme_ctrl *c;
 
 	if (!s || !transport)
 		return NULL;
-	nvme_subsystem_for_each_ctrl(s, c) {
+	c = p ? nvme_subsystem_next_ctrl(s, p) : nvme_subsystem_first_ctrl(s);
+	for (; c != NULL; c = nvme_subsystem_next_ctrl(s, c)) {
 		if (strcmp(c->transport, transport))
 			continue;
 		if (traddr && c->traddr &&
@@ -1166,7 +1168,7 @@ out_free_subsys:
 static nvme_ctrl_t nvme_ctrl_alloc(nvme_root_t r, nvme_subsystem_t s,
 				   const char *path, const char *name)
 {
-	nvme_ctrl_t c;
+	nvme_ctrl_t c, p;
 	char *addr = NULL, *address = NULL, *a, *e;
 	char *transport, *traddr = NULL, *trsvcid = NULL;
 	char *host_traddr = NULL, *host_iface = NULL;
@@ -1228,13 +1230,36 @@ static nvme_ctrl_t nvme_ctrl_alloc(nvme_root_t r, nvme_subsystem_t s,
 		}
 	}
 skip_address:
-	c = nvme_lookup_ctrl(s, transport, traddr,
-			     host_traddr, host_iface, trsvcid);
+	p = NULL;
+	do {
+		c = nvme_lookup_ctrl(s, transport, traddr,
+				     host_traddr, host_iface, trsvcid, p);
+		if (c) {
+			if (!c->name)
+				break;
+			if (!strcmp(c->name, name)) {
+				nvme_msg(r, LOG_DEBUG,
+					 "%s: found existing ctrl %s\n",
+					 __func__, c->name);
+				break;
+			}
+			nvme_msg(r, LOG_DEBUG, "%s: skipping ctrl %s\n",
+				 __func__, c->name);
+			p = c;
+		}
+	} while (c);
+	if (!c)
+		c = p;
 	free(transport);
 	if (address)
 		free(address);
 	if (!c) {
-		errno = ENOMEM;
+		if (!p) {
+			nvme_msg(r, LOG_ERR, "%s: failed to lookup ctrl\n",
+				 __func__);
+			errno = ENODEV;
+		} else
+			errno = ENOMEM;
 		return NULL;
 	}
 	c->address = addr;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -235,17 +235,20 @@ nvme_ctrl_t nvme_subsystem_next_ctrl(nvme_subsystem_t s, nvme_ctrl_t c);
  * @host_traddr: host transport address
  * @host_iface: host interface name
  * @trsvcid: transport service identifier
+ * @p: previous nvme_ctrl_t object
  *
  * Lookup a nvme_ctrl_t object in @s based on @transport, @traddr,
  * @host_traddr, @host_iface, and @trsvcid. @transport must be specified,
  * other fields may be required depending on the transport. A new
- * object is created if none is found.
+ * object is created if none is found. If @p is specified the lookup
+ * will start at @p instead of the first controller.
  *
  * Return: nvme_ctrl_t object
  */
 nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 			     const char *traddr, const char *host_traddr,
-			     const char *host_iface, const char *trsvcid);
+			     const char *host_iface, const char *trsvcid,
+			     nvme_ctrl_t p);
 
 
 /**

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -735,7 +735,8 @@ const char *nvme_ctrl_get_sysfs_dir(nvme_ctrl_t c);
  * nvme_ctrl_get_address() - Address string of an nvme_ctrl_t
  * @c: nvme_ctrl_t object
  *
- * Return: NVMe-over-Fabrics address string of @c
+ * Return: NVMe-over-Fabrics address string of @c or empty string
+ * of no address is present.
  */
 const char *nvme_ctrl_get_address(nvme_ctrl_t c);
 


### PR DESCRIPTION
Under some circumstances nvme_lookup_ctrl() might not have enough information to uniquely identify a controller. In these cases nvme_lookup_ctrl() will only ever return the first element, and any other matching element will be ignored.
This patchset adds a new parameter 'p' to nvme_lookup_ctrl() to allow the lookup to be restarted after a certain point.