### PR TITLE
examples: Fix printf format warnings on 32-bit

### DIFF
--- a/examples/display-tree.c
+++ b/examples/display-tree.c
@@ -11,6 +11,7 @@
  * selected attributes for each component.
  */
 #include <stdio.h>
+#include <inttypes.h>
 #include <libnvme.h>
 
 int main()
@@ -34,7 +35,7 @@ int main()
 			       nvme_subsystem_get_nqn(s));
 
 			nvme_subsystem_for_each_ns_safe(s, n, _n) {
-				printf("%c   |-- %s lba size:%d lba max:%lu\n",
+				printf("%c   |-- %s lba size:%d lba max:%" PRIu64 "\n",
 				       _s ? '|' : ' ',
 				       nvme_ns_get_name(n),
 				       nvme_ns_get_lba_size(n),
@@ -50,7 +51,7 @@ int main()
 				       nvme_ctrl_get_state(c));
 
 				nvme_ctrl_for_each_ns_safe(c, n, _n)
-					printf("%c   %c   %c-- %s lba size:%d lba max:%lu\n",
+					printf("%c   %c   %c-- %s lba size:%d lba max:%" PRIu64 "\n",
 					       _s ? '|' : ' ', _c ? '|' : ' ',
 					       _n ? '|' : '`',
 					       nvme_ns_get_name(n),

--- a/examples/telemetry-listen.c
+++ b/examples/telemetry-listen.c
@@ -66,7 +66,7 @@ static void save_telemetry(nvme_ctrl_t c)
 	if (ret < 0)
 		printf("failed to write telemetry log\n");
 	else
-		printf("telemetry log save as %s, wrote:%d size:%ld\n", buf,
+		printf("telemetry log save as %s, wrote:%d size:%zd\n", buf,
 			ret, log_size);
 	close(fd);
 	free(log);


### PR DESCRIPTION
We have a few warnings from mismatched printf format specifiers on
32-bit builds. Use PRIu64 for uint64_t, and %z for size_t.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>