### PR TITLE
ci: publish only sdist on PyPi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,67 +1,58 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Build and upload to PyPI
 
 on:
   push:
     branches: [ master ]
+    tags:
+      - '**'
   pull_request:
     branches: [ master ]
   workflow_dispatch:
 
 jobs:
-  build_wheels:
-    name: Build wheels manylinux
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
-        env:
-            CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
-            CIBW_SKIP: "*-musllinux_*"
-            CIBW_BEFORE_BUILD_LINUX: yum install -y openssl-devel libuuid-devel json-c-devel
-            CIBW_BUILD_VERBOSITY: 1
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-          retention-days: 5
-
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
           retention-days: 5
 
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
+  upload_test_pypi:
+    needs: [build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+
+  upload_pypi:
+    needs: [build_sdist]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.5
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Pre building the binaries with wheels is difficult, as we would also
need to ship the libnvme.so with the Python binding.

This is a well known limitation of this kind of setup (binding to a
shared library). Most project fallback to just ship the sdist.

Though there is a drawback as the C library is missing and the user
has to provide the library himself, with all problems which come along
with setup. But it seems common practice with other Python bindings,
so we don't want to be hostile to the ones which know what they are
doing.

Normal users should just use the distribution packages anyway.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #271