### PR TITLE
tree: add nvme_ctrl_get_ana_state()

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -12,6 +12,7 @@ LIBNVME_1_0 {
 		nvme_ctrl_first_ns;
 		nvme_ctrl_first_path;
 		nvme_ctrl_get_address;
+		nvme_ctrl_get_ana_state;
 		nvme_ctrl_get_dhchap_key;
 		nvme_ctrl_get_discovery_ctrl;
 		nvme_ctrl_get_fd;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -768,6 +768,19 @@ const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c)
 	return c->cfg.host_iface;
 }
 
+const char *nvme_ctrl_get_ana_state(nvme_ctrl_t c, __u32 nsid)
+{
+	if (nsid != NVME_NSID_ALL) {
+		nvme_path_t p;
+
+		nvme_ctrl_for_each_path(c, p) {
+			if (p->n && p->n->nsid == nsid)
+				return p->ana_state;
+		}
+	}
+	return NULL;
+}
+
 struct nvme_fabrics_config *nvme_ctrl_get_config(nvme_ctrl_t c)
 {
 	return &c->cfg;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -837,6 +837,15 @@ const char *nvme_ctrl_get_host_traddr(nvme_ctrl_t c);
 const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c);
 
 /**
+ * nvme_ctrl_get_ana_state() - ANA state of a controller path
+ * @c:		Constroller instance
+ * @nsid:	Namespace ID to evaluate
+ *
+ * Return: ANA state of the namespace @nsid on controller @c.
+ */
+const char *nvme_ctrl_get_ana_state(nvme_ctrl_t c, __u32 nsid);
+
+/**
  * nvme_ctrl_get_dhchap_key() - Return controller key
  * @c:	Controller for which the key should be set
  *


### PR DESCRIPTION
Add a function to return the ANA state of a namespace on a given
controller.

Signed-off-by: Hannes Reinecke <hare@suse.de>