### PR TITLE
log: Allow nvme_msg usage with invalid root pointer

### DIFF
--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -53,27 +53,32 @@ __nvme_msg(nvme_root_t r, int lvl,
 	};
 	char *header __cleanup__(cleanup_charp) = NULL;
 	char *message __cleanup__(cleanup_charp) = NULL;
-	int idx;
+	int idx = 0;
 
-	if (r->log_timestamp) {
+	if (r && lvl > r->log_level)
+		return;
+
+	if (r && r->log_timestamp) {
 		struct timespec now;
 
 		clock_gettime(LOG_CLOCK, &now);
 		snprintf(timebuf, sizeof(timebuf), "%6ld.%06ld",
 			 (long)now.tv_sec, now.tv_nsec / 1000);
+		idx |= 1 << 2;
 	} else
 		*timebuf = '\0';
 
-	if (r->log_pid)
+	if (r && r->log_pid) {
 		snprintf(pidbuf, sizeof(pidbuf), "%ld", (long)getpid());
-	else
+		idx |= 1 << 1;
+	} else
 		*pidbuf = '\0';
 
-	idx = ((r->log_timestamp ? 1 : 0) << 2) |
-		((r->log_pid ? 1 : 0) << 1) | (func ? 1 : 0);
+	if (func)
+		idx |= 1 << 0;
 
-	if (asprintf(&header, formats[idx], timebuf, pidbuf, func ? func : "")
-	    == -1)
+	if (asprintf(&header, formats[idx],
+		     timebuf, pidbuf, func ? func : "") == -1)
 		header = NULL;
 
 	va_start(ap, format);
@@ -81,10 +86,9 @@ __nvme_msg(nvme_root_t r, int lvl,
 		message = NULL;
 	va_end(ap);
 
-	if (lvl <= r->log_level)
-		fprintf(fp, "%s%s", header ? header : "<error>",
-			message ? message : "<error>");
-
+	fprintf(fp, "%s%s",
+		header ? header : "<error>",
+		message ? message : "<error>");
 }
 
 void nvme_init_logging(nvme_root_t r, int lvl, bool log_pid, bool log_tstamp)


### PR DESCRIPTION
24ac082f481d ("Add 'nvme_root_t' argument to nvme_msg()") and
19b12831a9ec ("Move global logging variables into nvme_root_t") moved
the logging controller knobs into the root object. In case the pointer
is invalid we should not try to use it. Instead just bailing out just
log the line.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #244 