### PR TITLE
libnvme: export 'nvme_lookup_ctrl()'

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -179,6 +179,7 @@ LIBNVME_1_0 {
 		nvme_io_passthru64;
 		nvme_io_passthru;
 		nvme_lockdown;
+		nvme_lookup_ctrl;
 		nvme_lookup_host;
 		nvme_lookup_subsystem;
 		nvme_namespace_attach_ctrls;


### PR DESCRIPTION
For some reason it has been missing from the map file.

Signed-off-by: Hannes Reinecke <hare@suse.de>