### PR TITLE
fabrics: Introduce connection connect error mapping

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -526,7 +526,26 @@ static int __nvmf_add_ctrl(nvme_root_t r, const char *argstr)
 	if (ret != len) {
 		nvme_msg(r, LOG_NOTICE, "Failed to write to %s: %s\n",
 			 nvmf_dev, strerror(errno));
-		ret = -ENVME_CONNECT_WRITE;
+		switch (errno) {
+		case EALREADY:
+			ret = -ENVME_CONNECT_ALREADY;
+			break;
+		case EINVAL:
+			ret = -ENVME_CONNECT_INVAL;
+			break;
+		case EADDRINUSE:
+			ret = -ENVME_CONNECT_ADDRINUSE;
+			break;
+		case ENODEV:
+			ret = -ENVME_CONNECT_NODEV;
+			break;
+		case EOPNOTSUPP:
+			ret = -ENVME_CONNECT_OPNOTSUPP;
+			break;
+		default:
+			ret = -ENVME_CONNECT_WRITE;
+			break;
+		}
 		goto out_close;
 	}
 

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -536,6 +536,11 @@ static const char * const libnvme_status[] = {
 	[ENVME_CONNECT_INVAL_TR] = "invalid transport type",
 	[ENVME_CONNECT_LOOKUP_SUBSYS_NAME] = "failed to lookup subsystem name",
 	[ENVME_CONNECT_LOOKUP_SUBSYS] = "failed to lookup subsystem",
+	[ENVME_CONNECT_ALREADY] = "already connnected",
+	[ENVME_CONNECT_INVAL] = "invalid arguments/configuration",
+	[ENVME_CONNECT_ADDRINUSE] = "hostnqn already in use",
+	[ENVME_CONNECT_NODEV] = "invalid interface",
+	[ENVME_CONNECT_OPNOTSUPP] ="not supported",
 };
 
 const char *nvme_errno_to_string(int status)

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -31,6 +31,11 @@
  * @ENVME_CONNECT_INVAL_TR:	invalid transport type
  * @ENVME_CONNECT_LOOKUP_SUBSYS_NAME:	failed to lookup subsystem name
  * @ENVME_CONNECT_LOOKUP_SUBSYS: failed to lookup subsystem
+ * @ENVME_CONNECT_ALREADY:	the connect attempt failed, already connected
+ * @ENVME_CONNECT_INVAL:	invalid arguments/configuration
+ * @ENVME_CONNECT_ADDRINUSE:	hostnqn already in use
+ * @ENVME_CONNECT_NODEV:	invalid interface
+ * @ENVME_CONNECT_OPNOTSUPP:	not supported
  */
 enum nvme_connect_err {
 	ENVME_CONNECT_RESOLVE	= 1000,
@@ -45,6 +50,11 @@ enum nvme_connect_err {
 	ENVME_CONNECT_INVAL_TR,
 	ENVME_CONNECT_LOOKUP_SUBSYS_NAME,
 	ENVME_CONNECT_LOOKUP_SUBSYS,
+	ENVME_CONNECT_ALREADY,
+	ENVME_CONNECT_INVAL,
+	ENVME_CONNECT_ADDRINUSE,
+	ENVME_CONNECT_NODEV,
+	ENVME_CONNECT_OPNOTSUPP,
 };
 
 /**


### PR DESCRIPTION
The kernel returns status information via error codes. Currently we
map all error codes to ENVME_CONNECT_WRITE if the operation
fails. Some of those error codes should be treated differently, such
as EALREADY which means the connection attempt failed because the
connection is already established.

Many of the error codes are overloaded so we have to guess if they are
actually from the nvme subsystem and not from the write
command. Though in practice it's almost certainty the nvme
subsystem. Still it's a guessing game due the very limited API
between userland and kernel.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See: #https://github.com/linux-nvme/nvme-cli/issues/1505