### PR TITLE
Move ccan definitions out of public headers.

### DIFF
--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -759,3 +759,9 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 
 	return num_bytes;
 }
+
+struct nvmf_ext_attr *nvmf_exat_ptr_next(struct nvmf_ext_attr *p)
+{
+	return (struct nvmf_ext_attr *)
+		((uintptr_t)p + (ptrdiff_t)nvmf_exat_size(le16_to_cpu(p->exatlen)));
+}

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -10,7 +10,6 @@
 #define _LIBNVME_UTIL_H
 
 #include "types.h"
-#include <ccan/endian/endian.h>
 
 /**
  * DOC: util.h
@@ -548,10 +547,6 @@ static inline __u16 nvmf_exat_size(size_t val_len)
  *
  * Return: Pointer to the next element in the array.
  */
-static inline struct nvmf_ext_attr *nvmf_exat_ptr_next(struct nvmf_ext_attr *p)
-{
-	return (struct nvmf_ext_attr *)
-		((uintptr_t)p + (ptrdiff_t)nvmf_exat_size(le16_to_cpu(p->exatlen)));
-}
+struct nvmf_ext_attr *nvmf_exat_ptr_next(struct nvmf_ext_attr *p);
 
 #endif /* _LIBNVME_UTIL_H */


### PR DESCRIPTION
This is to resolve issue: https://github.com/linux-nvme/libnvme/issues/260

Signed-off-by: Martin Belanger <martin.belanger@dell.com>