### PR TITLE
fix broken includes for the uuid.h header

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -8,27 +8,27 @@
 executable(
     'telemetry-listen',
     ['telemetry-listen.c'],
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )
 
 executable(
     'display-columnar',
     ['display-columnar.c'],
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )
 
 executable(
     'display-tree',
     ['display-tree.c'],
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )
 
 executable(
     'discover-loop',
     ['discover-loop.c'],
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -29,9 +29,9 @@ if have_python_support
     pynvme_clib = python3.extension_module(
         '_nvme',
         pymod_swig[1],
-        dependencies : py3_dep,
+        dependencies : [libnvme_dep, py3_dep],
         include_directories: [incdir, internal_incdir],
-        link_with: [libnvme, libccan],
+        link_with: [libccan],
         install: true,
         subdir: 'libnvme',
     )

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,7 +53,10 @@ pkg.generate(libnvme,
 
 libnvme_dep = declare_dependency(
     include_directories: ['.'],
-    dependencies: deps,
+    dependencies: [
+      libuuid_dep.partial_dependency(compile_args: true, includes: true),
+      json_c_dep.partial_dependency(compile_args: true, includes: true),
+    ],
     link_with: libnvme,
 )
 

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -13,7 +13,7 @@
 
 #include "fabrics.h"
 
-#include <uuid/uuid.h>
+#include <uuid.h>
 
 
 extern const char *nvme_ctrl_sysfs_dir;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -15,7 +15,7 @@
 #include <stddef.h>
 
 #include <sys/types.h>
-#include <uuid/uuid.h>
+#include <uuid.h>
 
 #include "ioctl.h"
 #include "util.h"

--- a/test/meson.build
+++ b/test/meson.build
@@ -12,7 +12,7 @@
 main = executable(
     'main-test',
     ['test.c'],
-    dependencies: libnvme_dep,
+    dependencies: [libnvme_dep, libuuid_dep],
     include_directories: [incdir, internal_incdir]
 )
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -12,28 +12,27 @@
 main = executable(
     'main-test',
     ['test.c'],
-    dependencies: libuuid_dep,
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )
 
 cpp = executable(
     'test-cpp',
     ['cpp.cc'],
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )
 
 register = executable(
     'test-register',
     ['register.c'],
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )
 
 zns = executable(
     'test-zns',
     ['zns.c'],
-    link_with: libnvme,
+    dependencies: libnvme_dep,
     include_directories: [incdir, internal_incdir]
 )

--- a/test/test.c
+++ b/test/test.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <inttypes.h>
-#include <uuid/uuid.h>
+#include <uuid.h>
 #include <libnvme.h>
 
 #include <ccan/endian/endian.h>


### PR DESCRIPTION
Per `man 3 uuid`, the correct include is `<uuid.h>`, and correspondingly the util-linux build system installs the uuid.h file to
`$(includedir)/uuid/` and uuid.pc adds `-I${includedir}/uuid` to the dependency Cflags.

Including it as `<uuid/uuid.h>` simply fails altogether. The exception is if, by coincidence, the libuuid includedir happens to be the same as one of the compiler's own internal include directories... which is pretty common if that is `/usr/include`. In this case, `<uuid/uuid.h>` fails to be found in the uuid dependency's export directories, but the compiler picks up a copy in its builtin search path.

In other cases, such as when util-linux is compiled into a custom prefix and added to the PKG_CONFIG_PATH, it either:
- fails with missing header errors, if libuuid-dev is not installed
- seems to succeed, but compiles against a different version of the headers than the library that is linked to, resulting in potentially various problems from bizarre linker errors, to subtly broken incompatible symbols that crash, or corrupt the results

The problem is even worse if you try to use util-linux as a subproject dependency fallback. In this case, `<uuid.h>` is correctly exported, but there is no disk location for `<uuid/uuid.h>` and absolutely no way to generate such a location in the builddir. This completely prevents the use of subproject fallbacks.