### PR TITLE
fabrics: add 'nvmf_update_config()'

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -333,6 +333,7 @@ LIBNVME_1_0 {
 		nvmf_subtype_str;
 		nvmf_treq_str;
 		nvmf_trtype_str;
+		nvmf_update_config;
 	local:
 		*;
 };

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -177,10 +177,37 @@ void nvmf_default_config(struct nvme_fabrics_config *cfg)
 	cfg->ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO;
 }
 
-#define UPDATE_CFG_OPTION(c, n, o, d)			\
+#define MERGE_CFG_OPTION(c, n, o, d)			\
 	if ((c)->o == d) (c)->o = (n)->o
 static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,
 		const struct nvme_fabrics_config *cfg)
+{
+	struct nvme_fabrics_config *ctrl_cfg = nvme_ctrl_get_config(c);
+
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, host_traddr, NULL);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, host_iface, NULL);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, nr_io_queues, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, nr_write_queues, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, nr_poll_queues, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, queue_size, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, keep_alive_tmo, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, reconnect_delay, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, ctrl_loss_tmo,
+			  NVMF_DEF_CTRL_LOSS_TMO);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, fast_io_fail_tmo, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, tos, -1);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, duplicate_connect, false);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, disable_sqflow, false);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, data_digest, false);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, tls, false);
+
+	return ctrl_cfg;
+}
+
+#define UPDATE_CFG_OPTION(c, n, o, d)			\
+	if ((n)->o != d) (c)->o = (n)->o
+void nvmf_update_config(nvme_ctrl_t c, const struct nvme_fabrics_config *cfg)
 {
 	struct nvme_fabrics_config *ctrl_cfg = nvme_ctrl_get_config(c);
 
@@ -201,8 +228,6 @@ static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, data_digest, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, tls, false);
-
-	return ctrl_cfg;
 }
 
 static int add_bool_argument(char **argstr, char *tok, bool arg)

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -169,6 +169,16 @@ const char *nvmf_cms_str(__u8 cms);
 void nvmf_default_config(struct nvme_fabrics_config *cfg);
 
 /**
+ * nvmf_update_config() - Update fabrics configuration values
+ * @c:          Controller to be modified
+ * @cfg:        Updated configuration values
+ *
+ * Updates the values from @c with the configuration values from @cfg;
+ * all non-default values from @cfg will overwrite the values in @c.
+ */
+void nvmf_update_config(nvme_ctrl_t c, const struct nvme_fabrics_config *cfg);
+
+/**
  * nvmf_add_ctrl() - Connect a controller and update topology
  * @h:		Host to which the controller should be attached
  * @c:		Controller to be connected


### PR DESCRIPTION
Add a function to update the fabrics configuration values of an
existing controller.

Signed-off-by: Hannes Reinecke <hare@suse.de>