### PR TITLE
fabrics: Lower log level in __nvmf_add_ctrl

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -521,7 +521,7 @@ static int __nvmf_add_ctrl(nvme_root_t r, const char *argstr)
 		 (int)strcspn(argstr,"\n"), argstr);
 	ret = write(fd, argstr, len);
 	if (ret != len) {
-		nvme_msg(r, LOG_ERR, "Failed to write to %s: %s\n",
+		nvme_msg(r, LOG_NOTICE, "Failed to write to %s: %s\n",
 			 nvmf_dev, strerror(errno));
 		ret = -ENVME_CONNECT_WRITE;
 		goto out_close;


### PR DESCRIPTION
9df8676d2db6 ("Add logging functionality to libnvme") introduced the
logging. The log level for writing to /dev/nvme-fabrics was set on
NOTICE because the kernel reports also status information such
EALREADY which is a soft error.

866c288a456f ("fabrics: update log level for write failures")
increased the log level without taking this into account.

Drop back to NOTICE level to avoid error message when doing

  $ nvme connect-all ....
  Failed to write to /dev/nvme-fabrics: Operation already in progress

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See: https://github.com/linux-nvme/nvme-cli/issues/1505