### PR TITLE
tree: do not set dhchap_key to 'none'

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -505,6 +505,10 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
 			if (h->dhchap_key)
 				free(h->dhchap_key);
 			h->dhchap_key = nvme_get_attr(path, "dhchap_secret");
+			if (h->dhchap_key && !strcmp(h->dhchap_key, "none")) {
+				free(h->dhchap_key);
+				h->dhchap_key = NULL;
+			}
 		}
 	}
 	if (!h)
@@ -1106,6 +1110,10 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	c->serial = nvme_get_ctrl_attr(c, "serial");
 	c->sqsize = nvme_get_ctrl_attr(c, "sqsize");
 	c->dhchap_key = nvme_get_ctrl_attr(c, "dhchap_ctrl_secret");
+	if (c->dhchap_key && !strcmp(c->dhchap_key, "none")) {
+		free(c->dhchap_key);
+		c->dhchap_key = NULL;
+	}
 	return 0;
 }
 
@@ -1306,6 +1314,10 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name)
 		if (h->dhchap_key)
 			free(h->dhchap_key);
 		h->dhchap_key = nvme_get_attr(path, "dhchap_secret");
+		if (h->dhchap_key && !strcmp(h->dhchap_key, "none")) {
+			free(h->dhchap_key);
+			h->dhchap_key = NULL;
+		}
 	}
 	if (!h) {
 		h = nvme_default_host(r);


### PR DESCRIPTION
When no dhchap key is set the kernel will set the sysfs attribute
to 'none'. And we shouldn't display this value in our internal tree
as it really means 'not set'.

Signed-off-by: Hannes Reinecke <hare@suse.de>