### PR TITLE
Update nvme_scan_filter_t

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -12,7 +12,6 @@ LIBNVME_1_0 {
 		nvme_ctrl_first_ns;
 		nvme_ctrl_first_path;
 		nvme_ctrl_get_address;
-		nvme_ctrl_get_ana_state;
 		nvme_ctrl_get_dhchap_key;
 		nvme_ctrl_get_discovery_ctrl;
 		nvme_ctrl_get_fd;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -185,6 +185,8 @@ LIBNVME_1_0 {
 		nvme_namespace_attach_ctrls;
 		nvme_namespace_detach_ctrls;
 		nvme_namespace_filter;
+		nvme_namespace_first_path;
+		nvme_namespace_next_path;
 		nvme_next_host;
 		nvme_next_subsystem;
 		nvme_ns_attach;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -39,10 +39,11 @@ static struct nvme_host *default_host;
 static void __nvme_free_host(nvme_host_t h);
 static void __nvme_free_ctrl(nvme_ctrl_t c);
 static int nvme_subsystem_scan_namespace(nvme_root_t r,
-		struct nvme_subsystem *s, char *name, nvme_scan_filter_t f);
+		struct nvme_subsystem *s, char *name,
+		nvme_scan_filter_t f, void *f_args);
 static int nvme_init_subsystem(nvme_subsystem_t s, const char *name);
 static int nvme_scan_subsystem(nvme_root_t r, const char *name,
-			       nvme_scan_filter_t f);
+			       nvme_scan_filter_t f, void *f_args);
 static int nvme_ctrl_scan_namespace(nvme_root_t r, struct nvme_ctrl *c,
 				    char *name);
 static int nvme_ctrl_scan_path(nvme_root_t r, struct nvme_ctrl *c, char *name);
@@ -75,7 +76,7 @@ nvme_host_t nvme_default_host(nvme_root_t r)
 	return h;
 }
 
-int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
+int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f, void *f_args)
 {
 	struct dirent **subsys, **ctrls;
 	int i, num_subsys, num_ctrls, ret;
@@ -97,7 +98,7 @@ int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 				 ctrls[i]->d_name, strerror(errno));
 			continue;
 		}
