### PR TITLE
SWIG: remove explicit invocation

### DIFF
--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -17,24 +17,18 @@ else
 endif
 
 if have_python_support
-    pymod_swig = custom_target(
-        'nvme.py',
-        input:   ['nvme.i'],
-        output:  ['nvme.py', 'nvme_wrap.c'],
-        command: [swig, '-python', '-py3', '-o', '@OUTPUT1@', '@INPUT0@'],
-        install: true,
-        install_dir: [python3.get_install_dir(pure: false, subdir: 'libnvme'), false],
-    )
-
     pynvme_clib = python3.extension_module(
         '_nvme',
-        pymod_swig[1],
         dependencies : py3_dep,
         include_directories: [incdir, internal_incdir],
         link_with: [libnvme, libccan],
         install: true,
         subdir: 'libnvme',
     )
+
+    # python distutils not include the SWIG generated module
+    # build_py (which copies python sources to the build directory) comes before build_ext
+    python3.install_sources(['nvme.py', ], pure:false, subdir:'libnvme')
 
     # Little hack to copy file __init__.py to the build directory. 
     # This is needed to create the proper directory layout to run the tests.

--- a/libnvme/setup.py
+++ b/libnvme/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 libnvme_module = Extension(
     '_nvme',
-    sources = ['nvme_wrap.c'],
+    sources = ['nvme.i'],
     libraries = ['nvme', 'json-c', 'uuid'],
     library_dirs = ['../src'],
     include_dirs = ['../ccan', '../src', '../src/nvme'],


### PR DESCRIPTION
python distutils handles swig already, so no need to
explicitely define it in meson build

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>