### PR TITLE
Fix %llx/%lx build warnings on powerpc

### DIFF
--- a/examples/discover-loop.c
+++ b/examples/discover-loop.c
@@ -12,6 +12,8 @@
  * system (no existing connection required). The output will look more
  * interesting with more targets.
  */
+#define __SANE_USERSPACE_TYPES__
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/register.c
+++ b/test/register.c
@@ -11,6 +11,8 @@
  * for your pci device found in /sys/class/nvme/nvmeX/device/resource0
  */
 
+#define __SANE_USERSPACE_TYPES__
+
 #include <fcntl.h>
 #include <inttypes.h>
 #include <libnvme.h>


### PR DESCRIPTION
powerpc64 uses the `int-l64` type definitions, so we get an unsigned long
for our `__u64` type. This causes several build warnings when we're
printing with `%llx` in tests/register.c and example/discover-loop.c, as
it's an unsigned long, not an unsigned long long.

One way to fix this would be to use the PRIx64 definitions from
inttypes.h - however, those are keyed off the `__WORDSIZE` definition,
essentially:

    # if __WORDSIZE == 64
    #  define PRIx64	"lx"
    # else
    #  define PRIx64	"llx"
    # endif

\- and that breaks on x86_64, where our `__u64` is an unsigned long long,
and would need `%llx`.

The powerpc types header does give us an option to use the int-l64
definitions though:

    /*
     * This is here because we used to use l64 for 64bit powerpc
     * and we don't want to impact user mode with our change to ll64
     * in the kernel.
     *
     * However, some user programs are fine with this.  They can
     * flag __SANE_USERSPACE_TYPES__ to get int-ll64.h here.
     */
    #if !defined(__SANE_USERSPACE_TYPES__) && defined(__powerpc64__) && !defined(__KERNEL__)
    # include <asm-generic/int-l64.h>
    #else
    # include <asm-generic/int-ll64.h>
    #endif

... and in our case we are in fact fine with this. So, #define
`__SANE_USERSPACE_TYPES__` for the two example programs.

We refrain from doing this to the library headers though, as we have no
idea what libnvme users will need for `__u64`.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>