### PR TITLE
tree: Remove dead !LIBUUID code

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -920,23 +920,16 @@ char *nvmf_hostnqn_generate()
 	char *hostnqn;
 	int ret;
 	char uuid_str[UUID_SIZE];
-#ifdef CONFIG_LIBUUID
 	uuid_t uuid;
-#endif
 
 	ret = uuid_from_dmi(uuid_str);
 	if (ret < 0) {
 		ret = uuid_from_device_tree(uuid_str);
 	}
-#ifdef CONFIG_LIBUUID
 	if (ret < 0) {
 		uuid_generate_random(uuid);
 		uuid_unparse_lower(uuid, uuid_str);
-		ret = 0;
 	}
-#endif
-	if (ret < 0)
-		return NULL;
 
 	if (asprintf(&hostnqn, "nqn.2014-08.org.nvmexpress:uuid:%s", uuid_str) < 0)
 		return NULL;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -13,9 +13,7 @@
 
 #include "fabrics.h"
 
-#ifdef CONFIG_LIBUUID
 #include <uuid/uuid.h>
-#endif
 
 
 extern const char *nvme_ctrl_sysfs_dir;
@@ -56,11 +54,7 @@ struct nvme_ns {
 
 	uint8_t eui64[8];
 	uint8_t nguid[16];
-#ifdef CONFIG_LIBUUID
 	uuid_t  uuid;
-#else
-	uint8_t uuid[16];
-#endif
 	enum nvme_csi csi;
 };
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1464,17 +1464,10 @@ const uint8_t *nvme_ns_get_nguid(nvme_ns_t n)
 	return n->nguid;
 }
 
-#ifdef CONFIG_LIBUUID
 void nvme_ns_get_uuid(nvme_ns_t n, uuid_t out)
 {
 	uuid_copy(out, n->uuid);
 }
-#else
-void nvme_ns_get_uuid(nvme_ns_t n, uint8_t *out)
-{
-	memcpy(out, n, 16);
-}
-#endif
 
 int nvme_ns_identify(nvme_ns_t n, struct nvme_id_ns *ns)
 {

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -15,9 +15,8 @@
 #include <stddef.h>
 
 #include <sys/types.h>
-#ifdef CONFIG_LIBUUID
 #include <uuid/uuid.h>
-#endif
+
 #include "ioctl.h"
 #include "util.h"
 
@@ -484,11 +483,7 @@ const uint8_t *nvme_ns_get_nguid(nvme_ns_t n);
  *
  * Copies the namespace's uuid into @out
  */
-#ifdef CONFIG_LIBUUID
 void nvme_ns_get_uuid(nvme_ns_t n, uuid_t out);
-#else
-void nvme_ns_get_uuid(nvme_ns_t n, uint8_t *out);
-#endif
 
 /**
  * nvme_ns_get_sysfs_dir() - sysfs directory of an nvme_ns_t object

--- a/test/test.c
+++ b/test/test.c
@@ -19,9 +19,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <inttypes.h>
-#ifdef CONFIG_LIBUUID
 #include <uuid/uuid.h>
-#endif
 #include <libnvme.h>
 
 #include <ccan/endian/endian.h>
@@ -368,10 +366,8 @@ int main(int argc, char **argv)
 				       nvme_ctrl_get_state(c));
 
 				nvme_ctrl_for_each_ns(c, n) {
-#ifdef CONFIG_LIBUUID
 					char uuid_str[40];
 					uuid_t uuid;
-#endif
 					printf("   `- %s lba size:%d lba max:%" PRIu64 "\n",
 					       nvme_ns_get_name(n),
 					       nvme_ns_get_lba_size(n),
@@ -380,12 +376,10 @@ int main(int argc, char **argv)
 					print_hex(nvme_ns_get_eui64(n), 8);
 					printf(" nguid:");
 					print_hex(nvme_ns_get_nguid(n), 16);
-#ifdef CONFIG_LIBUUID
 					nvme_ns_get_uuid(n, uuid);
 					uuid_unparse_lower(uuid, uuid_str);
 					printf(" uuid:%s csi:%d\n", uuid_str,
 					       nvme_ns_get_csi(n));
-#endif
 				}
 
 				nvme_ctrl_for_each_path(c, p)


### PR DESCRIPTION
We have added a hard dependency to libuuid. Remove the ifdefs and the
dead code.

Signed-off-by: Daniel Wagner <dwagner@suse.de>