### PR TITLE
build: Add kernel-doc CI build

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,21 @@
+name: libnvme documenation CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  kernel_doc_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Check documentation format
+        run: |
+          API_FILES="fabrics.h filters.h ioctl.h linux.h tree.h types.h"
+          for file in $API_FILES; do
+            ./doc/kernel-doc -v -none src/nvme/$file 2>&1 | sed -r 's/^([^:]+):([0-9]+): (warning|error):/::\3 file=\1,line=\2::/g'
+          done
+        shell: bash


### PR DESCRIPTION
We want to catching documentation failures early. Let's add a
dedicated documentation CI build. To keep build times low just
shortcut here and do not call meson to build the complete
documentation.

Signed-off-by: Daniel Wagner <dwagner@suse.de>