### PR TITLE
tree: Handle NULL subsysname in nvme_scan_ctrl()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1367,7 +1367,7 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name)
 	free(subsysnqn);
 
 	ret = 0;
-	if (s && !s->name)
+	if (s && !s->name && subsysname)
 		ret = nvme_init_subsystem(s, subsysname);
 	free(subsysname);
 	if (!s || ret < 0) {


### PR DESCRIPTION
As noted couple of lines earlier, the subsysname string might
be NULL. In that case, defer initialization of nvme_subsystem_t
in hope that it would get initialized while scanning subsystems.