### PR TITLE
fabrics: Invoke nvmf_dim() with provided tas argument.

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1306,6 +1306,5 @@ int nvmf_register_ctrl(nvme_ctrl_t c, enum nvmf_dim_tas tas, __u32 *result)
 	 * to retrieve the source address from the socket and use that
 	 * as the registration address.
 	 */
-	return nvmf_dim(c, NVMF_DIM_TAS_REGISTER, NVMF_TRTYPE_TCP,
-			nvme_get_adrfam(c), "", NULL, result);
+	return nvmf_dim(c, tas, NVMF_TRTYPE_TCP, nvme_get_adrfam(c), "", NULL, result);
 }


### PR DESCRIPTION
Looks like a copy-paste issue. One of the arguments to
nvmf_register_ctrl() is "tas" (i.e. the DIM Task). This argument
should be passed to the nvmf_dim() API, but instead a fixed value
of NVMF_DIM_TAS_REGISTER was passed.

The "tas" field specifies whether to perform a "registration",
"deregistration", or a "registration update".

Signed-off-by: Martin Belanger <martin.belanger@dell.com>