### PR TITLE
tree: add nvme_dump_tree()

### DIFF
--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -127,6 +127,8 @@ int json_read_config(nvme_root_t r, const char *config_file);
 
 int json_update_config(nvme_root_t r, const char *config_file);
 
+int json_dump_tree(nvme_root_t r);
+
 #if (LOG_FUNCNAME == 1)
 #define __nvme_log_func __func__
 #else

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -189,6 +189,16 @@ int nvme_dump_config(nvme_root_t r)
 #endif
 }
 
+int nvme_dump_tree(nvme_root_t r)
+{
+#ifdef CONFIG_JSONC
+	return json_dump_tree(r);
+#else
+	errno = ENOTSUP;
+	return -1;
+#endif
+}
+
 nvme_host_t nvme_first_host(nvme_root_t r)
 {
 	return list_top(&r->hosts, struct nvme_host, entry);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1095,6 +1095,17 @@ int nvme_update_config(nvme_root_t r);
 int nvme_dump_config(nvme_root_t r);
 
 /**
+ * nvme_dump_tree() - Dump internal object tree
+ * @r: nvme_root_t object
+ *
+ * Prints the internal object tree in JSON format
+ * to stdout.
+ *
+ * Return: 0 on success, -1 on failure.
+ */
+int nvme_dump_tree(nvme_root_t r);
+
+/**
  * nvme_get_attr() - Read sysfs attribute
  * @d: sysfs directory
  * @attr: sysfs attribute name


### PR DESCRIPTION
Dump the internal tree in JSON format to stdout for debugging.

Signed-off-by: Hannes Reinecke <hare@suse.de>