### PR TITLE
build: Add api-types.h to install headers

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -104,6 +104,7 @@ pkg.generate(libnvme_mi,
 mode = ['rw-r--r--', 0, 0]
 install_headers('libnvme.h', install_mode: mode)
 install_headers([
+        'nvme/api-types.h',
         'nvme/fabrics.h',
         'nvme/filters.h',
         'nvme/ioctl.h',


### PR DESCRIPTION
Signed-off-by: Jeff Lien <jeff.lien@wdc.com>

This will fix compile errors seen with the latest nvme-cli code needing the api-types.h include file.  