### PR TITLE
log.h: include tree.h for nvme_root_t

### DIFF
--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -8,6 +8,9 @@
 #include <stdbool.h>
 #include <syslog.h>
 
+/* for nvme_root_t */
+#include "tree.h"
+
 #ifndef MAX_LOGLEVEL
 #  define MAX_LOGLEVEL LOG_DEBUG
 #endif


### PR DESCRIPTION
nvme_init_logging() has a nvme_root_t, so we need a definition from
tree.h

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>