### PR TITLE
build: add 'uninstall' to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,21 @@ ifneq ("$(wildcard ${BUILD-DIR})","")
 	rm -rf ${BUILD-DIR}
 endif
 
-.PHONY: install dist
-install dist: ${BUILD-DIR}
-	cd ${BUILD-DIR} && meson $@
+.PHONY: install
+install: ${NAME}
+	cd ${BUILD-DIR} && sudo meson $@
+
+.PHONY: uninstall
+uninstall: ${BUILD-DIR}
+	sudo ninja -C ${BUILD-DIR} $@
 
 .PHONY: test
-test: ${BUILD-DIR}
+test: ${NAME}
 	ninja -C ${BUILD-DIR} $@
+
+.PHONY: dist
+dist: ${NAME}
+	cd ${BUILD-DIR} && meson $@
 
 .PHONY: rpm
 rpm: dist


### PR DESCRIPTION
Changes in this patch:

- This patch adds an `uninstall` target to the Makefile, which only had an `install` target but no `uninstall`. Note that for `uninstall` to work, an `install` must have previously been performed. meson/ninja keep installation data in the build directory that is required in order to perform an uninstall.
- Fixed dependency issues for `install`, `test`, and `dist`. These targets depend on `libnvme` being built. The previous dependency just required the configuration (meson) as the dependency and not actually building `libnvme`

Signed-off-by: Martin Belanger <martin.belanger@dell.com>