### PR TITLE
README: add note about min kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ please consult the following sites:
 
 **meson repo**: https://github.com/mesonbuild/meson
 
+## Dependency
+
+libnvme depends on minimum Linux kernel version v4.15, which
+introduced the /sys/class/nvme-subsystem.
+
 ## Prerequisite
 
 First, install meson.

--- a/doc/index.rst.in
+++ b/doc/index.rst.in
@@ -1,19 +1,18 @@
 Welcome to libnvme's documentation!
 ===================================
 
+This is the libnvme development C library. libnvme provides type definitions for
+NVMe specification structures, enumerations, and bit fields,
+helper functions to construct, dispatch, and decode commands and payloads,
+and utilities to connect, scan, and manage nvme devices on a Linux system.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-.. include::   rst/types.rst
-.. include::   rst/ioctl.rst
-.. include::   rst/fabrics.rst
-.. include::   rst/linux.rst
-.. include::   rst/tree.rst
-.. include::   rst/filters.rst
-.. include::   rst/util.rst
-.. include::   rst/log.rst
-
+   installation.rst
+   quickstart.rst
+   api.rst
 
 Indices and tables
 ==================

--- a/doc/installation.rst.in
+++ b/doc/installation.rst.in
@@ -1,18 +1,46 @@
 Installation
 ============
 
+Debian / Ubuntu:
+--------------
+
+.. code-block:: sh
+
+    $ apt-get install libnvme
+
+Fedora / Red Hat:
+--------------
+
+.. code-block:: sh
+
+    $ dnf install libnvme
+
 Python Version
 --------------
 
-tbd
+The latest Python 3 version is always recommended, since it has all the latest bells and
+whistles. libnvme supports Python 3.6 and above.
 
 Dependencies
 ------------
 
-tbd
+libnvme only uses packages from the standard library,
+so no additional dependencies will be installed when installing libnvme.
 
-Install libnvme
+Install libnvme python
 -------------
+
+Debian / Ubuntu:
+
+.. code-block:: sh
+
+    $ apt-get install python3-libnvme
+
+Fedora / Red Hat:
+
+.. code-block:: sh
+
+    $ dnf install python3-libnvme
 
 libnvme is available on `PyPI`_, and can be installed using pip. The version on PyPI is
 always the latest stable release.

--- a/doc/installation.rst.in
+++ b/doc/installation.rst.in
@@ -2,33 +2,36 @@ Installation
 ============
 
 Debian / Ubuntu:
---------------
+----------------
 
 .. code-block:: sh
 
     $ apt-get install libnvme
 
 Fedora / Red Hat:
---------------
+-----------------
 
 .. code-block:: sh
 
     $ dnf install libnvme
 
-Python Version
+Python binding
 --------------
 
-The latest Python 3 version is always recommended, since it has all the latest bells and
-whistles. libnvme supports Python 3.6 and above.
+Python Version
+^^^^^^^^^^^^^^
+
+The latest Python 3 version is always recommended, since it has all
+the latest bells and whistles. libnvme supports Python 3.6 and above.
 
 Dependencies
-------------
+^^^^^^^^^^^^
 
-libnvme only uses packages from the standard library,
-so no additional dependencies will be installed when installing libnvme.
+libnvme only uses packages from the standard library, so no additional
+dependencies will be installed when installing libnvme.
 
 Install libnvme python
--------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 Debian / Ubuntu:
 
@@ -42,8 +45,8 @@ Fedora / Red Hat:
 
     $ dnf install python3-libnvme
 
-libnvme is available on `PyPI`_, and can be installed using pip. The version on PyPI is
-always the latest stable release.
+libnvme is available on `PyPI`_, and can be installed using pip. The
+version on PyPI is always the latest stable release.
 
 .. _PyPi: https://pypi.org/project/libnvme/
 


### PR DESCRIPTION
The min kernel version is v4.15 kernel because libnvme depends on the
/sys/class/nvme-subsystem interface.

Signed-off-by: Daniel Wagner [dwagner@suse.de](mailto:dwagner@suse.de)

Fixes https://github.com/linux-nvme/nvme-cli/issues/1516