### PR TITLE
util: Add status code values in geneic status to errono conversion

### DIFF
--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -35,6 +35,8 @@ static inline __u8 nvme_generic_status_to_errno(__u16 status)
 	case NVME_SC_SGL_INVALID_METADATA:
 	case NVME_SC_SGL_INVALID_TYPE:
 	case NVME_SC_SGL_INVALID_OFFSET:
+	case NVME_SC_PRP_INVALID_OFFSET:
+	case NVME_SC_CMB_INVALID_USE:
 		return EINVAL;
 	case NVME_SC_CMDID_CONFLICT:
 		return EADDRINUSE;


### PR DESCRIPTION
updated nvme_generic_status_to_errno function with NVME_SC_PRP_INVALID_OFFSET, NVME_SC_CMB_INVALID_USE status code values in order to return EINVAL.

Signed-off-by: Arunpandian J <apj.arun@samsung.com>