### PR TITLE
CI: fixing dist packaging error

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
 
       - name: Build sdist
         run: pipx run build --sdist


### PR DESCRIPTION
Fixes #303

python.platlibdir and python.install_env are mutually exclusive

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>