### PR TITLE
fabrics: Allow to change sysconfdir for hostnqn and hostid file

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -35,23 +35,28 @@ if want_docs != 'false'
     list_man_pages = find_program('list-man-pages.sh')
     if want_docs_build
       foreach apif : api_files
-        afile = files('../src/nvme/' + apif)
-        c = run_command(list_man_pages, afile)
-        man_pages = c.stdout().split()
-        foreach page : man_pages
-          custom_target(
-            page.underscorify() + '_man',
-            input: afile,
-            output: page + '.2',
-            capture: true,
-            command: [kernel_doc,
-                      '-module', 'libnvme',
-                      '-man',
-                      '-function',
-                      page,
-                      afile],
-            install: true,
-            install_dir: mandir)
+        foreach file : files('../src/nvme/' + apif)
+          subst = configure_file(
+              input: file,
+              output: '@BASENAME@.msubst',
+              configuration: conf)
+          c = run_command(list_man_pages, subst)
+          man_pages = c.stdout().split()
+          foreach page : man_pages
+            custom_target(
+              page.underscorify() + '_man',
+              input: subst,
+              output: page + '.2',
+              capture: true,
+              command: [kernel_doc,
+                        '-module', 'libnvme',
+                        '-man',
+                        '-function',
+                        page,
+                        subst],
+              install: true,
+              install_dir: mandir)
+          endforeach
         endforeach
       endforeach
     else
@@ -69,9 +74,13 @@ if want_docs != 'false'
       rsts = []
       foreach apif : api_files
         afile = files('../src/nvme/' + apif)
+        subst = configure_file(
+            input: afile,
+            output: '@BASENAME@.hsubst',
+            configuration: conf)
         rst = custom_target(
           apif.underscorify() + '_rst',
-          input: afile,
+          input: subst,
           output: '@BASENAME@._rst',
           capture: true,
           command: [kernel_doc,

--- a/meson.build
+++ b/meson.build
@@ -29,11 +29,14 @@ includedir = join_paths(prefixdir, get_option('includedir'))
 datadir    = join_paths(prefixdir, get_option('datadir'))
 mandir     = join_paths(prefixdir, get_option('mandir'))
 bindir     = join_paths(prefixdir, get_option('bindir'))
+sysconfdir = join_paths(prefixdir, get_option('sysconfdir'))
 
 pkgconfiglibdir = get_option('pkgconfiglibdir') == '' ? join_paths(libdir, 'pkgconfig') : get_option('pkgconfiglibdir')
 
 ################################################################################
 conf = configuration_data()
+
+conf.set('SYSCONFDIR', sysconfdir)
 
 # Check for libuuid availability
 libuuid_dep = dependency('uuid', required: true)

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -41,9 +41,10 @@
 #define NVMF_HOSTID_SIZE	37
 #define UUID_SIZE		37  /* 1b4e28ba-2fa1-11d2-883f-0016d3cca427 + \0 */
 
+#define NVMF_HOSTNQN_FILE	"SYSCONFDIR/nvme/hostnqn"
+#define NVMF_HOSTID_FILE	"SYSCONFDIR/nvme/hostid"
+
 const char *nvmf_dev = "/dev/nvme-fabrics";
-const char *nvmf_hostnqn_file = "/etc/nvme/hostnqn";
-const char *nvmf_hostid_file = "/etc/nvme/hostid";
 
 const char *arg_str(const char * const *strings,
 		size_t array_size, size_t idx)
@@ -967,12 +968,12 @@ static char *nvmf_read_file(const char *f, int len)
 
 char *nvmf_hostnqn_from_file()
 {
-	return nvmf_read_file(nvmf_hostnqn_file, NVMF_NQN_SIZE);
+	return nvmf_read_file(NVMF_HOSTNQN_FILE, NVMF_NQN_SIZE);
 }
 
 char *nvmf_hostid_from_file()
 {
-	return nvmf_read_file(nvmf_hostid_file, NVMF_HOSTID_SIZE);
+	return nvmf_read_file(NVMF_HOSTID_FILE, NVMF_HOSTID_SIZE);
 }
 
 /**

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -203,7 +203,7 @@ char *nvmf_hostnqn_generate();
 
 /**
  * nvmf_hostnqn_from_file() - Reads the host nvm qualified name from the config
- * 			      default location in /etc/nvme/
+ * 			      default location in @SYSCONFDIR@/nvme/
  * Return: The host nqn, or NULL if unsuccessful. If found, the caller
  * is responsible to free the string.
  */
@@ -211,7 +211,7 @@ char *nvmf_hostnqn_from_file();
 
 /**
  * nvmf_hostid_from_file() - Reads the host identifier from the config default
- * 			     location in /etc/nvme/.
+ * 			     location in @SYSCONFDIR@/nvme/.
  * Return: The host identifier, or NULL if unsuccessful. If found, the caller
  * 	   is responsible to free the string.
  */


### PR DESCRIPTION
Instead hard coding the sysconfdir allow the user to overwrite the
location of the hostnqn and hostid file. The default is "/etc" but
when configured with --prefix=DIR the files should be read from
"DIR/nvme/".

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See also https://github.com/linux-nvme/nvme-cli/issues/1427