### PR TITLE
build: Add git ref to the binary

### DIFF
--- a/meson-vcs-tag.sh
+++ b/meson-vcs-tag.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+set -eu
+set -o pipefail
+
+dir="${1:?}"
+fallback="${2:?}"
+
+# Apparently git describe has a bug where it always considers the work-tree
+# dirty when invoked with --git-dir (even though 'git status' is happy). Work
+# around this issue by cd-ing to the source directory.
+cd "$dir"
+# Check that we have either .git/ (a normal clone) or a .git file (a work-tree)
+# and that we don't get confused if a tarball is extracted in a higher-level
+# git repository.
+[ -e .git ] && git describe --abbrev=7 --dirty=+ 2>/dev/null | sed 's/^v//' || echo "$fallback"

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ else
                     check: true)
     conf.set('GIT_VERSION', '"@0@"'.format(r.stdout().strip()))
 endif
+conf.set('PROJECT_VERSION', '"@0@"'.format(meson.project_version()))
 
 conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,17 @@ pkgconfiglibdir = get_option('pkgconfiglibdir') == '' ? join_paths(libdir, 'pkgc
 ################################################################################
 conf = configuration_data()
 
+version_tag = get_option('version-tag')
+if version_tag != ''
+        conf.set('GIT_VERSION', '"@0@"'.format(version_tag))
+else
+    r = run_command('meson-vcs-tag.sh',
+                    meson.current_source_dir(),
+                    meson.project_version(),
+                    check: true)
+    conf.set('GIT_VERSION', '"@0@"'.format(r.stdout().strip()))
+endif
+
 conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 
 # Check for libuuid availability

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 # -*- mode: meson -*-
+option('version-tag', type : 'string', description : 'override the git version string')
 option('pkgconfiglibdir', type : 'string', value : '', description : 'directory for standard pkg-config files')
 option('htmldir', type : 'string', value : '', description : 'directory for HTML documentation')
 

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,3 +1,8 @@
+LIBNVME_1_1 {
+	global:
+		nvme_get_version;
+};
+
 LIBNVME_1_0 {
 	global:
 		nvme_admin_passthru64;

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -778,3 +778,15 @@ struct nvmf_ext_attr *nvmf_exat_ptr_next(struct nvmf_ext_attr *p)
 	return (struct nvmf_ext_attr *)
 		((uintptr_t)p + (ptrdiff_t)nvmf_exat_size(le16_to_cpu(p->exatlen)));
 }
+
+const char *nvme_get_version(enum nvme_version type)
+{
+	switch(type) {
+	case NVME_VERSION_PROJECT:
+		return PROJECT_VERSION;
+	case NVME_VERSION_GIT:
+		return GIT_VERSION;
+	default:
+		return "n/a";
+	}
+}

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -23,6 +23,9 @@
 #include "util.h"
 #include "log.h"
 
+/* Source Code Control System, query version of binary with 'what' */
+const char sccsid[] = "@(#)libnvme " GIT_VERSION;
+
 static inline __u8 nvme_generic_status_to_errno(__u16 status)
 {
 	switch (status) {

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -532,4 +532,23 @@ static inline __u16 nvmf_exat_size(size_t val_len)
  */
 struct nvmf_ext_attr *nvmf_exat_ptr_next(struct nvmf_ext_attr *p);
 
+/**
+ * enum nvme_version - Selector for version to be returned by @nvme_get_version
+ *
+ * NVME_VERSION_PROJECT:	Project release version
+ * NVME_VERSION_GIT:		Git reference
+ */
+enum nvme_version {
+	NVME_VERSION_PROJECT	= 0,
+	NVME_VERSION_GIT	= 1,
+};
+
+/**
+ * nvme_get_version - Return version libnvme string
+ * @type:	Selects which version type (see @struct nvme_version)
+ *
+ * Return: Returns version string for known types or else "n/a"
+ */
+const char *nvme_get_version(enum nvme_version type);
+
 #endif /* _LIBNVME_UTIL_H */


### PR DESCRIPTION
In order to be able to figure out which binary is in use (for example
in debugging situation) it's really helpful to have the 'git describe'
ref added to the binary.

The simplest way to expose the it via good old Source Code Control
System string id. No need to come up with something complicated else
as there is no agreement on how to do this. So let's add this simple
magic string to library.

You can either query with 'what' or just

  $strings .build/src/libnvme.so | grep '@(#)'
  @(#)libnvme 1.0-1-g5ff5d22+

The idea how to extract the version string is shamelessly copied from
the systemd project.

Signed-off-by: Daniel Wagner <dwagner@suse.de>