### PR TITLE
CI: add python wheel build in addition to source package

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,47 +6,62 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
+name: Build and upload to PyPI
 
 on:
-  release:
-    types: [published]
   push:
     branches: [ master ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ master ]
-
   workflow_dispatch:
 
 jobs:
-  deploy:
-
+  build_wheels:
+    name: Build wheels manylinux
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        sudo apt-get install libjson-c-dev meson
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build --sdist
-    - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-    # - name: Publish package to PyPI
-    #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+        env:
+            CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
+            CIBW_SKIP: "*-musllinux_*"
+            CIBW_BEFORE_BUILD_LINUX: yum install -y openssl-devel libuuid-devel json-c-devel
+            CIBW_BUILD_VERBOSITY: 1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+          retention-days: 5
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+          retention-days: 5
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
When using source distribution,
python package will be compiled during pip install.

Wheels make the end-to-end installation of Python packages faster:
- wheels are typically smaller in size than source distributions
- pip fetches a prebuilt wheel and avoids the intermediate step of building

So why cibuildwheel and manylinux?

See https://github.com/pypa/manylinux and https://github.com/pypa/cibuildwheel

The goal of the manylinux project is to provide a convenient way to distribute binary Python extensions as wheels on Linux

See https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml

Skipping musllinux and auditwheel repair.
Skipping MacOS and Windows for now.

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>