### PR TITLE
tree: Ignore traddr case in nvme_lookup_ctrl()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1029,7 +1029,7 @@ nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 		if (strcmp(c->transport, transport))
 			continue;
 		if (traddr && c->traddr &&
-		    strcmp(c->traddr, traddr))
+		    strcasecmp(c->traddr, traddr))
 			continue;
 		if (host_traddr && c->cfg.host_traddr &&
 		    strcmp(c->cfg.host_traddr, host_traddr))


### PR DESCRIPTION
Some FC discovery controllers return traddr strings with upper case
hexadecimal. There was is no requirement in the NVME-FC specification
that it be upper or lower case. Switch to strcasecmp for case
insentive traddr comparison.

Based on nvme-cli change 1264c6323937 ("nvme-cli: Make connect-all
matching be case insensitive")

Signed-off-by: Daniel Wagner <dwagner@suse.de>