### PR TITLE
fabrics: Correctly stringify default hostnqn and hostid paths

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ pkgconfiglibdir = get_option('pkgconfiglibdir') == '' ? join_paths(libdir, 'pkgc
 ################################################################################
 conf = configuration_data()
 
-conf.set('SYSCONFDIR', sysconfdir)
+conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 
 # Check for libuuid availability
 libuuid_dep = dependency('uuid', required: true)

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -41,8 +41,8 @@
 #define NVMF_HOSTID_SIZE	37
 #define UUID_SIZE		37  /* 1b4e28ba-2fa1-11d2-883f-0016d3cca427 + \0 */
 
-#define NVMF_HOSTNQN_FILE	"SYSCONFDIR/nvme/hostnqn"
-#define NVMF_HOSTID_FILE	"SYSCONFDIR/nvme/hostid"
+#define NVMF_HOSTNQN_FILE	SYSCONFDIR "/nvme/hostnqn"
+#define NVMF_HOSTID_FILE	SYSCONFDIR "/nvme/hostid"
 
 const char *nvmf_dev = "/dev/nvme-fabrics";
 


### PR DESCRIPTION
Fixes: f356ab0ca74a ("fabrics: Allow to change sysconfdir for hostnqn and hostid file")
Reported-by: Hannes Reinecke <hare@suse.de>
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: [ #1446](https://github.com/linux-nvme/nvme-cli/issues/1446)