### PR TITLE
tree: simplifiy nvme_subsystem_lookup_namespace()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1840,7 +1840,7 @@ nvme_ns_t nvme_scan_namespace(const char *name)
 static int nvme_ctrl_scan_namespace(nvme_root_t r, struct nvme_ctrl *c,
 				    char *name)
 {
-	struct nvme_ns *n;
+	struct nvme_ns *n, *_n, *__n;
 
 	nvme_msg(r, LOG_DEBUG, "scan controller %s namespace %s\n",
 		 c->name, name);
@@ -1854,7 +1854,11 @@ static int nvme_ctrl_scan_namespace(nvme_root_t r, struct nvme_ctrl *c,
 		nvme_msg(r, LOG_DEBUG, "failed to scan namespace %s\n", name);
 		return -1;
 	}
-
+	nvme_ctrl_for_each_ns_safe(c, _n, __n) {
+		if (strcmp(n->name, _n->name))
+			continue;
+		__nvme_free_ns(_n);
+	}
 	n->s = c->s;
 	n->c = c;
 	list_add(&c->namespaces, &n->entry);

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1913,22 +1913,11 @@ static int nvme_subsystem_scan_namespace(nvme_root_t r, nvme_subsystem_t s,
 struct nvme_ns *nvme_subsystem_lookup_namespace(struct nvme_subsystem *s,
 						__u32 nsid)
 {
-	nvme_root_t r = s->h ? s->h->r : NULL;
 	struct nvme_ns *n;
-	char *name;
-	int ret;
 
-	ret = asprintf(&name, "%sn%u", s->name, nsid);
-	if (ret < 0)
-		return NULL;
-	n = __nvme_scan_namespace(s->sysfs_dir, name);
-	free(name);
-	if (!n) {
-		nvme_msg(r, LOG_DEBUG, "failed to scan namespace %d\n", nsid);
-		return NULL;
+	nvme_subsystem_for_each_ns(s, n) {
+		if (nvme_ns_get_nsid(n) == nsid)
+			return n;
 	}
-
-	n->s = s;
-	list_add(&s->namespaces, &n->entry);
-	return n;
+	return NULL;
 }


### PR DESCRIPTION
The list of namespaces needs to be considered static, and should
only be changed on a full rescan. So simplify the function to just
return the corresponding namespace entry from the topology tree.

Fixes: #364

Signed-off-by: Hannes Reinecke <hare@suse.de>