### PR TITLE
rpm: add makefile rule for rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ install dist: ${BUILD-DIR}
 .PHONY: test
 test: ${BUILD-DIR}
 	ninja -C ${BUILD-DIR} $@
+
+.PHONY: rpm
+rpm: dist
+	rpmbuild -ba ${BUILD-DIR}/libnvme.spec


### PR DESCRIPTION
see https://linux.die.net/man/8/rpmbuild
```
-ba
Build binary and source packages (after doing the %prep, %build, and %install stages).
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>