### PR TITLE
[libnvme] Add uuidx parm to get log page API

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -123,7 +123,6 @@ LIBNVME_1_0 {
 		nvme_get_log_fw_slot;
 		nvme_get_log_lba_status;
 		nvme_get_log_page;
-		nvme_get_log_page_padded;
 		nvme_get_log_persistent_event;
 		nvme_get_log_predictable_lat_event;
 		nvme_get_log_predictable_lat_nvmset;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -670,8 +670,24 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 
 static int nvme_discovery_log(int fd, __u32 len, struct nvmf_discovery_log *log, bool rae)
 {
-	return nvme_get_log_page(fd, 0, NVME_LOG_LID_DISCOVER, rae, 512,
-				 len, log);
+	struct nvme_get_log_args args = {
+		.args_size = sizeof(args),
+		.fd = fd,
+		.nsid = NVME_NSID_NONE,
+		.lsp = NVME_LOG_LSP_NONE,
+		.lsi = NVME_LOG_LSI_NONE,
+		.uuidx = NVME_UUID_NONE,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result = NULL,
+		.lid = NVME_LOG_LID_DISCOVER,
+		.log = log,
+		.len = len,
+		.csi = NVME_CSI_NVM,
+		.rae = rae,
+		.ot = false,
+	};
+
+	return nvme_get_log_page(fd, 4096, &args);
 }
 
 int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -11,6 +11,7 @@
 
 #include <stddef.h>
 
+#include "ioctl.h"
 #include "types.h"
 
 /**
@@ -99,36 +100,13 @@ int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log,
 /**
  * nvme_get_log_page() - get log page data
  * @fd:	      File descriptor of nvme device
- * @nsid:     Namespace Identifier, if applicable.
- * @log_id:   Log Identifier, see &enum nvme_cmd_get_log_lid.
- * @rae:      Retain asynchronous events
  * @xfer_len: Max log transfer size per request to split the total.
- * @data_len: Total length of the log to transfer.
- * @data:     User address of at least &data_len to store the log.
+ * @args:	&struct nvme_get_log_args argument structure
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_log_page(int fd, __u32 nsid, __u8 log_id, bool rae,
-		      __u32 xfer_len, __u32 data_len, void *data);
-
-/**
- * nvme_get_log_page_padded() - get log page data with 4k xfer length
- * @fd:	      File descriptor of nvme device
- * @nsid:     Namespace Identifier, if applicable.
- * @log_id:   Log Identifier, see &enum nvme_cmd_get_log_lid.
- * @rae:      Retain asynchronous events
- * @data_len: Total length of the log to transfer.
- * @data:     User address of at least &data_len to store the log.
- *
- * Calls nvme_get_log_page() with a default 4k transfer length, as that is
- * guaranteed by the protocol to be a safe transfer size.
- *
- * Return: The nvme command status if a response was received (see
- * &enum nvme_status_field) or -1 with errno set otherwise.
- */
-int nvme_get_log_page_padded(int fd, __u32 nsid, __u8 log_id, bool rae,
-			     __u32 data_len, void *data);
+int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args);
 
 /**
  * nvme_get_ana_log_len() - Retreive size of the current ANA log


### PR DESCRIPTION
 Add uuidx parm to nvme_get_log_page and nvme_get_log_page_padded functions

Signed-off-by: Jeff Lien <jeff.lien@wdc.com>