-		if ((f) && !f(NULL, c, NULL)) {
+		if ((f) && !f(NULL, c, NULL, f_args)) {
 			nvme_msg(r, LOG_DEBUG, "filter out controller %s\n",
 				 ctrls[i]->d_name);
 			nvme_free_ctrl(c);
@@ -114,7 +115,7 @@ int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 	}
 
 	for (i = 0; i < num_subsys; i++) {
-		ret = nvme_scan_subsystem(r, subsys[i]->d_name, f);
+		ret = nvme_scan_subsystem(r, subsys[i]->d_name, f, f_args);
 		if (ret < 0) {
 			nvme_msg(r, LOG_DEBUG,
 				 "failed to scan subsystem %s: %s\n",
@@ -172,7 +173,7 @@ nvme_root_t nvme_scan(const char *config_file)
 {
 	nvme_root_t r = nvme_create_root(NULL, DEFAULT_LOGLEVEL);
 
-	nvme_scan_topology(r, NULL);
+	nvme_scan_topology(r, NULL, NULL);
 	nvme_read_config(r, config_file);
 	return r;
 }
@@ -266,7 +267,7 @@ void nvme_refresh_topology(nvme_root_t r)
 
 	nvme_for_each_host_safe(r, h, _h)
 		__nvme_free_host(h);
-	nvme_scan_topology(r, NULL);
+	nvme_scan_topology(r, NULL, NULL);
 }
 
 void nvme_free_tree(nvme_root_t r)
@@ -476,7 +477,7 @@ struct nvme_host *nvme_lookup_host(nvme_root_t r, const char *hostnqn,
 }
 
 static int nvme_subsystem_scan_namespaces(nvme_root_t r, nvme_subsystem_t s,
-		nvme_scan_filter_t f)
+		nvme_scan_filter_t f, void *f_args)
 {
 	struct dirent **namespaces;
 	int i, num_ns, ret;
@@ -491,7 +492,7 @@ static int nvme_subsystem_scan_namespaces(nvme_root_t r, nvme_subsystem_t s,
 
 	for (i = 0; i < num_ns; i++) {
 		ret = nvme_subsystem_scan_namespace(r, s,
-						    namespaces[i]->d_name, f);
+				namespaces[i]->d_name, f, f_args);
 		if (ret < 0)
 			nvme_msg(r, LOG_DEBUG,
 				 "failed to scan namespace %s: %s\n",
@@ -528,7 +529,7 @@ static int nvme_init_subsystem(nvme_subsystem_t s, const char *name)
 }
 
 static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
-			       nvme_scan_filter_t f)
+		nvme_scan_filter_t f, void *f_args)
 {
 	struct nvme_subsystem *s = NULL, *_s;
 	char *path, *subsysnqn;
@@ -584,13 +585,13 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
 	if (!s)
 		return -1;
 
-	if (f && !f(s, NULL, NULL)) {
+	if (f && !f(s, NULL, NULL, f_args)) {
 		nvme_msg(r, LOG_DEBUG, "filter out subsystem %s\n", name);
 		__nvme_free_subsystem(s);
 		return 0;
 	}
 
-	nvme_subsystem_scan_namespaces(r, s, f);
+	nvme_subsystem_scan_namespaces(r, s, f, f_args);
 
 	return 0;
 }
@@ -1410,9 +1411,9 @@ void nvme_rescan_ctrl(struct nvme_ctrl *c)
 	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
 	if (!c->s)
 		return;
-	nvme_subsystem_scan_namespaces(r, c->s, NULL);
 	nvme_ctrl_scan_namespaces(r, c);
 	nvme_ctrl_scan_paths(r, c);
+	nvme_subsystem_scan_namespaces(r, c->s, NULL, NULL);
 }
 
 static int nvme_bytes_to_lba(nvme_ns_t n, off_t offset, size_t count,
@@ -1883,7 +1884,7 @@ static void nvme_subsystem_set_ns_path(nvme_subsystem_t s, nvme_ns_t n)
 }
 
 static int nvme_subsystem_scan_namespace(nvme_root_t r, nvme_subsystem_t s,
-		char *name, nvme_scan_filter_t f)
+		char *name, nvme_scan_filter_t f, void *f_args)
 {
 	struct nvme_ns *n;
 
@@ -1894,7 +1895,7 @@ static int nvme_subsystem_scan_namespace(nvme_root_t r, nvme_subsystem_t s,
 		nvme_msg(r, LOG_DEBUG, "failed to scan namespace %s\n", name);
 		return -1;
 	}
-	if (f && !f(NULL, NULL, n)) {
+	if (f && !f(NULL, NULL, n, f_args)) {
 		nvme_msg(r, LOG_DEBUG, "filter out namespace %s\n", name);
 		__nvme_free_ns(n);
 		return 0;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -325,6 +325,16 @@ nvme_ns_t nvme_subsystem_next_ns(nvme_subsystem_t s, nvme_ns_t n)
 	return n ? list_next(&s->namespaces, n, entry) : NULL;
 }
 
+nvme_path_t nvme_namespace_first_path(nvme_ns_t ns)
+{
+	return list_top(&ns->paths, struct nvme_path, nentry);
+}
+
+nvme_path_t nvme_namespace_next_path(nvme_ns_t ns, nvme_path_t p)
+{
+	return p ? list_next(&ns->paths, p, nentry) : NULL;
+}
+
 static void __nvme_free_ns(struct nvme_ns *n)
 {
 	list_del_init(&n->entry);

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -97,7 +97,7 @@ int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f)
 				 ctrls[i]->d_name, strerror(errno));
 			continue;
 		}
-		if ((f) && !f(c->s)) {
+		if ((f) && !f(NULL, c, NULL)) {
 			nvme_msg(r, LOG_DEBUG, "filter out controller %s\n",
 				 ctrls[i]->d_name);
 			nvme_free_ctrl(c);
@@ -575,7 +575,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
 
 	nvme_subsystem_scan_namespaces(r, s);
 
-	if (f && !f(s)) {
+	if (f && !f(s, NULL, NULL)) {
 		nvme_msg(r, LOG_DEBUG, "filter out subsystem %s\n", name);
 		__nvme_free_subsystem(s);
 	}

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -801,19 +801,6 @@ const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c)
 	return c->cfg.host_iface;
 }
 
-const char *nvme_ctrl_get_ana_state(nvme_ctrl_t c, __u32 nsid)
-{
-	if (nsid != NVME_NSID_ALL) {
-		nvme_path_t p;
-
-		nvme_ctrl_for_each_path(c, p) {
-			if (p->n && p->n->nsid == nsid)
-				return p->ana_state;
-		}
-	}
-	return NULL;
-}
-
 struct nvme_fabrics_config *nvme_ctrl_get_config(nvme_ctrl_t c)
 {
 	return &c->cfg;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -875,15 +875,6 @@ const char *nvme_ctrl_get_host_traddr(nvme_ctrl_t c);
 const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c);
 
 /**
- * nvme_ctrl_get_ana_state() - ANA state of a controller path
- * @c:		Constroller instance
- * @nsid:	Namespace ID to evaluate
- *
- * Return: ANA state of the namespace @nsid on controller @c.
- */
-const char *nvme_ctrl_get_ana_state(nvme_ctrl_t c, __u32 nsid);
-
-/**
  * nvme_ctrl_get_dhchap_key() - Return controller key
  * @c:	Controller for which the key should be set
  *

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -217,6 +217,23 @@ nvme_ctrl_t nvme_subsystem_first_ctrl(nvme_subsystem_t s);
 nvme_ctrl_t nvme_subsystem_next_ctrl(nvme_subsystem_t s, nvme_ctrl_t c);
 
 /**
+ * nvme_namespace_first_path() - Start path iterator
+ * @ns:	Namespace instance
+ *
+ * Return: First &nvme_path_t object of an @ns iterator
+ */
+nvme_path_t nvme_namespace_first_path(nvme_ns_t ns);
+
+/**
+ * nvme_namespace_next_path() - Next path iterator
+ * @ns:	Namespace instance
+ * @p:	Previous &nvme_path_t object of an @ns iterator
+ *
+ * Return: Next &nvme_path_t object of an @ns iterator
+ */
+nvme_path_t nvme_namespace_next_path(nvme_ns_t c, nvme_path_t p);
+
+/**
  * nvme_lookup_ctrl() - Lookup nvme_ctrl_t object
  * @s:			&nvme_subsystem_t object
  * @transport:		Transport name
@@ -402,6 +419,27 @@ nvme_ns_t nvme_subsystem_next_ns(nvme_subsystem_t s, nvme_ns_t n);
 #define nvme_subsystem_for_each_ns(s, n)			\
 	for (n = nvme_subsystem_first_ns(s); n != NULL;		\
 		n = nvme_subsystem_next_ns(s, n))
+
+/**
+ * nvme_namespace_for_each_path_safe() - Traverse paths
+ * @ns:	Namespace instance
+ * @p:	&nvme_path_t object
+ * @_p:	A &nvme_path_t_node to use as temporary storage
+ */
+#define nvme_namespace_for_each_path_safe(n, p, _p)		\
+	for (p = nvme_namespace_first_path(n),			\
+	     _p = nvme_namespace_next_path(n, p);		\
+             p != NULL;						\
+	     p = _p, _p = nvme_namespace_next_path(n, p))
+
+/**
+ * nvme_namespace_for_each_path() - Traverse paths
+ * @ns:	Namespace instance
+ * @p:	&nvme_path_t object
+ */
+#define nvme_namespace_for_each_path(c, p)			\
+	for (p = nvme_namespace_first_path(c); p != NULL;	\
+		p = nvme_namespace_next_path(c, p))
 
 /**
  * nvme_ns_get_fd() - Get associated filedescriptor

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -33,7 +33,8 @@ typedef struct nvme_subsystem *nvme_subsystem_t;
 typedef struct nvme_host *nvme_host_t;
 typedef struct nvme_root *nvme_root_t;
 
-typedef bool (*nvme_scan_filter_t)(nvme_subsystem_t, nvme_ctrl_t, nvme_ns_t);
+typedef bool (*nvme_scan_filter_t)(nvme_subsystem_t, nvme_ctrl_t,
+				   nvme_ns_t, void *);
 
 /**
  * nvme_create_root() - Initialize root object
@@ -1050,15 +1051,16 @@ const char *nvme_subsystem_get_type(nvme_subsystem_t s);
 
 /**
  * nvme_scan_topology() - Scan NVMe topology and apply filter
- * @r:	nvme_root_t object
- * @f:	filter to apply
+ * @r:	    nvme_root_t object
+ * @f:	    filter to apply
+ * @f_args: user-specified argument to @f
  *
  * Scans the NVMe topology and filters out the resulting elements
  * by applying @f.
  *
  * Return: Number of elements scanned
  */
-int nvme_scan_topology(nvme_root_t r, nvme_scan_filter_t f);
+int nvme_scan_topology(nvme_root_t r, nvme_scan_filter_t f, void *f_args);
 
 /**
  * nvme_host_get_hostnqn() - Host NQN of an nvme_host_t object

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -33,7 +33,7 @@ typedef struct nvme_subsystem *nvme_subsystem_t;
 typedef struct nvme_host *nvme_host_t;
 typedef struct nvme_root *nvme_root_t;
 
-typedef bool (*nvme_scan_filter_t)(nvme_subsystem_t);
+typedef bool (*nvme_scan_filter_t)(nvme_subsystem_t, nvme_ctrl_t, nvme_ns_t);
 
 /**
  * nvme_create_root() - Initialize root object

--- a/test/test.c
+++ b/test/test.c
@@ -24,11 +24,11 @@
 
 #include <ccan/endian/endian.h>
 
-static char *nqn_match;
-
 static bool nvme_match_subsysnqn_filter(nvme_subsystem_t s,
-		nvme_ctrl_t c, nvme_ns_t ns)
+		nvme_ctrl_t c, nvme_ns_t ns, void *f_args)
 {
+	char *nqn_match = f_args;
+
 	if (s)
 		return strcmp(nvme_subsystem_get_nqn(s), nqn_match) == 0;
 	return true;
@@ -324,13 +324,13 @@ int main(int argc, char **argv)
 	nvme_path_t p;
 	nvme_ns_t n;
 	const char *ctrl = "nvme4";
+	const char *nqn_match = "testnqn";
 
 	printf("Test filter for common loop back target\n");
-	nqn_match = "testnqn";
 	r = nvme_create_root(NULL, DEFAULT_LOGLEVEL);
 	if (!r)
 		return 1;
-	nvme_scan_topology(r, nvme_match_subsysnqn_filter);
+	nvme_scan_topology(r, nvme_match_subsysnqn_filter, (void *)nqn_match);
 	nvme_for_each_host(r, h) {
 		nvme_for_each_subsystem(h, s) {
 			printf("%s - NQN=%s\n", nvme_subsystem_get_name(s),

--- a/test/test.c
+++ b/test/test.c
@@ -26,9 +26,12 @@
 
 static char *nqn_match;
 
-static bool nvme_match_subsysnqn_filter(nvme_subsystem_t s)
+static bool nvme_match_subsysnqn_filter(nvme_subsystem_t s,
+		nvme_ctrl_t c, nvme_ns_t ns)
 {
-	return strcmp(nvme_subsystem_get_nqn(s), nqn_match) == 0;
+	if (s)
+		return strcmp(nvme_subsystem_get_nqn(s), nqn_match) == 0;
+	return true;
 }
 
 static int test_ctrl(nvme_ctrl_t c)


### PR DESCRIPTION
Update nvme_scan_filter_t to accept 4 arguments (subsystem, controller, namespace, f_args) and apply the filter for subsystem namespaces, too. This allows for a more targeted filter implementations and to remove the hack to display the ANA state.