### PR TITLE
tree: always allocate config file in nvme_read_config()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -152,9 +152,12 @@ int nvme_read_config(nvme_root_t r, const char *config_file)
 		return err;
 	}
 
+	r->config_file = strdup(config_file);
+	if (!r->config_file) {
+		errno = ENOMEM;
+		return err;
+	}
 	err = json_read_config(r, config_file);
-	if (!err)
-		r->config_file = strdup(config_file);
 	/*
 	 * The json configuration file is optional,
 	 * so ignore errors when opening the file.


### PR DESCRIPTION
Even if there was an error when reading the config file we still
should store the config file name, as it might used later on to
update/write the config file.
So parsing errors don't really matter, and we'll get notified for
I/O errors on writing anyway.

Signed-off-by: Hannes Reinecke <hare@suse.de>