### PR TITLE
meson: build display-tree example

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -20,6 +20,13 @@ executable(
 )
 
 executable(
+    'display-tree',
+    ['display-tree.c'],
+    link_with: libnvme,
+    include_directories: [incdir, internal_incdir]
+)
+
+executable(
     'discover-loop',
     ['discover-loop.c'],
     link_with: libnvme,


### PR DESCRIPTION
The 'display-tree' example program wasn't build with meson.

Signed-off-by: Hannes Reinecke <hare@suse.de>