### PR TITLE
CI: fixing dist packaging error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["mesonpep517", "wheel", "meson", "ninja"] # PEP 508 specifications.
+requires = ["mesonpep517", "wheel", "meson==0.61.2", "ninja"] # PEP 508 specifications.
 build-backend = "mesonpep517.buildapi"
 
 [tool.mesonpep517.metadata]


### PR DESCRIPTION
Fixes #303

python.platlibdir and python.install_env are mutually exclusive

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>