### PR TITLE
fabrics: Remove double connection error logging

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -702,8 +702,6 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 		if (!ret)
 			return c;
 	}
-	nvme_msg(h->r, LOG_ERR, "failed to connect controller, error %d\n",
-		 errno);
 	nvme_free_ctrl(c);
 	return NULL;
 }


### PR DESCRIPTION
fabrics: Remove double connection error logging

nvmf_connect_disc_entry() is calling nvmf_add_ctrl() to do the
connecting attempt. We have in nvmf_add_ctrl() all error paths logging
enabled, so another logging in nvmf_connect_disc_entry() is not
necessary and introduces a problem such as nmve-cli users interpreting
this as hard error.

For example the kernel reports via < 0 return values state information
such as the connection is already there if the user runs 'nvme
connect-all' twice:

  $ .build/nvme connect-all -t tcp --traddr=10.161.8.24  --trsvcid=4421
  Failed to write to /dev/nvme-fabrics: Operation already in progress
  failed to connect controller, error 1006

Let's remove this error message.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See: #https://github.com/linux-nvme/nvme-cli/issues/1505