### PR TITLE
fabrics: Free old traddr in nvmf_add_ctrl

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -536,15 +536,15 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 	cfg = merge_config(c, cfg);
 	nvme_ctrl_set_discovered(c, true);
 	if (traddr_is_hostname(h->r, c)) {
-		const char *traddr = c->traddr;
+		char *traddr = c->traddr;
 
 		c->traddr = hostname2traddr(h->r, traddr);
 		if (!c->traddr) {
-			c->traddr = (char *)traddr;
+			c->traddr = traddr;
 			errno = ENVME_CONNECT_TRADDR;
 			return -1;
 		}
-		free(c->traddr);
+		free(traddr);
 	}
 
 	ret = build_options(h, c, &argstr);


### PR DESCRIPTION
We need to free the old traddr and not the newly translated traddr.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

```
failed to add controller, error failed to write to nvme-fabrics device
free(): double free detected in tcache 2

Program received signal SIGABRT, Aborted.
0x00007ffff6fb3cdb in raise () from /lib64/libc.so.6
Missing separate debuginfos, use: zypper install libhugetlbfs-debuginfo-2.20-3.3.1.x86_64 libjson-c3-debuginfo-0.13-3.3.1.x86_64 libopenssl1_1-debuginfo-1.1.1d-11.38.1.x86_64 libuuid1-debuginfo-2.36.2-4.5.1.x86_64 libz1-debuginfo-1.2.11-3.24.1.x86_64
(gdb) bt
#0  0x00007ffff6fb3cdb in raise () from /lib64/libc.so.6
#1  0x00007ffff6fb5375 in abort () from /lib64/libc.so.6
#2  0x00007ffff6ff9b07 in __libc_message () from /lib64/libc.so.6
#3  0x00007ffff7001b8a in malloc_printerr () from /lib64/libc.so.6
#4  0x00007ffff70039dd in _int_free () from /lib64/libc.so.6
#5  0x00007ffff7bbd4fc in __nvme_free_ctrl (c=0x6f0290) at ../subprojects/libnvme/src/nvme/tree.c:921
#6  0x00007ffff7bbd5d4 in nvme_free_ctrl (c=0x6f0290) at ../subprojects/libnvme/src/nvme/tree.c:930
#7  0x00000000004087fa in nvmf_discover (desc=0x496068 "Send Get Log Page request to Discovery Controller.", argc=4, argv=0x7fffffffe420, connect=false)
    at ../fabrics.c:590
#8  0x0000000000423226 in discover_cmd (argc=4, argv=0x7fffffffe420, command=0x6cd2a0 <discover_cmd_cmd>, plugin=0x6cd7a0 <builtin>) at ../nvme.c:7827
#9  0x00000000004437fa in handle_plugin (argc=4, argv=0x7fffffffe420, plugin=0x6cd7a0 <builtin>) at ../plugin.c:155
#10 0x00000000004233b8 in main (argc=5, argv=0x7fffffffe418) at ../nvme.c:7873
```