### PR TITLE
meson: use host target for defining endianness

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -125,12 +125,12 @@ conf.set10(
 )
 conf.set10(
     'HAVE_LITTLE_ENDIAN',
-    build_machine.endian() == 'little',
+    host_machine.endian() == 'little',
     description: 'Building for little-endian'
 )
 conf.set10(
     'HAVE_BIG_ENDIAN',
-    build_machine.endian() == 'big',
+    host_machine.endian() == 'big',
     description: 'Building for big-endian'
 )
 conf.set10(


### PR DESCRIPTION
We're currently basing the host endian tests on the build_machine; we
should be using host_machine instead.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>