### PR TITLE
Add support for TP8010 explicit registration

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -25,6 +25,10 @@
 		    "description": "NVMe host ID",
 		    "type": "string"
 		},
+		"hostsymname": {
+		    "description": "NVMe host symbolic name",
+		    "type": "string"
+		},
 		"required": [ "hostnqn" ],
 		"subsystems": {
 		    "description": "Array of NVMe subsystem properties",

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -6,7 +6,8 @@
  * Authors: Hannes Reinecke <hare@suse.de>
  */
 
-%module nvme
+%module(docstring="Python bindings for libnvme") nvme
+%feature("autodoc", "1");
 
 %include "exception.i"
 
@@ -280,8 +281,10 @@ struct nvme_root {
 struct nvme_host {
   %immutable hostnqn;
   %immutable hostid;
+  %immutable hostsymname;
   char *hostnqn;
   char *hostid;
+  char *hostsymname;
   char *dhchap_key;
 };
 
@@ -373,6 +376,9 @@ struct nvme_ns {
   void update_config() {
     nvme_update_config($self);
   }
+  void dump_config() {
+    nvme_dump_config($self);
+  }
 }
 
 %extend host_iter {
@@ -393,13 +399,27 @@ struct nvme_ns {
 
 %extend nvme_host {
   nvme_host(struct nvme_root *r, const char *hostnqn = NULL,
-	    const char *hostid = NULL) {
-    if (!hostnqn)
-      return nvme_default_host(r);
-    return nvme_lookup_host(r, hostnqn, hostid);
+	    const char *hostid = NULL, const char *hostsymname = NULL) {
+
+    nvme_host_t h = hostnqn ? nvme_lookup_host(r, hostnqn, hostid) : nvme_default_host(r);
+    if (hostsymname)
+        nvme_host_set_hostsymname(h, hostsymname);
+    return h;
   }
   ~nvme_host() {
     nvme_free_host($self);
+  }
+%define SET_SYMNAME_DOCSTRING
+"@brief Set or Clear Host's Symbolic Name
+
+@param hostsymname: A symbolic name, or None to clear the symbolic name.
+@type hostsymname: str|None
+
+@return: None"
+%enddef
+  %feature("autodoc", SET_SYMNAME_DOCSTRING) set_symname;
+  void set_symname(const char *hostsymname) {
+    nvme_host_set_hostsymname($self, hostsymname);
   }
   char *__str__() {
     static char tmp[2048];
@@ -553,6 +573,29 @@ struct nvme_ns {
   }
   void disconnect() {
     nvme_disconnect_ctrl($self);
+  }
+
+  %feature("autodoc", "@return: True if controller supports explicit registration. False otherwise.") is_registration_supported;
+  bool is_registration_supported() {
+    return nvmf_is_registration_supported($self);
+  }
+
+  %feature("autodoc", "@return None on success or Error string on error.") registration_ctl;
+  PyObject *registration_ctl(enum nvmf_dim_tas tas) {
+    __u32 result;
+    int   status;
+
+    status = nvmf_registration_ctl($self, NVME_TAS_REGISTER, &result);
+    if (status != NVME_SC_SUCCESS) {
+      // On error, return an error message
+      if (status < 0)
+        return PyUnicode_FromFormat("Status:0x%04x - %s", status, nvme_status_to_string(status, false));
+      else
+        return PyUnicode_FromFormat("Result:0x%04x, Status:0x%04x - %s", result, status, nvme_status_to_string(status, false));
+    }
+
+    // On success, return None
+    Py_RETURN_NONE;
   }
 
   %newobject discover;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -145,8 +145,10 @@ LIBNVME_1_0 {
 		nvme_host_get_dhchap_key;
 		nvme_host_get_hostid;
 		nvme_host_get_hostnqn;
+		nvme_host_get_hostsymname;
 		nvme_host_get_root;
 		nvme_host_set_dhchap_key;
+		nvme_host_set_hostsymname;
 		nvme_identify;
 		nvme_identify_active_ns_list;
 		nvme_identify_allocated_ns;
@@ -329,6 +331,8 @@ LIBNVME_1_0 {
 		nvmf_subtype_str;
 		nvmf_treq_str;
 		nvmf_trtype_str;
+		nvmf_registration_ctl;
+		nvmf_is_registration_supported;
 	local:
 		*;
 };

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -20,6 +20,7 @@
 #include <dirent.h>
 #include <inttypes.h>
 
+#include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <arpa/inet.h>
@@ -963,4 +964,256 @@ char *nvmf_hostnqn_from_file()
 char *nvmf_hostid_from_file()
 {
 	return nvmf_read_file(nvmf_hostid_file, NVMF_HOSTID_SIZE);
+}
+
+/**
+ * nvmf_get_tel() - Calculate the amount of memory needed for a Discovery
+ * Information Entry. Each Entry must contain at a minimum an Extended
+ * Attribute for the HostID. The Entry may optionally contain an Extended
+ * Attribute for the Symbolic Name.
+ *
+ * @hostsymname - Symbolic name (may be NULL)
+ *
+ * Return: Total Entry Length
+ */
+static __u32 nvmf_get_tel(const char *hostsymname)
+{
+	__u32 tel = SIZEOF_EXT_DIE_WO_EXAT;
+	__u16 len;
+
+	/* Host ID is mandatory */
+	tel += exat_size(sizeof(uuid_t));
+
+	/* Symbolic name is optional */
+	len = hostsymname ? strlen(hostsymname) : 0;
+	if (len)
+		tel += exat_size(len);
+
+	return tel;
+}
+
+/**
+ * nvmf_fill_die() - Fill the Discovery Information Entry pointed to by
+ * 	@die.
+ *
+ * @die - Pointer to Discovery Information Entry to be filled
+ * @h - Pointer to the host data structure
+ * @tel - Length of the DIE
+ * @trtype - Transport type
+ * @adrfam - Address family
+ * @reg_addr - Address to register. Setting this to an empty string tells
+ * 	the DC to infer address from the source address of the socket.
+ * @tsas - Transport Specific Address Subtype for the address being
+ * 	registered.
+ */
+static void nvmf_fill_die(struct nvmf_ext_die  *die,
+			  struct nvme_host     *h,
+			  __u32                 tel,
+			  __u8                  trtype,
+			  __u8                  adrfam,
+			  const char           *reg_addr,
+			  union nvmf_tsas      *tsas)
+{
+	__u16 numexat = 0;
+	size_t symname_len;
+	struct nvmf_ext_attr *exat;
+
+	die->tel = htole32(tel);
+	die->trtype = trtype;
+	die->adrfam = adrfam;
+
+	memcpy(die->nqn, h->hostnqn, MIN(sizeof(die->nqn), strlen(h->hostnqn)));
+	memcpy(die->traddr, reg_addr, MIN(sizeof(die->traddr), strlen(reg_addr)));
+
+	if (tsas)
+		memcpy(&die->tsas, tsas, sizeof(die->tsas));
+
+	/* Extended Attribute for the HostID (mandatory) */
+	numexat++;
+	exat = &die->exat;
+	exat->type = htole16(NVME_EXATTYPE_HOSTID);
+	exat->len  = htole16(exat_len(sizeof(uuid_t)));
+	uuid_parse(h->hostid, exat->val);
+
+	/* Extended Attribute for the Symbolic Name (optional) */
+	symname_len = h->hostsymname ? strlen(h->hostsymname) : 0;
+	if (symname_len) {
+		__u16 exatlen = exat_len(symname_len);
+
+		numexat++;
+		exat = exat_ptr_next(exat);
+		exat->type = htole16(NVME_EXATTYPE_SYMNAME);
+		exat->len  = htole16(exatlen);
+		memcpy(exat->val, h->hostsymname, symname_len);
+		/* Per Base specs, ASCII strings must be padded with spaces */
+		memset(&exat->val[symname_len], ' ', exatlen - symname_len);
+	}
+
+	die->numexat = htole16(numexat);
+}
+
+/**
+ * nvmf_dim() - Perform explicit registration, deregistration,
+ * or registration-update (specified by @tas) by sending a Discovery
+ * Information Management (DIM) command to the Discovery Controller (DC).
+ *
+ * @ctrl: Host NVMe controller instance maintaining the admin queue used to
+ *      submit the DIM command to the DC.
+ * @tas: Task field of the Command Dword 10 (cdw10). Indicates whether to
+ *     perform a Registration, Deregistration, or Registration-update.
+ * @trtype: Transport type (enum nvmf_trtype - must be NVMF_TRTYPE_TCP)
+ * @adrfam: Address family (enum nvmf_addr_family)
+ * @reg_addr - Address to register. Setting this to an empty string tells
+ *       the DC to infer address from the source address of the socket.
+ * @tsas - Transport Specific Address Subtype for the address being
+ *       registered.
+ *
+ * Return:   0: success,
+ *         > 0: NVMe error status code,
+ *         < 0: Linux errno error code
+ */
+static int nvmf_dim(nvme_ctrl_t        c,
+		    enum nvmf_dim_tas  tas,
+		    __u8               trtype,
+		    __u8               adrfam,
+		    const char        *reg_addr,
+		    union nvmf_tsas   *tsas,
+		    __u32             *result)
+{
+	int                   ret;
+	__u32                 tdl;  /* Total Data Length */
+	__u32                 tel;  /* Total Entry Length */
+	struct nvmf_dim_data *dim;  /* Discovery Information Management */
+	struct nvmf_ext_die  *die;  /* Discovery Information Entry */
+	nvme_root_t           r = c->s && c->s->h ? c->s->h->r : NULL;
+
+	struct nvme_dim_args args = {
+		.args_size = sizeof(args),
+		.fd = nvme_ctrl_get_fd(c),
+		.result = result,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.tas = tas
+	};
+
+	if (!c->s) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. subsystem undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (!c->s->h) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. host undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (!c->s->h->hostid) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. hostid undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (!c->s->h->hostnqn) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. hostnqn undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (strcmp(c->transport, "tcp") != 0) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: DIM only supported for TCP connections.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	/* Register one Discovery Information Entry (DIE) of size TEL */
+	tel = nvmf_get_tel(c->s->h->hostsymname);
+	tdl = SIZEOF_DIM_WO_DIE + tel;
+
+	dim = (struct nvmf_dim_data *)calloc(1, tdl);
+	if (!dim)
+		return -ENOMEM;
+
+	dim->tdl    = htole32(tdl);
+	dim->nument = htole64(1);    /* only one DIE to register */
+	dim->entfmt = htole16(NVME_ENTFMT_EXTENDED);
+	dim->etype  = htole16(NVME_REGISTRATION_HOST);
+	dim->ektype = htole16(0x5F); /* must be 0x5F per specs */
+
+	memcpy(dim->eid, c->s->h->hostnqn, MIN(sizeof(dim->eid), strlen(c->s->h->hostnqn)));
+
+	ret = getEntityName(dim->ename, sizeof(dim->ename));
+	if (ret <= 0)
+		nvme_msg(r, LOG_INFO, "%s: Failed to retrieve ENAME. %s.\n",
+			 c->name, strerror(errno));
+
+	ret = getEntityVersion(dim->ever, sizeof(dim->ever));
+	if (ret <= 0)
+		nvme_msg(r, LOG_INFO, "%s: Failed to retrieve EVER.\n", c->name);
+
+	die = &dim->die.extended;
+	nvmf_fill_die(die, c->s->h, tel, trtype, adrfam, reg_addr, tsas);
+
+	args.data_len = tdl;
+	args.data = dim;
+	ret = nvme_send_dim_command(&args);
+
+	free(dim);
+
+	return ret;
+}
+
+/**
+ * nvme_get_adrfam() - Get address family for the address we're registering
+ * with the DC. We retrieve this info from the socket itself. If we can't
+ * get the source address from the socket, then we'll infer the address
+ * family from the address of the DC since the DC address has the same
+ * address family.
+ *
+ * @ctrl: Host NVMe controller instance maintaining the admin queue used to
+ *        submit the DIM command to the DC.
+ *
+ * Return: The address family of the source address associated with the
+ *         socket connected to the DC.
+ */
+static __u8 nvme_get_adrfam(nvme_ctrl_t c)
+{
+	struct sockaddr_storage addr;
+	__u8 adrfam = NVMF_ADDR_FAMILY_IP4;
+	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
+
+	if (!inet_pton_with_scope(r, AF_UNSPEC, c->traddr, c->trsvcid, &addr)) {
+		if (addr.ss_family == AF_INET6)
+			adrfam = NVMF_ADDR_FAMILY_IP6;
+	}
+
+	return adrfam;
+}
+
+bool nvmf_is_registration_supported(nvme_ctrl_t c)
+{
+	return streq(c->dctype, "ddc") || streq(c->dctype, "cdc");
+}
+
+int nvmf_registration_ctl(nvme_ctrl_t c, enum nvmf_dim_tas tas, __u32 *result)
+{
+	int ret = NVME_SC_SUCCESS;
+	if (nvmf_is_registration_supported(c)) {
+		/* We're registering our source address with the DC. To do
+		 * that, we can simply send an empty string. This tells the DC
+		 * to retrieve the source address from the socket and use that
+		 * as the registration address.
+		 */
+		ret = nvmf_dim(c, NVME_TAS_REGISTER, NVMF_TRTYPE_TCP,
+			       nvme_get_adrfam(c), "", NULL, result);
+	} else {
+		errno = ENOTSUP;
+		ret = -ENOTSUP;
+	}
+
+	return ret;
 }

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -241,4 +241,31 @@ static inline void nvme_chomp(char *s, int l)
 		s[l--] = '\0';
 }
 
+/**
+ * nvmf_is_registration_supported - check whether registration can be
+ * performed.
+ *
+ * @c: Control object
+ *
+ * Return: true if controller supports explicit registration. false
+ * otherwise.
+ */
+bool nvmf_is_registration_supported(nvme_ctrl_t c);
+
+/**
+ * nvmf_registration_ctl() - Perform registration task with a Discovery
+ * Controller (DC). Three tasks are supported: register, deregister, and
+ * registration update.
+ *
+ * @c: Control object
+ * @tas: Task field of the Command Dword 10 (cdw10). Indicates whether to
+ *     perform a Registration, Deregistration, or Registration-update.
+ * @result: The result returned by the DC upon command completion.
+ *
+ * Return:   0: success,
+ *         > 0: NVMe error status code,
+ *         < 0: Linux errno error code
+ */
+int nvmf_registration_ctl(nvme_ctrl_t c, enum nvmf_dim_tas tas, __u32 *result);
+
 #endif /* _LIBNVME_FABRICS_H */

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -306,6 +306,8 @@ enum nvme_cmd_dword_fields {
 	NVME_ZNS_MGMT_RECV_ZRASF_MASK				= 0xff,
 	NVME_ZNS_MGMT_RECV_ZRAS_FEAT_SHIFT			= 16,
 	NVME_ZNS_MGMT_RECV_ZRAS_FEAT_MASK			= 0x1,
+	NVME_DIM_TAS_SHIFT					= 0,
+	NVME_DIM_TAS_MASK					= 0xF,
 };
 
 enum features {
@@ -1841,4 +1843,24 @@ int nvme_zns_append(struct nvme_zns_append_args *args)
 		return -1;
 	}
 	return nvme_submit_io_passthru64(args->fd, &cmd, args->result);
+}
+
+int nvme_send_dim_command(struct nvme_dim_args *args)
+{
+	__u32 cdw10 = NVME_SET(args->tas, DIM_TAS);
+
+	struct nvme_passthru_cmd  cmd = {
+		.opcode     = nvme_admin_discovery_info_mgmt,
+		.cdw10      = cdw10,
+		.addr       = (__u64)(uintptr_t)args->data,
+		.data_len   = args->data_len,
+		.timeout_ms = args->timeout,
+	};
+
+	if (args->args_size < sizeof(*args)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
 }

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -4346,4 +4346,36 @@ struct nvme_zns_append_args {
  */
 int nvme_zns_append(struct nvme_zns_append_args *args);
 
+/**
+ * nvme_dim_args - Arguments for the NVMe Discovery Information Management
+ * command
+ * @args_size:	Length of the structure
+ * @fd:		File descriptor of nvme device
+ * @result:	Set on completion to the command's CQE DWORD 0 controller
+ * 		response.
+ * @timeout:	Timeout in ms
+ * @data_len:	Length of @data
+ * @data:	Pointer to the DIM data
+ * @tas:	Task field of the Command Dword 10 (cdw10)
+ */
+struct nvme_dim_args {
+	int	args_size;
+	int	fd;
+	__u32	*result;
+	__u32	timeout;
+	__u32	data_len;
+	void	*data;
+	__u8	tas;
+} __attribute__((packed, aligned(__alignof__(__u32*))));
+
+/**
+ * nvme_send_dim_command - Send a Discovery Information Management command.
+ *
+ * @args:	&struct nvme_zns_append_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_send_dim_command(struct nvme_dim_args *args);
+
 #endif /* _LIBNVME_IOCTL_H */

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -146,6 +146,9 @@ static void json_parse_host(nvme_root_t r, struct json_object *host_obj)
 	attr_obj = json_object_object_get(host_obj, "dhchap_key");
 	if (attr_obj)
 		nvme_host_set_dhchap_key(h, json_object_get_string(attr_obj));
+	attr_obj = json_object_object_get(host_obj, "hostsymname");
+	if (attr_obj)
+		nvme_host_set_hostsymname(h, json_object_get_string(attr_obj));
 	subsys_array = json_object_object_get(host_obj, "subsystems");
 	if (!subsys_array)
 		return;
@@ -288,7 +291,7 @@ int json_update_config(nvme_root_t r, const char *config_file)
 	json_root = json_object_new_array();
 	nvme_for_each_host(r, h) {
 		nvme_subsystem_t s;
-		const char *hostnqn, *hostid, *dhchap_key;
+		const char *hostnqn, *hostid, *dhchap_key, *hostsymname;
 
 		host_obj = json_object_new_object();
 		if (!host_obj)
@@ -304,6 +307,10 @@ int json_update_config(nvme_root_t r, const char *config_file)
 		if (dhchap_key)
 			json_object_object_add(host_obj, "dhchap_key",
 					       json_object_new_string(dhchap_key));
+		hostsymname = nvme_host_get_hostsymname(h);
+		if (hostsymname)
+			json_object_object_add(host_obj, "hostsymname",
+					       json_object_new_string(hostsymname));
 		subsys_array = json_object_new_array();
 		nvme_for_each_subsystem(h, s) {
 			json_update_subsys(subsys_array, s);

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -80,6 +80,8 @@ struct nvme_ctrl {
 	char *traddr;
 	char *trsvcid;
 	char *dhchap_key;
+	char *cntrltype;
+	char *dctype;
 	bool discovery_ctrl;
 	bool discovered;
 	bool persistent;
@@ -109,6 +111,7 @@ struct nvme_host {
 	char *hostnqn;
 	char *hostid;
 	char *dhchap_key;
+	char *hostsymname;
 };
 
 struct nvme_root {

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1168,4 +1168,23 @@ char *nvme_get_path_attr(nvme_path_t p, const char *attr);
  */
 nvme_ns_t nvme_scan_namespace(const char *name);
 
+/**
+ * nvme_host_get_hostsymname() - Get the host's symbolic name
+ *
+ * @h: Host for which the symbolic name should be returned.
+ *
+ * Return: The symbolic name or NULL if a symbolic name hasn't been
+ * configure.
+ */
+const char *nvme_host_get_hostsymname(nvme_host_t h);
+
+/**
+ * nvme_host_set_hostsymname() - Set the host's symbolic name
+ *
+ * @h: Host for which the symbolic name should be set.
+ * @hostsymname: Symbolic name
+ */
+void nvme_host_set_hostsymname(nvme_host_t h, const char *hostsymname);
+
+
 #endif /* _LIBNVME_TREE_H */

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -10,6 +10,7 @@
 #ifndef _LIBNVME_TYPES_H
 #define _LIBNVME_TYPES_H
 
+#include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -909,7 +910,10 @@ struct nvme_id_psd {
  * 	       that a host is allowed to place in a capsule. A value of 0h
  * 	       indicates no limit.
  * @ofcs:      Optional Fabric Commands Support, see &enum nvme_id_ctrl_ofcs.
- * @rsvd1806:  Reserved
+ * @dctype:    Discovery Controller Type (DCTYPE). This field indicates what
+ *             type of Discovery controller the controller is (see enum
+ *             nvme_id_ctrl_dctype)
+ * @rsvd1807:  Reserved
  * @psd:       Power State Descriptors, see &struct nvme_id_psd.
  * @vs:	       Vendor Specific
  */
@@ -1007,7 +1011,8 @@ struct nvme_id_ctrl {
 	__u8			fcatt;
 	__u8			msdbd;
 	__le16			ofcs;
-	__u8			rsvd1806[242];
+	__u8			dctype;
+	__u8			rsvd1807[241];
 
 	struct nvme_id_psd	psd[32];
 	__u8			vs[1024];
@@ -1117,6 +1122,18 @@ enum nvme_id_ctrl_cntrltype {
 	NVME_CTRL_CNTRLTYPE_IO			= 1,
 	NVME_CTRL_CNTRLTYPE_DISCOVERY		= 2,
 	NVME_CTRL_CNTRLTYPE_ADMIN		= 3,
+};
+
+/**
+ * enum nvme_id_ctrl_cntrltype - Discovery Controller types
+ * @NVME_CTRL_DCTYPE_NOT_REPORTED: Not reported (I/O, Admin, and pre-TP8010)
+ * @NVME_CTRL_DCTYPE_DDC: Direct Discovery controller
+ * @NVME_CTRL_DCTYPE_CDC: Central Discovery controller
+ */
+enum nvme_id_ctrl_dctype {
+	NVME_CTRL_DCTYPE_NOT_REPORTED	= 0,
+	NVME_CTRL_DCTYPE_DDC		= 1,
+	NVME_CTRL_DCTYPE_CDC		= 2,
 };
 
 /**
@@ -4479,6 +4496,38 @@ enum nvmf_disc_eflags {
 };
 
 /**
+ * union nvmf_tsas - Transport Specific Address Subtype
+ * @common:  Common transport specific attributes
+ * @rdma:    RDMA transport specific attribute settings
+ * @qptype:  RDMA QP Service Type (RDMA_QPTYPE): Specifies the type of RDMA
+ * 	     Queue Pair. See &enum nvmf_rdma_qptype.
+ * @prtype:  RDMA Provider Type (RDMA_PRTYPE): Specifies the type of RDMA
+ * 	     provider. See &enum nvmf_rdma_prtype.
+ * @cms:     RDMA Connection Management Service (RDMA_CMS): Specifies the type
+ * 	     of RDMA IP Connection Management Service. See &enum nvmf_rdma_cms.
+ * @pkey:    RDMA_PKEY: Specifies the Partition Key when AF_IB (InfiniBand)
+ * 	     address family type is used.
+ * @tcp:     TCP transport specific attribute settings
+ * @sectype: Security Type (SECTYPE): Specifies the type of security used by the
+ * 	     NVMe/TCP port. If SECTYPE is a value of 0h (No Security), then the
+ * 	     host shall set up a normal TCP connection. See &enum nvmf_tcp_sectype.
+ */
+union nvmf_tsas {
+	char		common[NVMF_TSAS_SIZE];
+	struct rdma {
+		__u8	qptype;
+		__u8	prtype;
+		__u8	cms;
+		__u8	rsvd3[5];
+		__u16	pkey;
+		__u8	rsvd10[246];
+	} rdma;
+	struct tcp {
+		__u8	sectype;
+	} tcp;
+};
+
+/**
  * struct nvmf_disc_log_entry - Discovery Log Page entry
  * @trtype:  Transport Type (TRTYPE): Specifies the NVMe Transport type.
  * 	     See &enum nvmf_trtype.
@@ -4523,20 +4572,6 @@ enum nvmf_disc_eflags {
  * 	     that may be used for a Connect command as an ASCII string. The
  * 	     Address Family field describes the reference for parsing this field.
  * @tsas:    Transport specific attribute settings
- * @common:  Common transport specific attributes
- * @rdma:    RDMA transport specific attribute settings
- * @qptype:  RDMA QP Service Type (RDMA_QPTYPE): Specifies the type of RDMA
- * 	     Queue Pair. See &enum nvmf_rdma_qptype.
- * @prtype:  RDMA Provider Type (RDMA_PRTYPE): Specifies the type of RDMA
- * 	     provider. See &enum nvmf_rdma_prtype.
- * @cms:     RDMA Connection Management Service (RDMA_CMS): Specifies the type
- * 	     of RDMA IP Connection Management Service. See &enum nvmf_rdma_cms.
- * @pkey:    RDMA_PKEY: Specifies the Partition Key when AF_IB (InfiniBand)
- * 	     address family type is used.
- * @tcp:     TCP transport specific attribute settings
- * @sectype: Security Type (SECTYPE): Specifies the type of security used by the
- * 	     NVMe/TCP port. If SECTYPE is a value of 0h (No Security), then the
- * 	     host shall set up a normal TCP connection. See &enum nvmf_tcp_sectype.
  */
 struct nvmf_disc_log_entry {
 	__u8		trtype;
@@ -4552,20 +4587,7 @@ struct nvmf_disc_log_entry {
 	__u8		rsvd64[192];
 	char		subnqn[NVME_NQN_LENGTH];
 	char		traddr[NVMF_TRADDR_SIZE];
-	union tsas {
-		char		common[NVMF_TSAS_SIZE];
-		struct rdma {
-			__u8	qptype;
-			__u8	prtype;
-			__u8	cms;
-			__u8	rsvd3[5];
-			__u16	pkey;
-			__u8	rsvd10[246];
-		} rdma;
-		struct tcp {
-			__u8	sectype;
-		} tcp;
-	} tsas;
+	union nvmf_tsas	tsas;
 };
 
 /**
@@ -4695,6 +4717,162 @@ struct nvmf_discovery_log {
 	__u8		rsvd14[1006];
 	struct nvmf_disc_log_entry entries[];
 };
+
+/**
+ * Discovery Information Management (DIM) command. This is sent by a
+ * host to a Discovery Controller (DC) to perform explicit registration.
+ */
+#define NVMF_ENAME_LEN       256
+#define NVMF_EVER_LEN        64
+
+enum nvmf_dim_tas {
+	NVME_TAS_REGISTER   = 0x00,
+	NVME_TAS_DEREGISTER = 0x01,
+	NVME_TAS_UPDATE     = 0x02,
+};
+
+enum nvmf_disc_info_entfmt
+{
+	NVME_ENTFMT_BASIC    = 0x01,
+	NVME_ENTFMT_EXTENDED = 0x02,
+};
+
+enum nvmf_disc_info_etype
+{
+	NVME_REGISTRATION_HOST = 0x01,
+	NVME_REGISTRATION_DDC  = 0x02,
+	NVME_REGISTRATION_CDC  = 0x03,
+};
+
+enum nvmf_exattype
+{
+	NVME_EXATTYPE_HOSTID   = 0x01, /* Host Identifier */
+	NVME_EXATTYPE_SYMNAME  = 0x02, /* Symbolic Name */
+};
+
+/**
+ * struct nvmf_ext_attr - Extended Attribute (EXAT)
+ *
+ *              Bytes           Description
+ *   @type      01:00           Extended Attribute Type (EXATTYPE) - see enum nvmf_exattype
+ *   @len       03:02           Extended Attribute Length (EXATLEN)
+ *   @val       (EXATLEN-1)     Extended Attribute Value (EXATVAL) - size allocated for array must be a multiple of 4 bytes
+ *              +4:04
+ */
+struct nvmf_ext_attr
+{                                                           /* Bytes */
+	__le16			type;                       /* 01:00 */
+	__le16			len;                        /* 03:02 */
+	__u8			val[];                      /* (EXATLEN-1)+4:04 */
+};
+#define SIZEOF_EXT_EXAT_WO_VAL offsetof(struct nvmf_ext_attr, val)
+
+/**
+ * struct nvmf_ext_die - Extended Discovery Information Entry (DIE)
+ *
+ *              Bytes           Description
+ *   @trtype    00              Transport Type (enum nvme_trtype)
+ *   @adrfam    01              Address Family (enum nvmf_addr_familiy)
+ *   @subtype   02              Subsystem Type (enum nvme_subsys_type)
+ *   @treq      03              Transport Requirements (enum nvmf_treq)
+ *   @portid    05:04           Port ID
+ *   @cntlid    07:06           Controller ID
+ *   @asqsz     09:08           Admin Max SQ Size
+ *              31:10           Reserved
+ *   @trsvcid   63:32           Transport Service Identifier
+ *              255:64          Reserved
+ *   @nqn       511:256         NVM Qualified Name
+ *   @traddr    767:512         Transport Address
+ *   @tsas      1023:768        Transport Specific Address Subtype
+ *   @tel       1027:1024       Total Entry Length
+ *   @numexat   1029:1028       Number of Extended Attributes
+ *              1031:1030       Reserved
+ *   @exat[0]   ((EXATLEN-1)+   Extented Attributes 0 (see @numexat)
+ *              4)+1032:1032    Cannot access as an array because each EXAT
+ *                              entry has an undetermined size.
+ *   @exat[N]   TEL-1:TEL-      Extented Attributes N (w/ N = NUMEXAT-1)
+ *              (EXATLEN+4)
+ */
+struct nvmf_ext_die
+{                                                           /* Bytes */
+	__u8			trtype;                     /* 00 */
+	__u8			adrfam;                     /* 01 */
+	__u8			subtype;                    /* 02 */
+	__u8			treq;                       /* 03 */
+	__le16			portid;                     /* 05:04 */
+	__le16			cntlid;                     /* 07:06 */
+	__le16			asqsz;                      /* 09:08 */
+	__u8			resv10[22];                 /* 31:10 */
+	char			trsvcid[NVMF_TRSVCID_SIZE]; /* 63:32 */
+	__u8			resv64[192];                /* 255:64 */
+	char			nqn[NVME_NQN_LENGTH];       /* 511:256 */
+	char			traddr[NVMF_TRADDR_SIZE];   /* 767:512 */
+	union nvmf_tsas		tsas;                       /* 1023:768 */
+	__le32			tel;                        /* 1027:1024 */
+	__le16			numexat;                    /* 1029:1028 */
+	__u16			resv1030;                   /* 1031:1030 */
+	struct nvmf_ext_attr	exat;                       /* TEL-1:1032 */
+};
+
+#define SIZEOF_EXT_DIE_WO_EXAT offsetof(struct nvmf_ext_die, exat)
+
+/**
+ * union nvmf_disc_info_entry - Discovery Information Entry (DIE)
+ *
+ * Depending on the ENTFMT specified in the DIM, DIEs can be entered with
+ * the Basic or Extended formats. For Basic format, each entry has a fixed
+ * length. Therefore, the "basic" field defined below can be accessed as a
+ * C array. For the Extended format, however, each entry is of variable
+ * length (TEL). Therefore, the "extended" field defined below cannot be
+ * accessed as a C array. Instead, the "extended" field is akin to a
+ * linked-list, where one can "walk" through the list. To move to the next
+ * entry, one simply adds the current entry's length (TEL) to the "walk"
+ * pointer. The number of entries in the list is specified by NUMENT.
+ * Although extended entries are of a variable lengths (TEL), TEL is
+ * always a mutiple of 4 bytes.
+ */
+union nvmf_die
+{
+	struct nvmf_disc_log_entry	basic[0];
+	struct nvmf_ext_die		extended;
+};
+
+/**
+ * struct nvmf_dim_data - Discovery Information Management (DIM) - Data
+ *
+ *              Bytes           Description
+ *   @tdl       03:00           Total Data Length
+ *              07:04           Reserved
+ *   @nument    15:08           Number of entries
+ *   @entfmt    17:16           Entry Format (enum nvmf_disc_info_entfmt)
+ *   @etype     19:18           Entity Type (enum nvmf_disc_info_etype)
+ *   @portlcL   20              Port Local
+ *              21              Reserved
+ *   @ektype    23:22           Entry Key Type
+ *   @eid       279:24          Entity Identifier (e.g. Host NQN)
+ *   @ename     535:280         Entity Name (e.g. hostname)
+ *   @ever      599:536         Entity Version (e.g. OS Name/Version)
+ *              1023:600        Reserved
+ *   @die       TDL-1:1024      Discovery Information Entry (see @nument above)
+ */
+struct nvmf_dim_data
+{                                                           /* Bytes */
+	__le32			tdl;                        /* 03:00 */
+	__u32			rsvd4;                      /* 07:04 */
+	__le64			nument;                     /* 15:08 */
+	__le16			entfmt;                     /* 17:16 */
+	__le16			etype;                      /* 19:18 */
+	__u8			portlcl;                    /* 20 */
+	__u8			rsvd21;                     /* 21 */
+	__le16			ektype;                     /* 23:22 */
+	char			eid[NVME_NQN_LENGTH];       /* 279:24 */
+	char			ename[NVMF_ENAME_LEN];      /* 535:280 */
+	char			ever[NVMF_EVER_LEN];        /* 599:536 */
+	__u8			rsvd600[424];               /* 1023:600 */
+	union nvmf_die		die;                        /* TDL-1:1024 */
+};
+
+#define SIZEOF_DIM_WO_DIE offsetof(struct nvmf_dim_data, die)
 
 /**
  * struct nvmf_connect_data - Data payload for the 'connect' command
@@ -5395,6 +5573,34 @@ struct nvme_mi_vpd_hdr {
  * @NVME_SC_IOCS_COMBINATION_REJECTED:	I/O Command Set Combination Rejected
  * @NVME_SC_INVALID_IOCS:	      Invalid I/O Command Set
  * @NVME_SC_ID_UNAVAILABLE:	      Identifier Unavailable
+ *
+ * @NVME_SC_INVALID_DISCOVERY_INFO    The discovery information provided in
+ *      			      one or more extended discovery
+ *      			      information entries is not applicable
+ *      			      for the type of entity selected in
+ *      			      the Entity Type (ETYPE) field of the
+ *      			      Discovery Information Management
+ *      			      command data portion’s header.
+ * @NVME_SC_ZONING_DATA_STRUCT_LOCKED The requested Zoning data structure
+ *      			      is locked on the CDC.
+ * @NVME_SC_ZONING_DATA_STRUCT_NOTFND The requested Zoning data structure
+ *      			      does not exist on the CDC.
+ * @NVME_SC_INSUFFICIENT_DISC_RES     The number of discover information
+ *      			      entries provided in the data portion
+ *      			      of the Discovery Information
+ *      			      Management command for a registration
+ *      			      task (i.e., TAS field cleared to 0h)
+ *      			      exceeds the available capacity for
+ *      			      new discovery information entries on
+ *      			      the CDC or DDC. This may be a
+ *      			      transient condition.
+ * @NVME_SC_REQSTD_FUNCTION_DISABLED  Fabric Zoning is not enabled on the
+ *      			      CDC
+ * @NVME_SC_ZONEGRP_ORIGINATOR_INVLD  The NQN contained in the ZoneGroup
+ *      			      Originator field does not match the
+ *      			      Host NQN used by the DDC to connect
+ *      			      to the CDC.
+ *
  * @NVME_SC_BAD_ATTRIBUTES:	      Conflicting Dataset Management Attributes
  * @NVME_SC_INVALID_PI:		      Invalid Protection Information
  * @NVME_SC_READ_ONLY:		      Attempted Write to Read Only Range
@@ -5623,6 +5829,13 @@ enum nvme_status_field {
 	NVME_SC_INVALID_IOCS			= 0x2c,
 	NVME_SC_ID_UNAVAILABLE			= 0x2d,
 
+	NVME_SC_INVALID_DISCOVERY_INFO		= 0x2f,
+	NVME_SC_ZONING_DATA_STRUCT_LOCKED	= 0x30,
+	NVME_SC_ZONING_DATA_STRUCT_NOTFND	= 0x31,
+	NVME_SC_INSUFFICIENT_DISC_RES		= 0x32,
+	NVME_SC_REQSTD_FUNCTION_DISABLED	= 0x33,
+	NVME_SC_ZONEGRP_ORIGINATOR_INVLD	= 0x34,
+
 	/*
 	 * I/O Command Set Specific - NVM commands:
 	 */
@@ -5744,6 +5957,7 @@ static inline __u16 nvme_status_code(__u16 status_field)
  * @nvme_admin_security_recv:
  * @nvme_admin_sanitize_nvm:
  * @nvme_admin_get_lba_status:
+ * @nvme_admin_discovery_info_mgmt: Discovery Information Management (DIM)
  */
 enum nvme_admin_opcode {
 	nvme_admin_delete_sq		= 0x00,
@@ -5777,6 +5991,7 @@ enum nvme_admin_opcode {
 	nvme_admin_security_recv	= 0x82,
 	nvme_admin_sanitize_nvm		= 0x84,
 	nvme_admin_get_lba_status	= 0x86,
+	nvme_admin_discovery_info_mgmt	= 0x21,
 };
 
 /**

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -424,4 +424,149 @@ static inline void nvme_id_ns_flbas_to_lbaf_inuse(__u8 flbas, __u8 *lbaf_inuse)
 struct nvme_root;
 
 char *hostname2traddr(struct nvme_root *r, const char *traddr);
+
+/**
+ * getEntityName - Get Entity Name (ENAME). Per TP8010, ENAME is defined as
+ * the name associated with the host (i.e. hostname).
+ *
+ * @buffer: The buffer where the ENAME will be saved as an ASCII string.
+ * @bufsz:  The size of @buffer.
+ *
+ * Return:: Number of characters copied to @buffer.
+ */
+size_t getEntityName(char *buffer, size_t bufsz);
+
+/**
+ * getEntityVersion - Get Entity Version (EVER). EVER is defined as the
+ * operating system name and version as an ASCII string. This function
+ * reads different files from the file system and builds a string as
+ * follows: [os type] [os release] [distro release]
+ *
+ *     E.g. "Linux 5.17.0-rc1 SLES 15.4"
+ *
+ * @buffer: The buffer where the EVER will be saved as an ASCII string.
+ * @bufsz:  The size of @buffer.
+ *
+ * Return:: Number of characters copied to @buffer.
+ */
+size_t getEntityVersion(char *buffer, size_t bufsz);
+
+/**
+ * read_file - read contents of file into @buffer, but don't NUL-terminate
+ * the buffer.
+ *
+ * @fname:  File name
+ * @buffer: Where to save file's contents
+ * @bufsz:  Size of @buffer. On success, @bufsz gets decremented by the
+ *          number of characters that were read.
+ *
+ * Return: The number of characters read.
+ */
+size_t read_file(const char * fname, char *buffer, size_t *bufsz);
+
+/**
+ * kv_strip - Strip leading/trailing blanks as well as trailing comments
+ *   from the Key=Value string pointed to by @kv.
+ *
+ * @kv: The key-value string to strip
+ *
+ * Return: A pointer to the stripped string. Note that the original string,
+ *         @kv, gets modified.
+ */
+char* kv_strip(char *kv);
+
+/**
+ * kv_keymatch - Look for @key in the Key=Value pair pointed to by @kv
+ *   and return a pointer to the Value if @key is found.
+ *
+ * @brief Check if @kv starts with @key. If it does then make sure that we
+ *   have a whole-word match on the @key, and if we do, return a pointer to
+ *   the first character of value (i.e. skip leading spaces, tabs, and
+ *   equal sign)
+ *
+ * @kv: The key=value string to search for the presence of @key
+ * @key: The key to look for
+ *
+ * Return: A pointer to the first character of "value" if a match is found.
+ * NULL otherwise.
+ */
+char* kv_keymatch(const char *kv, const char *key);
+
+/**
+ * startswith - Checks that a string starts with a given prefix.
+ *
+ * @s: The string to check
+ * @prefix: A string that @s could be starting with
+ *
+ * Return: If @s starts with @prefix, then return a pointer within @s at
+ * the first character after the matched @prefix. NULL otherwise.
+ */
+char* startswith(const char *s, const char *prefix);
+
+/**
+ * round_up - Round a value @val to the next multiple speified by @mult.
+ * @val: Value to round
+ * @mult: Multiple to round to.
+ *
+ * @usage:  int x = round_up(13, sizeof(__u32)); // 13 -> 16
+ */
+#define __round_mask(val, mult) ((__typeof__(val))((mult)-1))
+#define round_up(val, mult)     ((((val)-1) | __round_mask((val), (mult)))+1)
+
+/**
+ * exat_len() - Return the size in bytes, rounded to a multiple of 4 ((i.e.
+ *         size of __u32), of the buffer needed to hold the exat value of
+ *         size @val_len.
+ */
+static inline __u16 exat_len(size_t val_len)
+{
+	return (__u16)round_up(val_len, sizeof(__u32));
+}
+
+/**
+ * exat_size - return the size of the "struct nvmf_ext_attr"
+ *   needed to hold a value of size @val_len.
+ *
+ * @val_len: This is the length of the data to be copied to the "val"
+ *         field of a "struct nvmf_ext_attr".
+ *
+ * Return: The size in bytes, rounded to a multiple of 4 (i.e. size of
+ *         __u32), of the "struct nvmf_ext_attr" required to hold a string of
+ *         length @val_len.
+ */
+static inline __u16 exat_size(size_t val_len)
+{
+	return (__u16)(SIZEOF_EXT_EXAT_WO_VAL + exat_len(val_len));
+}
+
+/**
+ * exat_ptr_next - Increment @p to the next element in the array. Extended
+ *   attributes are saved to an array of "struct nvmf_ext_attr" where each
+ *   element of the array is of variable size. In order to move to the next
+ *   element in the array one must increment the pointer to the current
+ *   element (@p) by the size of the current element.
+ *
+ * @p: Pointer to an element of an array of "struct nvmf_ext_attr".
+ *
+ * Return: Pointer to the next element in the array.
+ */
+static inline struct nvmf_ext_attr *exat_ptr_next(struct nvmf_ext_attr *p)
+{
+	return (struct nvmf_ext_attr *)
+		((uintptr_t)p + (ptrdiff_t)exat_size(le16toh(p->len)));
+}
+
+/**
+ * streq - Convenience macro to check whether two strings are equal. This
+ * is more readable than "!strcmp(a, b)".
+ *
+ * @a: first string
+ * @b: other string
+ *
+ * Example:
+ *	if (streq(string, ""))
+ *		printf("String is empty!\n");
+ */
+#define streq(a,b) (strcmp((a),(b)) == 0)
+
 #endif /* _LIBNVME_UTIL_H */


### PR DESCRIPTION
This adds support for TP8010. More precisely, it adds the ability to send a new PDU, the Discovery Information Management (DIM) PDU, which is used to perform an explicit registration with Direct Discovery Controllers (DDC) and Central Discovery Controllers (CDC).

The following new APIs are added:
```
nvme_host_set_hostsymname()
nvme_host_get_hostsymname()
nvmf_registration_ctl()
nvmf_is_registration_supported()
```
Note: The Host Symbolic Name is an optional parameter needed for by DIM PDU. When defined, it will be included in the DIM, otherwise it is omitted.

The kernel exposes a new attribute, the Discovery Controller Type (dctype) through the sysfs (kernel patch pending merge). This is used to determine whether explicit registration using the DIM PDU is supported. When the dctype (a previously reserved field of the Identify command response) is set to 1 (DDC) or 2 (CDC), we know that the remote Discovery Controller supports TP8010 and explicit registration. For pre-TP8010 DCs or any other type of controllers (admin, I/O), the dctype is set to 0 indicating that the dctype is not reported, in which case explicit registration will not be attempted.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>