### PR TITLE
fabrics: add default port number for NVMe/TCP I/O controllers

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -922,8 +922,13 @@ void nvme_free_ctrl(nvme_ctrl_t c)
 static void discovery_trsvcid(nvme_ctrl_t c)
 {
 	if (!strcmp(c->transport, "tcp")) {
-		/* Default port for NVMe/TCP discovery controllers */
-		c->trsvcid = strdup(__stringify(NVME_DISC_IP_PORT));
+		if (c->discovery_ctrl) {
+			/* Default port for NVMe/TCP discovery controllers */
+			c->trsvcid = strdup(__stringify(NVME_DISC_IP_PORT));
+		} else {
+			/* Default port for NVMe/TCP io controllers */
+			c->trsvcid = __stringify(NVME_RDMA_IP_PORT);
+		}
 	} else if (!strcmp(c->transport, "rdma")) {
 		/* Default port for NVMe/RDMA controllers */
 		c->trsvcid = strdup(__stringify(NVME_RDMA_IP_PORT));


### PR DESCRIPTION
As per section 7.4.9.3 "Transport Service Identifier" of the NVMe over
Fabrics 1.1 specification, the default IANA port number for a NVMe/TCP
discovery controller is 8009. But at the same time, it also clearly
states that NVMe/TCP I/O controllers should not use TCP port number
8009, but may instead use 4420 as the default here.

So make sure to fill these values appropriately, and pass it down.

Signed-off-by: Martin George <marting@netapp.com>
[dwagner: backport from monolithic branch]
Signed-off-by: Daniel Wagner <dwagner@suse.de>