### PR TITLE
fabrics: use '%' instead of SCOPE_DELIMITER

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -325,7 +325,7 @@ static int inet6_pton(nvme_root_t r, const char *src, uint16_t port,
 		nvme_msg(r, LOG_ERR, "cannot copy: %s\n", src);
 
 	const char *scope = NULL;
-	char *p = strchr(tmp, SCOPE_DELIMITER);
+	char *p = strchr(tmp, '%');
 	if (p) {
 		*p = '\0';
 		scope = src + (p - tmp) + 1;


### PR DESCRIPTION
this definition does not exist in musl libc, and has always been '%' in  
glibc\[0\] for over 20 years.  

\[0\]: https://github.com/bminor/glibc/commit/c0bc5f7b8fd62dfa566dd3adb91f3a1ee8db6aeb