### PR TITLE
Version: add RC (release candidate) to the meson version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -52,7 +52,7 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    #if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -62,6 +62,7 @@ jobs:
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verbose: true
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@
 project(
     'libnvme', ['c', 'cpp'],
     meson_version: '>= 0.47.0',
-    version: '1.0',
+    version: '1.0rc7',
     license: 'LGPLv2+',
     default_options: [
         'c_std=gnu99',
@@ -18,7 +18,7 @@ project(
     ]
 )
 
-library_version = meson.project_version() + '.0'
+library_version = '1.0.0'
 
 ################################################################################
 cc = meson.get_compiler('c')


### PR DESCRIPTION
This is to help uploading python package to pip

see discussion in https://github.com/linux-nvme/libnvme/issues/95 and https://github.com/linux-nvme/libnvme/issues/287

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>