### PR TITLE
tree: Fix subsystem initialization in nvme_scan_ctrl()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1364,10 +1364,13 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name)
 	subsysname = nvme_ctrl_lookup_subsystem_name(r, name);
 	/* subsysname might be NULL here */
 	s = nvme_lookup_subsystem(h, subsysname, subsysnqn);
-	if (subsysname)
-		free(subsysname);
 	free(subsysnqn);
-	if (!s) {
+
+	ret = 0;
+	if (s && !s->name)
+		ret = nvme_init_subsystem(s, subsysname);
+	free(subsysname);
+	if (!s || ret < 0) {
 		free(path);
 		errno = ENOMEM;
 		return NULL;


### PR DESCRIPTION
The subsystem instance would normally get properly initialized
in later stages of topology scanning, unless there's a host
mismatch and the instance would stand alone.

Related to #291