### PR TITLE
openssl: update to patch-3 to fix installation issue

### DIFF
--- a/subprojects/openssl.wrap
+++ b/subprojects/openssl.wrap
@@ -3,9 +3,9 @@ directory = openssl-1.1.1l
 source_url = https://www.openssl.org/source/openssl-1.1.1l.tar.gz
 source_filename = openssl-1.1.1l.tar.gz
 source_hash = 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
-patch_filename = openssl_1.1.1l-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/openssl_1.1.1l-2/get_patch
-patch_hash = 852521fb016fa2deee8ebf9ffeeee0292c6de86a03c775cf72ac04e86f9f177e
+patch_filename = openssl_1.1.1l-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openssl_1.1.1l-3/get_patch
+patch_hash = a0cb8285cda3ae0e1898b4e88427c19bf245184259f41395010182655f9f8ce6
 
 [provide]
 libcrypto = libcrypto_dep


### PR DESCRIPTION
Fixes #268

Patch taken from https://mesonbuild.com/Wrapdb-projects.html
Wrap file used https://wrapdb.mesonbuild.com/v2/openssl_1.1.1l-3/openssl.wrap
Fixed by https://github.com/mesonbuild/wrapdb/pull/322