### PR TITLE
Add support for TP8010

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -25,6 +25,10 @@
 		    "description": "NVMe host ID",
 		    "type": "string"
 		},
+		"hostsymname": {
+		    "description": "NVMe host symbolic name",
+		    "type": "string"
+		},
 		"required": [ "hostnqn" ],
 		"subsystems": {
 		    "description": "Array of NVMe subsystem properties",

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -280,8 +280,10 @@ struct nvme_root {
 struct nvme_host {
   %immutable hostnqn;
   %immutable hostid;
+  %immutable hostsymname;
   char *hostnqn;
   char *hostid;
+  char *hostsymname;
   char *dhchap_key;
 };
 
@@ -393,13 +395,27 @@ struct nvme_ns {
 
 %extend nvme_host {
   nvme_host(struct nvme_root *r, const char *hostnqn = NULL,
-	    const char *hostid = NULL) {
-    if (!hostnqn)
-      return nvme_default_host(r);
-    return nvme_lookup_host(r, hostnqn, hostid);
+	    const char *hostid = NULL, const char *hostsymname = NULL) {
+
+    nvme_host_t h = hostnqn ? nvme_lookup_host(r, hostnqn, hostid) : nvme_default_host(r);
+    if (hostsymname)
+        nvme_host_set_hostsymname(h, hostsymname);
+    return h;
   }
   ~nvme_host() {
     nvme_free_host($self);
+  }
+%define SET_SYMNAME_DOCSTRING
+"@brief Set or Clear Host's Symbolic Name
+
+@param hostsymname: A symbolic name, or None to clear the symbolic name.
+@type hostsymname: str|None
+
+@return: None"
+%enddef
+  %feature("autodoc", SET_SYMNAME_DOCSTRING) set_symname;
+  void set_symname(const char *hostsymname) {
+    nvme_host_set_hostsymname($self, hostsymname);
   }
   char *__str__() {
     static char tmp[2048];

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -145,8 +145,10 @@ LIBNVME_1_0 {
 		nvme_host_get_dhchap_key;
 		nvme_host_get_hostid;
 		nvme_host_get_hostnqn;
+		nvme_host_get_hostsymname;
 		nvme_host_get_root;
 		nvme_host_set_dhchap_key;
+		nvme_host_set_hostsymname;
 		nvme_identify;
 		nvme_identify_active_ns_list;
 		nvme_identify_allocated_ns;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -331,6 +331,8 @@ LIBNVME_1_0 {
 		nvmf_subtype_str;
 		nvmf_treq_str;
 		nvmf_trtype_str;
+		nvmf_registration_ctl;
+		nvmf_is_registration_supported;
 	local:
 		*;
 };

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -20,6 +20,7 @@
 #include <dirent.h>
 #include <inttypes.h>
 
+#include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <arpa/inet.h>
@@ -963,4 +964,263 @@ char *nvmf_hostnqn_from_file()
 char *nvmf_hostid_from_file()
 {
 	return nvmf_read_file(nvmf_hostid_file, NVMF_HOSTID_SIZE);
+}
+
+/**
+ * nvmf_get_tel() - Calculate the amount of memory needed for a DIE.
+ *
+ * Each Discovery Information Entry (DIE) must contain at a minimum an
+ * Extended Attribute for the HostID. The Entry may optionally contain an
+ * Extended Attribute for the Symbolic Name.
+ *
+ * @hostsymname - Symbolic name (may be NULL)
+ *
+ * Return: Total Entry Length
+ */
+static __u32 nvmf_get_tel(const char *hostsymname)
+{
+	__u32 tel = SIZEOF_EXT_DIE_WO_EXAT;
+	__u16 len;
+
+	/* Host ID is mandatory */
+	tel += exat_size(sizeof(uuid_t));
+
+	/* Symbolic name is optional */
+	len = hostsymname ? strlen(hostsymname) : 0;
+	if (len)
+		tel += exat_size(len);
+
+	return tel;
+}
+
+/**
+ * nvmf_fill_die() - Fill a Discovery Information Entry.
+ *
+ * @die - Pointer to Discovery Information Entry to be filled
+ * @h - Pointer to the host data structure
+ * @tel - Length of the DIE
+ * @trtype - Transport type
+ * @adrfam - Address family
+ * @reg_addr - Address to register. Setting this to an empty string tells
+ * the DC to infer address from the source address of the socket.
+ * @tsas - Transport Specific Address Subtype for the address being
+ * registered.
+ */
+static void nvmf_fill_die(struct nvmf_ext_die  *die,
+			  struct nvme_host     *h,
+			  __u32                 tel,
+			  __u8                  trtype,
+			  __u8                  adrfam,
+			  const char           *reg_addr,
+			  union nvmf_tsas      *tsas)
+{
+	__u16 numexat = 0;
+	size_t symname_len;
+	struct nvmf_ext_attr *exat;
+
+	die->tel = cpu_to_le32(tel);
+	die->trtype = trtype;
+	die->adrfam = adrfam;
+
+	memcpy(die->nqn, h->hostnqn, MIN(sizeof(die->nqn), strlen(h->hostnqn)));
+	memcpy(die->traddr, reg_addr, MIN(sizeof(die->traddr), strlen(reg_addr)));
+
+	if (tsas)
+		memcpy(&die->tsas, tsas, sizeof(die->tsas));
+
+	/* Extended Attribute for the HostID (mandatory) */
+	numexat++;
+	exat = &die->exat;
+	exat->type = cpu_to_le16(NVME_EXATTYPE_HOSTID);
+	exat->len  = cpu_to_le16(exat_len(sizeof(uuid_t)));
+	uuid_parse(h->hostid, exat->val);
+
+	/* Extended Attribute for the Symbolic Name (optional) */
+	symname_len = h->hostsymname ? strlen(h->hostsymname) : 0;
+	if (symname_len) {
+		__u16 exatlen = exat_len(symname_len);
+
+		numexat++;
+		exat = exat_ptr_next(exat);
+		exat->type = cpu_to_le16(NVME_EXATTYPE_SYMNAME);
+		exat->len  = cpu_to_le16(exatlen);
+		memcpy(exat->val, h->hostsymname, symname_len);
+		/* Per Base specs, ASCII strings must be padded with spaces */
+		memset(&exat->val[symname_len], ' ', exatlen - symname_len);
+	}
+
+	die->numexat = cpu_to_le16(numexat);
+}
+
+/**
+ * nvmf_dim() - Perform explicit registration, deregistration,
+ * or registration-update (specified by @tas) by sending a Discovery
+ * Information Management (DIM) command to the Discovery Controller (DC).
+ *
+ * @ctrl: Host NVMe controller instance maintaining the admin queue used to
+ *   submit the DIM command to the DC.
+ * @tas: Task field of the Command Dword 10 (cdw10). Indicates whether to
+ *   perform a Registration, Deregistration, or Registration-update.
+ * @trtype: Transport type (enum nvmf_trtype - must be NVMF_TRTYPE_TCP)
+ * @adrfam: Address family (enum nvmf_addr_family)
+ * @reg_addr - Address to register. Setting this to an empty string tells
+ *   the DC to infer address from the source address of the socket.
+ * @tsas - Transport Specific Address Subtype for the address being
+ *   registered.
+ * @result - location where to save the command-specific result returned by
+ *   the discovery controller.
+ *
+ * Return:   0: success,
+ *         > 0: NVMe error status code,
+ *         < 0: Linux errno error code
+ */
+static int nvmf_dim(nvme_ctrl_t        c,
+		    enum nvmf_dim_tas  tas,
+		    __u8               trtype,
+		    __u8               adrfam,
+		    const char        *reg_addr,
+		    union nvmf_tsas   *tsas,
+		    __u32             *result)
+{
+	int                   ret;
+	__u32                 tdl;  /* Total Data Length */
+	__u32                 tel;  /* Total Entry Length */
+	struct nvmf_dim_data *dim;  /* Discovery Information Management */
+	struct nvmf_ext_die  *die;  /* Discovery Information Entry */
+	nvme_root_t           r = c->s && c->s->h ? c->s->h->r : NULL;
+
+	struct nvme_dim_args args = {
+		.args_size = sizeof(args),
+		.fd = nvme_ctrl_get_fd(c),
+		.result = result,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.tas = tas
+	};
+
+	if (!c->s) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. subsystem undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (!c->s->h) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. host undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (!c->s->h->hostid) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. hostid undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (!c->s->h->hostnqn) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: failed to perform DIM. hostnqn undefined.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	if (strcmp(c->transport, "tcp")) {
+		nvme_msg(r, LOG_ERR,
+			 "%s: DIM only supported for TCP connections.\n",
+			 c->name);
+		return -EINVAL;
+	}
+
+	/* Register one Discovery Information Entry (DIE) of size TEL */
+	tel = nvmf_get_tel(c->s->h->hostsymname);
+	tdl = SIZEOF_DIM_WO_DIE + tel;
+
+	dim = (struct nvmf_dim_data *)calloc(1, tdl);
+	if (!dim)
+		return -ENOMEM;
+
+	dim->tdl    = cpu_to_le32(tdl);
+	dim->nument = cpu_to_le64(1);    /* only one DIE to register */
+	dim->entfmt = cpu_to_le16(NVME_ENTFMT_EXTENDED);
+	dim->etype  = cpu_to_le16(NVME_REGISTRATION_HOST);
+	dim->ektype = cpu_to_le16(0x5F); /* must be 0x5F per specs */
+
+	memcpy(dim->eid, c->s->h->hostnqn, MIN(sizeof(dim->eid), strlen(c->s->h->hostnqn)));
+
+	ret = get_entity_name(dim->ename, sizeof(dim->ename));
+	if (ret <= 0)
+		nvme_msg(r, LOG_INFO, "%s: Failed to retrieve ENAME. %s.\n",
+			 c->name, strerror(errno));
+
+	ret = get_entity_version(dim->ever, sizeof(dim->ever));
+	if (ret <= 0)
+		nvme_msg(r, LOG_INFO, "%s: Failed to retrieve EVER.\n", c->name);
+
+	die = &dim->die.extended;
+	nvmf_fill_die(die, c->s->h, tel, trtype, adrfam, reg_addr, tsas);
+
+	args.data_len = tdl;
+	args.data = dim;
+	ret = nvme_send_dim_command(&args);
+
+	free(dim);
+
+	return ret == -1 ? -errno : ret;
+}
+
+/**
+ * nvme_get_adrfam() - Get address family for the address we're registering
+ * with the DC.
+ *
+ * We retrieve this info from the socket itself. If we can't get the source
+ * address from the socket, then we'll infer the address family from the
+ * address of the DC since the DC address has the same address family.
+ *
+ * @ctrl: Host NVMe controller instance maintaining the admin queue used to
+ *   submit the DIM command to the DC.
+ *
+ * Return: The address family of the source address associated with the
+ *   socket connected to the DC.
+ */
+static __u8 nvme_get_adrfam(nvme_ctrl_t c)
+{
+	struct sockaddr_storage addr;
+	__u8 adrfam = NVMF_ADDR_FAMILY_IP4;
+	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
+
+	if (!inet_pton_with_scope(r, AF_UNSPEC, c->traddr, c->trsvcid, &addr)) {
+		if (addr.ss_family == AF_INET6)
+			adrfam = NVMF_ADDR_FAMILY_IP6;
+	}
+
+	return adrfam;
+}
+
+bool nvmf_is_registration_supported(nvme_ctrl_t c)
+{
+	if (!c->cntrltype || !c->dctype)
+		nvme_fetch_cntrltype_dctype_from_id(c);
+
+	return !strcmp(c->dctype, "ddc") || !strcmp(c->dctype, "cdc");
+}
+
+int nvmf_registration_ctl(nvme_ctrl_t c, enum nvmf_dim_tas tas, __u32 *result)
+{
+	int ret = NVME_SC_SUCCESS;
+
+	if (nvmf_is_registration_supported(c)) {
+		/* We're registering our source address with the DC. To do
+		 * that, we can simply send an empty string. This tells the DC
+		 * to retrieve the source address from the socket and use that
+		 * as the registration address.
+		 */
+		ret = nvmf_dim(c, NVME_TAS_REGISTER, NVMF_TRTYPE_TCP,
+			       nvme_get_adrfam(c), "", NULL, result);
+	} else {
+		errno = ENOTSUP;
+		ret = -ENOTSUP;
+	}
+
+	return ret;
 }

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -241,4 +241,37 @@ static inline void nvme_chomp(char *s, int l)
 		s[l--] = '\0';
 }
 
+/**
+ * nvmf_is_registration_supported - check whether registration can be
+ * performed.
+ *
+ * Only discovery controllers (DC) that comply with TP8010 support explicit
+ * registration with the DIM PDU. These can be identified by looking at the
+ * value of a dctype in the Identify command response. A value of 1 (DDC)
+ * or 2 (CDC) indicates that the DC supports explicit registration.
+ *
+ * @c: Control object
+ *
+ * Return: true if controller supports explicit registration. false
+ * otherwise.
+ */
+bool nvmf_is_registration_supported(nvme_ctrl_t c);
+
+/**
+ * nvmf_registration_ctl() - Perform registration task with a Discovery
+ * Controller (DC). Three tasks are supported: register, deregister, and
+ * registration update.
+ *
+ * @c: Control object
+ * @tas: Task field of the Command Dword 10 (cdw10). Indicates whether to
+ *   perform a Registration, Deregistration, or Registration-update.
+ * @result: The command-specific result returned by the DC upon command
+ *   completion.
+ *
+ * Return:   0: success,
+ *         > 0: NVMe error status code,
+ *         < 0: Linux errno error code
+ */
+int nvmf_registration_ctl(nvme_ctrl_t c, enum nvmf_dim_tas tas, __u32 *result);
+
 #endif /* _LIBNVME_FABRICS_H */

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -306,6 +306,8 @@ enum nvme_cmd_dword_fields {
 	NVME_ZNS_MGMT_RECV_ZRASF_MASK				= 0xff,
 	NVME_ZNS_MGMT_RECV_ZRAS_FEAT_SHIFT			= 16,
 	NVME_ZNS_MGMT_RECV_ZRAS_FEAT_MASK			= 0x1,
+	NVME_DIM_TAS_SHIFT					= 0,
+	NVME_DIM_TAS_MASK					= 0xF,
 };
 
 enum features {
@@ -1841,4 +1843,24 @@ int nvme_zns_append(struct nvme_zns_append_args *args)
 		return -1;
 	}
 	return nvme_submit_io_passthru64(args->fd, &cmd, args->result);
+}
+
+int nvme_send_dim_command(struct nvme_dim_args *args)
+{
+	__u32 cdw10 = NVME_SET(args->tas, DIM_TAS);
+
+	struct nvme_passthru_cmd  cmd = {
+		.opcode     = nvme_admin_discovery_info_mgmt,
+		.cdw10      = cdw10,
+		.addr       = (__u64)(uintptr_t)args->data,
+		.data_len   = args->data_len,
+		.timeout_ms = args->timeout,
+	};
+
+	if (args->args_size < sizeof(*args)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
 }

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -4346,4 +4346,37 @@ struct nvme_zns_append_args {
  */
 int nvme_zns_append(struct nvme_zns_append_args *args);
 
+/**
+ * nvme_dim_args - Arguments for the Discovery Information Management (DIM)
+ * command
+ *
+ * @args_size:	Length of the structure
+ * @fd:		File descriptor of nvme device
+ * @result:	Set on completion to the command's CQE DWORD 0 controller response.
+ * @timeout:	Timeout in ms
+ * @data_len:	Length of @data
+ * @data:	Pointer to the DIM data
+ * @tas:	Task field of the Command Dword 10 (cdw10)
+ */
+struct nvme_dim_args {
+	int	args_size;
+	int	fd;
+	__u32	*result;
+	__u32	timeout;
+	__u32	data_len;
+	void	*data;
+	__u8	tas;
+} __attribute__((packed, aligned(__alignof__(__u32*))));
+
+/**
+ * nvme_send_dim_command - Send a Discovery Information Management (DIM)
+ * command.
+ *
+ * @args:	&struct nvme_dim_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_send_dim_command(struct nvme_dim_args *args);
+
 #endif /* _LIBNVME_IOCTL_H */

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -146,6 +146,9 @@ static void json_parse_host(nvme_root_t r, struct json_object *host_obj)
 	attr_obj = json_object_object_get(host_obj, "dhchap_key");
 	if (attr_obj)
 		nvme_host_set_dhchap_key(h, json_object_get_string(attr_obj));
+	attr_obj = json_object_object_get(host_obj, "hostsymname");
+	if (attr_obj)
+		nvme_host_set_hostsymname(h, json_object_get_string(attr_obj));
 	subsys_array = json_object_object_get(host_obj, "subsystems");
 	if (!subsys_array)
 		return;
@@ -288,7 +291,7 @@ int json_update_config(nvme_root_t r, const char *config_file)
 	json_root = json_object_new_array();
 	nvme_for_each_host(r, h) {
 		nvme_subsystem_t s;
-		const char *hostnqn, *hostid, *dhchap_key;
+		const char *hostnqn, *hostid, *dhchap_key, *hostsymname;
 
 		host_obj = json_object_new_object();
 		if (!host_obj)
@@ -304,6 +307,10 @@ int json_update_config(nvme_root_t r, const char *config_file)
 		if (dhchap_key)
 			json_object_object_add(host_obj, "dhchap_key",
 					       json_object_new_string(dhchap_key));
+		hostsymname = nvme_host_get_hostsymname(h);
+		if (hostsymname)
+			json_object_object_add(host_obj, "hostsymname",
+					       json_object_new_string(hostsymname));
 		subsys_array = json_object_new_array();
 		nvme_for_each_subsystem(h, s) {
 			json_update_subsys(subsys_array, s);

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -80,6 +80,8 @@ struct nvme_ctrl {
 	char *traddr;
 	char *trsvcid;
 	char *dhchap_key;
+	char *cntrltype;
+	char *dctype;
 	bool discovery_ctrl;
 	bool discovered;
 	bool persistent;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -109,6 +109,7 @@ struct nvme_host {
 	char *hostnqn;
 	char *hostid;
 	char *dhchap_key;
+	char *hostsymname;
 };
 
 struct nvme_root {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -64,6 +64,9 @@ nvme_host_t nvme_default_host(nvme_root_t r)
 	hostid = nvmf_hostid_from_file();
 
 	h = nvme_lookup_host(r, hostnqn, hostid);
+
+	nvme_host_set_hostsymname(h, NULL);
+
 	default_host = h;
 	free(hostnqn);
 	if (hostid)
@@ -209,6 +212,27 @@ const char *nvme_host_get_hostnqn(nvme_host_t h)
 const char *nvme_host_get_hostid(nvme_host_t h)
 {
 	return h->hostid;
+}
+
+const char *nvme_host_get_hostsymname(nvme_host_t h)
+{
+	return h->hostsymname;
+}
+
+/**
+ * nvme_host_set_hostsymname - Set the host's symbolic name
+ *
+ * @h - The host
+ * @hostsymname - The Symbolic Name
+ */
+void nvme_host_set_hostsymname(nvme_host_t h, const char *hostsymname)
+{
+	if (h->hostsymname) {
+		free(h->hostsymname);
+		h->hostsymname = NULL;
+	}
+	if (hostsymname)
+		h->hostsymname = strdup(hostsymname);
 }
 
 const char *nvme_host_get_dhchap_key(nvme_host_t h)
@@ -390,6 +414,7 @@ static void __nvme_free_host(struct nvme_host *h)
 		free(h->hostid);
 	if (h->dhchap_key)
 		free(h->dhchap_key);
+	nvme_host_set_hostsymname(h, NULL);
 	h->r->modified = true;
 	free(h);
 }

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1168,4 +1168,23 @@ char *nvme_get_path_attr(nvme_path_t p, const char *attr);
  */
 nvme_ns_t nvme_scan_namespace(const char *name);
 
+/**
+ * nvme_host_get_hostsymname() - Get the host's symbolic name
+ *
+ * @h: Host for which the symbolic name should be returned.
+ *
+ * Return: The symbolic name or NULL if a symbolic name hasn't been
+ * configure.
+ */
+const char *nvme_host_get_hostsymname(nvme_host_t h);
+
+/**
+ * nvme_host_set_hostsymname() - Set the host's symbolic name
+ *
+ * @h: Host for which the symbolic name should be set.
+ * @hostsymname: Symbolic name
+ */
+void nvme_host_set_hostsymname(nvme_host_t h, const char *hostsymname);
+
+
 #endif /* _LIBNVME_TREE_H */

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1186,5 +1186,17 @@ const char *nvme_host_get_hostsymname(nvme_host_t h);
  */
 void nvme_host_set_hostsymname(nvme_host_t h, const char *hostsymname);
 
+/**
+ * nvme_fetch_attrs_from_id() - Retrieve the cntrltype and dctype from
+ * identify command response.
+ *
+ * On legacy kernels the cntrltype and dctype are not exposed through the
+ * sysfs. We must get them directly from the controller by performing an
+ * identify command.
+ *
+ * @c The controller
+ */
+void nvme_fetch_cntrltype_dctype_from_id(nvme_ctrl_t c);
+
 
 #endif /* _LIBNVME_TREE_H */

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -909,7 +909,10 @@ struct nvme_id_psd {
  * 	       that a host is allowed to place in a capsule. A value of 0h
  * 	       indicates no limit.
  * @ofcs:      Optional Fabric Commands Support, see &enum nvme_id_ctrl_ofcs.
- * @rsvd1806:  Reserved
+ * @dctype:    Discovery Controller Type (DCTYPE). This field indicates what
+ *             type of Discovery controller the controller is (see enum
+ *             nvme_id_ctrl_dctype)
+ * @rsvd1807:  Reserved
  * @psd:       Power State Descriptors, see &struct nvme_id_psd.
  * @vs:	       Vendor Specific
  */
@@ -1007,7 +1010,8 @@ struct nvme_id_ctrl {
 	__u8			fcatt;
 	__u8			msdbd;
 	__le16			ofcs;
-	__u8			rsvd1806[242];
+	__u8			dctype;
+	__u8			rsvd1807[241];
 
 	struct nvme_id_psd	psd[32];
 	__u8			vs[1024];
@@ -1117,6 +1121,18 @@ enum nvme_id_ctrl_cntrltype {
 	NVME_CTRL_CNTRLTYPE_IO			= 1,
 	NVME_CTRL_CNTRLTYPE_DISCOVERY		= 2,
 	NVME_CTRL_CNTRLTYPE_ADMIN		= 3,
+};
+
+/**
+ * enum nvme_id_ctrl_cntrltype - Discovery Controller types
+ * @NVME_CTRL_DCTYPE_NOT_REPORTED: Not reported (I/O, Admin, and pre-TP8010)
+ * @NVME_CTRL_DCTYPE_DDC: Direct Discovery controller
+ * @NVME_CTRL_DCTYPE_CDC: Central Discovery controller
+ */
+enum nvme_id_ctrl_dctype {
+	NVME_CTRL_DCTYPE_NOT_REPORTED	= 0,
+	NVME_CTRL_DCTYPE_DDC		= 1,
+	NVME_CTRL_DCTYPE_CDC		= 2,
 };
 
 /**

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -11,9 +11,11 @@
 #include <string.h>
 #include <errno.h>
 
+#include <sys/param.h>
 #include <sys/types.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <unistd.h>
 
 #include <ccan/endian/endian.h>
 
@@ -241,6 +243,12 @@ static const char * const cmd_spec_status[] = {
 	[NVME_SC_IOCS_COMBINATION_REJECTED]	  = "The I/O command set combination is rejected",
 	[NVME_SC_INVALID_IOCS]			  = "The I/O command set is invalid",
 	[NVME_SC_ID_UNAVAILABLE]		  = "Identifier Unavailable: The number of Endurance Groups or NVM Sets supported has been exceeded",
+	[NVME_SC_INVALID_DISCOVERY_INFO]	  = "Discovery Info Entry not applicable to selected entity",
+	[NVME_SC_ZONING_DATA_STRUCT_LOCKED]       = "The requested Zoning data structure is locked on the CDC",
+	[NVME_SC_ZONING_DATA_STRUCT_NOTFND]       = "The requested Zoning data structure does not exist on the CDC",
+	[NVME_SC_INSUFFICIENT_DISC_RES] 	  = "Discovery Info entries exceed Discovery Controller's capacity",
+	[NVME_SC_REQSTD_FUNCTION_DISABLED]        = "Fabric Zoning is not enabled on the CDC",
+	[NVME_SC_ZONEGRP_ORIGINATOR_INVLD]        = "The NQN contained in the ZoneGroup Originator field does not match the Host NQN used by the DDC to connect to the CDC",
 };
 
 static const char * const nvm_status[] = {
@@ -549,4 +557,183 @@ char *hostname2traddr(struct nvme_root *r, const char *traddr)
 free_addrinfo:
 	freeaddrinfo(host_info);
 	return ret_traddr;
+}
+
+char* startswith(const char *s, const char *prefix)
+{
+	size_t l;
+
+	l = strlen(prefix);
+	if (!strncmp(s, prefix, l))
+		return (char *)s + l;
+
+	return NULL;
+}
+
+char* kv_strip(char *kv)
+{
+	kv[strcspn(kv, "\n\r")] = '\0';
+
+	kv += strspn(kv, " \t\n\r");     /* Remove leading newline and spaces */
+	if (*kv == '#' || *kv == '\0') { /* Skip comments and empty lines */
+		*kv = '\0';
+		return kv;
+	}
+	kv[strcspn(kv, "\n\r")] = '\0';  /* Remove trailing newline chars */
+
+	/* Delete trailing comments (including spaces/tabs that precede the #)*/
+	char *s = &kv[strcspn(kv, "#")];
+	*s-- = '\0';
+	while ((s >= kv) && ((*s == ' ') || (*s == '\t'))) {
+		*s-- = '\0';
+	}
+
+	return kv;
+}
+
+char* kv_keymatch(const char *kv, const char *key)
+{
+	char *value;
+
+	value = startswith(kv, key);
+	if (value) {
+		switch (*value) {
+		case ' ':  /* Make sure */
+		case '\t': /* key is a whole word. */
+		case '=':  /* I.e. it should be followed by spaces, tabs, or a equal sign. */
+			value += strspn(value, " \t="); /* Skip leading spaces, tabs, and equal sign (=) */
+			return value;
+		default: ;
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * read_file - read contents of file into @buffer.
+ *
+ * The @buffer is not NUL-terminated. It's OK if the file doesn't exist or
+ * empty. In this case nothing gets written to @buffer and 0 is returned as
+ * the number of characters read.
+ *
+ * @fname:  File name
+ * @buffer: Where to save file's contents
+ * @bufsz:  Size of @buffer. On success, @bufsz gets decremented by the
+ *          number of characters that were writtent to @buffer.
+ *
+ * Return: The number of characters read. If the file cannot be opened or
+ * nothing is read from the file, then this function returns 0.
+ */
+static size_t read_file(const char * fname, char *buffer, size_t *bufsz)
+{
+	char   *p;
+	FILE   *file;
+	size_t len;
+
+	file = fopen(fname, "re");
+	if (!file)
+		return 0;
+
+	p = fgets(buffer, *bufsz, file);
+	fclose(file);
+
+	if (!p)
+		return 0;
+
+	len = strcspn(buffer, " \t\n\r"); /* Strip unwanted trailing chars */
+	*bufsz -= len;
+
+	return len;
+}
+
+static size_t copy_value(char * buf, size_t buflen, const char * value)
+{
+	size_t val_len;
+
+	memset(buf, 0, buflen);
+	if (value[0] == '"') value++;   /* Remove leading " */
+	val_len = strcspn(value, "\""); /* Remove trailing " */
+	memcpy(buf, value, MIN(val_len, buflen-1));
+
+	return val_len;
+}
+
+size_t get_entity_name(char *buffer, size_t bufsz)
+{
+	size_t len = !gethostname(buffer, bufsz) ? strlen(buffer) : 0;
+
+	/* Fill the rest of buffer with zeros */
+	memset(&buffer[len], '\0', bufsz-len);
+
+	return len;
+}
+
+size_t get_entity_version(char *buffer, size_t bufsz)
+{
+	FILE    *file;
+	size_t  num_bytes = 0;
+
+	/* /proc/sys/kernel/ostype typically contains the string "Linux" */
+	num_bytes += read_file("/proc/sys/kernel/ostype", &buffer[num_bytes], &bufsz);
+
+	/* /proc/sys/kernel/osrelease contains the Linux
+	 * version (e.g. 5.8.0-63-generic)
+	 */
+	buffer[num_bytes++] = ' '; /* Append a space */
+	num_bytes += read_file("/proc/sys/kernel/osrelease", &buffer[num_bytes], &bufsz);
+
+	/* /etc/os-release contains Key-Value pairs. We only care about the key
+	 * PRETTY_NAME, which contains the Distro's version. For example:
+	 * "SUSE Linux Enterprise Server 15 SP4", "Ubuntu 20.04.3 LTS", or
+	 * "Fedora Linux 35 (Server Edition)"
+	 */
+	file = fopen("/etc/os-release", "re");
+	if (file) {
+		char    name[64] = {0};
+		size_t  name_len = 0;
+		char    ver_id[64] = {0};
+		size_t  ver_id_len = 0;
+		char    line[LINE_MAX];
+		char    *p;
+		char    *s;
+
+		/* Read key-value pairs one line at a time */
+		while ((!name_len || !ver_id_len) && (p = fgets(line, sizeof(line), file)) != NULL) {
+			/* Clean up string by removing leading/trailing blanks
+			 * and new line characters. Also eliminate trailing
+			 * comments, if any.
+			 */
+			p = kv_strip(p);
+			if (*p == '\0') continue; /* Empty string? */
+
+			if ((s = kv_keymatch(p, "NAME")) != NULL)
+				name_len = copy_value(name, sizeof(name), s);
+
+			if ((s = kv_keymatch(p, "VERSION_ID")) != NULL)
+				ver_id_len = copy_value(ver_id, sizeof(ver_id), s);
+		}
+		fclose(file);
+
+		if (name_len) {
+			buffer[num_bytes++] = ' '; /* Append a space */
+			name_len = MIN(name_len, bufsz);
+			memcpy(&buffer[num_bytes], name, name_len);
+			bufsz -= name_len;
+			num_bytes += name_len;
+		}
+
+		if (ver_id_len) {
+			buffer[num_bytes++] = ' '; /* Append a space */
+			ver_id_len = MIN(ver_id_len, bufsz);
+			memcpy(&buffer[num_bytes], ver_id, ver_id_len);
+			bufsz -= ver_id_len;
+			num_bytes += ver_id_len;
+		}
+	}
+
+	/* Fill the rest of buffer with zeros */
+	memset(&buffer[num_bytes], '\0', bufsz);
+
+	return num_bytes;
 }

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -10,6 +10,7 @@
 #define _LIBNVME_UTIL_H
 
 #include "types.h"
+#include <ccan/endian/endian.h>
 
 /**
  * DOC: util.h
@@ -424,4 +425,128 @@ static inline void nvme_id_ns_flbas_to_lbaf_inuse(__u8 flbas, __u8 *lbaf_inuse)
 struct nvme_root;
 
 char *hostname2traddr(struct nvme_root *r, const char *traddr);
+
+/**
+ * get_entity_name - Get Entity Name (ENAME).
+ *
+ * Per TP8010, ENAME is defined as the name associated with the host (i.e.
+ * hostname).
+ *
+ * @buffer: The buffer where the ENAME will be saved as an ASCII string.
+ * @bufsz:  The size of @buffer.
+ *
+ * Return:: Number of characters copied to @buffer.
+ */
+size_t get_entity_name(char *buffer, size_t bufsz);
+
+/**
+ * get_entity_version - Get Entity Version (EVER).
+ *
+ * EVER is defined as the operating system name and version as an ASCII
+ * string. This function reads different files from the file system and
+ * builds a string as follows: [os type] [os release] [distro release]
+ *
+ *     E.g. "Linux 5.17.0-rc1 SLES 15.4"
+ *
+ * @buffer: The buffer where the EVER will be saved as an ASCII string.
+ * @bufsz:  The size of @buffer.
+ *
+ * Return:: Number of characters copied to @buffer.
+ */
+size_t get_entity_version(char *buffer, size_t bufsz);
+
+/**
+ * kv_strip - Strip leading/trailing blanks as well as trailing comments
+ * from the Key=Value string pointed to by @kv.
+ *
+ * @kv: The key-value string to strip
+ *
+ * Return: A pointer to the stripped string. Note that the original string,
+ *         @kv, gets modified.
+ */
+char* kv_strip(char *kv);
+
+/**
+ * kv_keymatch - Look for @key in the Key=Value pair pointed to by @k and
+ * return a pointer to the Value if @key is found.
+ *
+ * Check if @kv starts with @key. If it does then make sure that we have a
+ * whole-word match on the @key, and if we do, return a pointer to the
+ * first character of value (i.e. skip leading spaces, tabs, and equal
+ * sign)
+ *
+ * @kv: The key=value string to search for the presence of @key
+ * @key: The key to look for
+ *
+ * Return: A pointer to the first character of "value" if a match is found.
+ * NULL otherwise.
+ */
+char* kv_keymatch(const char *kv, const char *key);
+
+/**
+ * startswith - Checks that a string starts with a given prefix.
+ *
+ * @s: The string to check
+ * @prefix: A string that @s could be starting with
+ *
+ * Return: If @s starts with @prefix, then return a pointer within @s at
+ * the first character after the matched @prefix. NULL otherwise.
+ */
+char* startswith(const char *s, const char *prefix);
+
+/**
+ * round_up - Round a value @val to the next multiple specified by @mult.
+ *
+ * @val: Value to round
+ * @mult: Multiple to round to.
+ *
+ * @usage:  int x = round_up(13, sizeof(__u32)); // 13 -> 16
+ */
+#define __round_mask(val, mult) ((__typeof__(val))((mult)-1))
+#define round_up(val, mult)     ((((val)-1) | __round_mask((val), (mult)))+1)
+
+/**
+ * exat_len() - Return the size in bytes, rounded to a multiple of 4
+ * (e.g., size of __u32), of the buffer needed to hold the exat value of
+ * size @val_len.
+ */
+static inline __u16 exat_len(size_t val_len)
+{
+	return (__u16)round_up(val_len, sizeof(__u32));
+}
+
+/**
+ * exat_size - return the size of the "struct nvmf_ext_attr" needed to hold
+ * a value of size @val_len.
+ *
+ * @val_len: This is the length of the data to be copied to the "val"
+ *         field of a "struct nvmf_ext_attr".
+ *
+ * Return: The size in bytes, rounded to a multiple of 4 (i.e. size of
+ *         __u32), of the "struct nvmf_ext_attr" required to hold a string of
+ *         length @val_len.
+ */
+static inline __u16 exat_size(size_t val_len)
+{
+	return (__u16)(SIZEOF_EXT_EXAT_WO_VAL + exat_len(val_len));
+}
+
+/**
+ * exat_ptr_next - Increment @p to the next element in the array.
+ *
+ * Extended attributes are saved to an array of "struct nvmf_ext_attr"
+ * where each element of the array is of variable size. In order to move to
+ * the next element in the array one must increment the pointer to the
+ * current element (@p) by the size of the current element.
+ *
+ * @p: Pointer to an element of an array of "struct nvmf_ext_attr".
+ *
+ * Return: Pointer to the next element in the array.
+ */
+static inline struct nvmf_ext_attr *exat_ptr_next(struct nvmf_ext_attr *p)
+{
+	return (struct nvmf_ext_attr *)
+		((uintptr_t)p + (ptrdiff_t)exat_size(le16_to_cpu(p->len)));
+}
+
 #endif /* _LIBNVME_UTIL_H */


### PR DESCRIPTION
This adds support for TP8010. More precisely, it adds the ability to send a new PDU, the Discovery Information Management (DIM) PDU, which is used to perform an explicit registration with Direct Discovery Controllers (DDC) and Central Discovery Controllers (CDC).

This pull request is composed of 3 commits:

1. Add the symbolic name
2. Add the cntrltype and dctype to the controller structure. 
3. Add support for the DIM command.

The following new APIs are added:
```
nvme_host_set_hostsymname()
nvme_host_get_hostsymname()
nvmf_registration_ctl()
nvmf_is_registration_supported()
```

Note: The Host Symbolic Name is an optional parameter needed for by DIM PDU. When defined, it will be included in the DIM, otherwise it is omitted.

The kernel exposes a new attribute, the Discovery Controller Type (dctype) through the sysfs (kernel patch was applied to Linux-nvme repo earlier today). This is used to determine whether explicit registration using the DIM PDU is supported. When the dctype (a previously reserved field of the Identify command response) is set to 1 (DDC) or 2 (CDC), we know that the remote Discovery Controller supports TP8010 and explicit registration. For pre-TP8010 DCs or any other type of controllers (admin, I/O), the dctype is set to 0 indicating that the dctype is not reported, in which case explicit registration will not be attempted.

Signed-off-by: Martin Belanger [martin.belanger@dell.com](mailto:martin.belanger@dell.com)