### PR TITLE
add cdw13 for set_feature_args structure

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -440,6 +440,7 @@ int nvme_set_features(struct nvme_set_features_args *args)
 		.cdw10		= cdw10,
 		.cdw11		= args->cdw11,
 		.cdw12		= args->cdw12,
+		.cdw13		= args->cdw13,
 		.cdw14		= cdw14,
 		.cdw15		= args->cdw15,
 		.timeout_ms	= args->timeout,

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1994,6 +1994,7 @@ struct nvme_set_features_args {
 	__u32 nsid;
 	__u32 cdw11;
 	__u32 cdw12;
+	__u32 cdw13;
 	__u32 cdw15;
 	__u32 data_len;
 	bool save;
@@ -2034,6 +2035,7 @@ static inline int nvme_set_features_data(int fd, __u8 fid, __u32 nsid,
 		.nsid = nsid,
 		.cdw11 = cdw11,
 		.cdw12 = 0,
+		.cdw13 = 0,
 		.cdw15 = 0,
 		.data_len = data_len,
 		.save = save,


### PR DESCRIPTION
setting of cdw13 is required for Micron's latency monitoring feature. Addition of cdw13 to nvme_set_feature_args should not change the IOCTL value as nvme_passthrough_cmd has cdw13 already.