### PR TITLE
meson: only build test/cpp if a c++ compiler is available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
 project(
-    'libnvme', ['c', 'cpp'],
+    'libnvme', ['c'],
     meson_version: '>= 0.47.0',
     version: '1.0',
     license: 'LGPL-2.1-or-later',
@@ -22,6 +22,7 @@ library_version = meson.project_version() + '.0'
 
 ################################################################################
 cc = meson.get_compiler('c')
+cxx_available = add_languages('cpp', required: false)
 
 prefixdir  = get_option('prefix')
 libdir     = join_paths(prefixdir, get_option('libdir'))

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,12 +16,14 @@ main = executable(
     include_directories: [incdir, internal_incdir]
 )
 
-cpp = executable(
-    'test-cpp',
-    ['cpp.cc'],
-    dependencies: libnvme_dep,
-    include_directories: [incdir, internal_incdir]
-)
+if cxx_available
+    cpp = executable(
+        'test-cpp',
+        ['cpp.cc'],
+        dependencies: libnvme_dep,
+        include_directories: [incdir, internal_incdir]
+    )
+endif
 
 register = executable(
     'test-register',


### PR DESCRIPTION
Currently, the meson project configuration specifies both 'c' and 'ccp'
languages. We use the latter to build a single test binary.

This change makes the cpp language optional, so we can compile the rest
of libnvme without a C++ environment.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>