### PR TITLE
tree: avoid segfault if subsysnqn is not available

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -414,7 +414,8 @@ struct nvme_subsystem *nvme_lookup_subsystem(struct nvme_host *h,
 	struct nvme_subsystem *s;
 
 	nvme_for_each_subsystem(h, s) {
-		if (strcmp(s->subsysnqn, subsysnqn))
+		if (subsysnqn && s->subsysnqn &&
+		    strcmp(s->subsysnqn, subsysnqn))
 			continue;
 		if (name && s->name &&
 		    strcmp(s->name, name))


### PR DESCRIPTION
A nvme config command specifying the -M & -J options would end
up in a segfault if subsysnqn is NULL, as shown below:

nvme config -M -J /etc/nvme/config.json
Segmentation fault (core dumped)

Avoid this segfault by proceeding with the subsysnqn strcmp in
nvme_lookup_subsystem() only if subsysnqn is available.

Signed-off-by: Martin George <marting@netapp.com>