### PR TITLE
libnvme: export nvme_free_dirents

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -4,6 +4,7 @@ LIBNVME_1_1 {
 	global:
 		nvme_get_version;
 		nvme_init_copy_range_f1;
+		nvme_free_dirents;
 };
 
 LIBNVME_1_0 {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -6,7 +6,6 @@
  * Authors: Keith Busch <keith.busch@wdc.com>
  * 	    Chaitanya Kulkarni <chaitanya.kulkarni@wdc.com>
  */
-#include <dirent.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -48,7 +47,7 @@ static int nvme_ctrl_scan_namespace(nvme_root_t r, struct nvme_ctrl *c,
 				    char *name);
 static int nvme_ctrl_scan_path(nvme_root_t r, struct nvme_ctrl *c, char *name);
 
-static inline void nvme_free_dirents(struct dirent **d, int i)
+void nvme_free_dirents(struct dirent **d, int i)
 {
 	while (i-- > 0)
 		free(d[i]);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -10,6 +10,7 @@
 #ifndef _LIBNVME_TREE_H
 #define _LIBNVME_TREE_H
 
+#include <dirent.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -1227,5 +1228,12 @@ const char *nvme_host_get_hostsymname(nvme_host_t h);
  * @hostsymname:	Symbolic name
  */
 void nvme_host_set_hostsymname(nvme_host_t h, const char *hostsymname);
+
+/**
+ * nvme_free_dirents() - free dirents
+ * @d:		Dirents that is allocated with scan functions
+ * @count:	Number of dirents to be free
+ */
+void nvme_free_dirents(struct dirent **d, int count);
 
 #endif /* _LIBNVME_TREE_H */


### PR DESCRIPTION
it should be called after called nvme_scan_* that use dirents

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>