### PR TITLE
tree: fixup coredump during nvme discover

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -941,7 +941,7 @@ static void discovery_trsvcid(nvme_ctrl_t c)
 			c->trsvcid = strdup(__stringify(NVME_DISC_IP_PORT));
 		} else {
 			/* Default port for NVMe/TCP io controllers */
-			c->trsvcid = __stringify(NVME_RDMA_IP_PORT);
+			c->trsvcid = strdup(__stringify(NVME_RDMA_IP_PORT));
 		}
 	} else if (!strcmp(c->transport, "rdma")) {
 		/* Default port for NVMe/RDMA controllers */


### PR DESCRIPTION
nvme_free_ctrl() expects the 'trsvcid' string to be dynamically
allocated; just calling 'stringify' will cause a coredump on exit.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/1433

Signed-off-by: Hannes Reinecke <hare@suse.de>