### PR TITLE
ioctl: nvme_uring_cmd add structure and opcodes

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -119,6 +119,48 @@ struct nvme_passthru_cmd64 {
         __u64   result;
 };
 
+/**
+ * struct nvme_uring_cmd - nvme uring command structure
+ * @opcode:	Operation code, see &enum nvme_io_opcodes and &enum nvme_admin_opcodes
+ * @flags:	Not supported: intended for command flags (eg: SGL, FUSE)
+ * @rsvd1:	Reserved for future use
+ * @nsid:	Namespace Identifier, or Fabrics type
+ * @cdw2:	Command Dword 2 (no spec defined use)
+ * @cdw3:	Command Dword 3 (no spec defined use)
+ * @metadata:	User space address to metadata buffer (NULL if not used)
+ * @addr:	User space address to data buffer (NULL if not used)
+ * @metadata_len: Metadata buffer transfer length
+ * @data_len:	Data buffer transfer length
+ * @cdw10:	Command Dword 10 (command specific)
+ * @cdw11:	Command Dword 11 (command specific)
+ * @cdw12:	Command Dword 12 (command specific)
+ * @cdw13:	Command Dword 13 (command specific)
+ * @cdw14:	Command Dword 14 (command specific)
+ * @cdw15:	Command Dword 15 (command specific)
+ * @timeout_ms:	If non-zero, overrides system default timeout in milliseconds
+ * @rsvd2:	Reserved for future use (and fills an impicit struct pad
+ */
+struct nvme_uring_cmd {
+	__u8	opcode;
+	__u8	flags;
+	__u16	rsvd1;
+	__u32	nsid;
+	__u32	cdw2;
+	__u32	cdw3;
+	__u64	metadata;
+	__u64	addr;
+	__u32	metadata_len;
+	__u32	data_len;
+	__u32	cdw10;
+	__u32	cdw11;
+	__u32	cdw12;
+	__u32	cdw13;
+	__u32	cdw14;
+	__u32	cdw15;
+	__u32	timeout_ms;
+	__u32   rsvd2;
+};
+
 #define NVME_IOCTL_ID		_IO('N', 0x40)
 #define NVME_IOCTL_RESET	_IO('N', 0x44)
 #define NVME_IOCTL_SUBSYS_RESET	_IO('N', 0x45)
@@ -127,6 +169,10 @@ struct nvme_passthru_cmd64 {
 #define NVME_IOCTL_IO_CMD	_IOWR('N', 0x43, struct nvme_passthru_cmd)
 #define NVME_IOCTL_ADMIN64_CMD  _IOWR('N', 0x47, struct nvme_passthru_cmd64)
 #define NVME_IOCTL_IO64_CMD     _IOWR('N', 0x48, struct nvme_passthru_cmd64)
+
+/* io_uring async commands: */
+#define NVME_URING_CMD_IO	_IOWR('N', 0x80, struct nvme_uring_cmd)
+#define NVME_URING_CMD_IO_VEC	_IOWR('N', 0x81, struct nvme_uring_cmd)
 
 #endif /* _UAPI_LINUX_NVME_IOCTL_H */
 


### PR DESCRIPTION
This patch adds definition of structure nvme_uring_cmd and two new opcodes
NVME_URING_CMD_IO / NVME_URING_CMD_IO_VEC. This new structure
definition and opcodes are required for using uring-nvme-passthrough
feature. This feature has been picked for 5.19 kernel.

https://git.kernel.org/pub/scm/linux/kernel/git/axboe/linux-block.git/log/?h=for-next

Link to the patches
https://git.kernel.org/pub/scm/linux/kernel/git/axboe/linux-block.git/commit/?h=for-next&id=456cba386e94f22fa1b1426303fdcac9e66b1417
https://git.kernel.org/pub/scm/linux/kernel/git/axboe/linux-block.git/commit/?h=for-next&id=f569add47119fa910ed7711b26b8d38e21f7ea77
