### PR TITLE
Consider file config when adding controller

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -19,6 +19,7 @@ LIBNVME_1_0 {
 		nvme_ctrl_first_ns;
 		nvme_ctrl_first_path;
 		nvme_ctrl_get_address;
+		nvme_ctrl_get_config;
 		nvme_ctrl_get_dhchap_key;
 		nvme_ctrl_get_discovery_ctrl;
 		nvme_ctrl_get_fd;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -132,6 +132,11 @@ int json_update_config(nvme_root_t r, const char *config_file);
 
 int json_dump_tree(nvme_root_t r);
 
+nvme_ctrl_t __nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
+			       const char *traddr, const char *host_traddr,
+			       const char *host_iface, const char *trsvcid,
+			       nvme_ctrl_t p);
+
 #if (LOG_FUNCNAME == 1)
 #define __nvme_log_func __func__
 #else

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1020,17 +1020,14 @@ struct nvme_ctrl *nvme_create_ctrl(nvme_root_t r,
 	return c;
 }
 
-nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
-			     const char *traddr, const char *host_traddr,
-			     const char *host_iface, const char *trsvcid,
-			     nvme_ctrl_t p)
+nvme_ctrl_t __nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
+			       const char *traddr, const char *host_traddr,
+			       const char *host_iface, const char *trsvcid,
+			       nvme_ctrl_t p)
+
 {
-	nvme_root_t r;
 	struct nvme_ctrl *c;
 
-	if (!s || !transport)
-		return NULL;
-	r = s->h ? s->h->r : NULL;
 	c = p ? nvme_subsystem_next_ctrl(s, p) : nvme_subsystem_first_ctrl(s);
 	for (; c != NULL; c = nvme_subsystem_next_ctrl(s, c)) {
 		if (strcmp(c->transport, transport))
@@ -1049,6 +1046,27 @@ nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 			continue;
 		return c;
 	}
+
+	return NULL;
+}
+
+nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
+			     const char *traddr, const char *host_traddr,
+			     const char *host_iface, const char *trsvcid,
+			     nvme_ctrl_t p)
+{
+	nvme_root_t r;
+	struct nvme_ctrl *c;
+
+	if (!s || !transport)
+		return NULL;
+
+	c = __nvme_lookup_ctrl(s, transport, traddr, host_traddr,
+			       host_iface, trsvcid, p);
+	if (c)
+		return c;
+
+	r = s->h ? s->h->r : NULL;
 	c = nvme_create_ctrl(r, s->subsysnqn, transport, traddr,
 			     host_traddr, host_iface, trsvcid);
 	if (c) {


### PR DESCRIPTION
fabrics: Consider config from file when adding new controller

nvme_read_config() function is attaching the configuration
to tree. But when we create a new controller via nvme_create_ctrl()
and then call nvmf_add_ctrl() we ignore this previously read
in configuration.

Hence lookup if there exist a controller/config and merge into
the fabrics config.

Note, the order of the merge is important. For example we want
the config from the command line to have higher priority
than the one from the config file.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: https://github.com/linux-nvme/nvme-cli/issues/1520