### PR TITLE
build: Make CI build fail on warnings

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -19,8 +19,9 @@ jobs:
       - uses: actions/setup-python@v1
       - uses: BSFishy/meson-build@v1.0.3
         with:
-          action: test
+          setup-options: --werror
           options: --verbose
+          action: test
       # Preserve meson's log file on failure
       - uses: actions/upload-artifact@v1
         if: failure()


### PR DESCRIPTION
Currently, warnings are hidden in the logs and the build is marked as
succeeded. Mark all warnings as error so that we see them show up in
the review process.

Signed-off-by: Daniel Wagner <dwagner@suse.de>