### PR TITLE
doc: Add kernel-doc to header files

### DIFF
--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -102,6 +102,7 @@ struct nvme_get_log_args {
  * @nsid:	Namespace ID, if applicable
  * @cdw11:	Value to set the feature to
  * @cdw12:	Feature specific command dword12 field
+ * @cdw13:	Feature specific command dword13 field
  * @cdw15:	Feature specific command dword15 field
  * @data_len:	Length of feature data, if applicable, in bytes
  * @save:	Save value across power states
@@ -167,6 +168,7 @@ struct nvme_get_features_args {
  * @pil:	Protection information location (beginning or end), true if end
  * @ses:	Secure erase settings
  * @lbaf:	Logical block address format least significant 4 bits
+ * @rsvd1:	Reserved
  * @lbafu:	Logical block address format most significant 2 bits
  */
 struct nvme_format_nvm_args {
@@ -586,6 +588,7 @@ struct nvme_virtual_mgmt_args {
  *		to use end-to-end protection information.
  * @dspec:	Directive specific value
  * @dsm:	Data set management attributes, see &enum nvme_io_dsm_flags
+ * @rsvd1:	Reserved
  * @reftag_u64:	This field specifies the variable sized Expected Initial
  *		Logical Block Reference Tag (EILBRT) or Initial Logical Block
  *		Reference Tag (ILBRT). It is the 8 byte version required for
@@ -862,6 +865,7 @@ struct nvme_zns_mgmt_recv_args {
  * @control:
  * @lbat:	Logical block application tag
  * @lbatm:	Logical block application tag mask
+ * @rsvd1:	Reserved
  * @ilbrt_u64:	Initial logical block reference tag - 8 byte
  *              version required for enhanced protection info
  *

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -95,7 +95,7 @@ struct nvme_passthru_cmd {
  * @cdw14:	Command Dword 14 (command specific)
  * @cdw15:	Command Dword 15 (command specific)
  * @timeout_ms:	If non-zero, overrides system default timeout in milliseconds
- * @rsvd2:	Reserved for future use (and fills an impicit struct pad
+ * @rsvd2:	Reserved for future use (and fills an implicit struct pad
  * @result:	Set on completion to the command's CQE DWORD 0-1 controller response
  */
 struct nvme_passthru_cmd64 {
@@ -139,7 +139,7 @@ struct nvme_passthru_cmd64 {
  * @cdw14:	Command Dword 14 (command specific)
  * @cdw15:	Command Dword 15 (command specific)
  * @timeout_ms:	If non-zero, overrides system default timeout in milliseconds
- * @rsvd2:	Reserved for future use (and fills an impicit struct pad
+ * @rsvd2:	Reserved for future use (and fills an implicit struct pad
  */
 struct nvme_uring_cmd {
 	__u8	opcode;
@@ -180,7 +180,10 @@ struct nvme_uring_cmd {
 #endif /* _LINUX_NVME_IOCTL_H */
 
 /**
- * Helper function used to determine structure sizes
+ * sizeof_args - Helper function used to determine structure sizes
+ * @type:	Argument structure type
+ * @member:	Member inside the type
+ * @align:	Alignment information
  */
 #define sizeof_args(type, member, align)					\
   ({										\
@@ -210,7 +213,7 @@ int nvme_submit_admin_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
  * @fd:		File descriptor of nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
- * @rsvd:	Reserevd for future use
+ * @rsvd:	Reserved for future use
  * @nsid:	Namespace identifier
  * @cdw2:	Command dword 2
  * @cdw3:	Command dword 3
@@ -220,9 +223,9 @@ int nvme_submit_admin_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
  * @cdw13:	Command dword 13
  * @cdw14:	Command dword 14
  * @cdw15:	Command dword 15
- * @data_len:	Length of the data transfered in this command in bytes
+ * @data_len:	Length of the data transferred in this command in bytes
  * @data:	Pointer to user address of the data buffer
- * @metadata_len:Length of metadata transfered in this command
+ * @metadata_len:Length of metadata transferred in this command
  * @metadata:	Pointer to user address of the metadata buffer
  * @timeout_ms:	How long the kernel waits for the command to complete
  * @result:	Optional field to return the result from the CQE dword 0
@@ -260,7 +263,7 @@ int nvme_submit_admin_passthru(int fd, struct nvme_passthru_cmd *cmd,
  * @fd:		File descriptor of nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
- * @rsvd:	Reserevd for future use
+ * @rsvd:	Reserved for future use
  * @nsid:	Namespace identifier
  * @cdw2:	Command dword 2
  * @cdw3:	Command dword 3
@@ -270,9 +273,9 @@ int nvme_submit_admin_passthru(int fd, struct nvme_passthru_cmd *cmd,
  * @cdw13:	Command dword 13
  * @cdw14:	Command dword 14
  * @cdw15:	Command dword 15
- * @data_len:	Length of the data transfered in this command in bytes
+ * @data_len:	Length of the data transferred in this command in bytes
  * @data:	Pointer to user address of the data buffer
- * @metadata_len:Length of metadata transfered in this command
+ * @metadata_len:Length of metadata transferred in this command
  * @metadata:	Pointer to user address of the metadata buffer
  * @timeout_ms:	How long the kernel waits for the command to complete
  * @result:	Optional field to return the result from the CQE dword 0
@@ -310,7 +313,7 @@ int nvme_submit_io_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
  * @fd:		File descriptor of nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
- * @rsvd:	Reserevd for future use
+ * @rsvd:	Reserved for future use
  * @nsid:	Namespace identifier
  * @cdw2:	Command dword 2
  * @cdw3:	Command dword 3
@@ -320,9 +323,9 @@ int nvme_submit_io_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
  * @cdw13:	Command dword 13
  * @cdw14:	Command dword 14
  * @cdw15:	Command dword 15
- * @data_len:	Length of the data transfered in this command in bytes
+ * @data_len:	Length of the data transferred in this command in bytes
  * @data:	Pointer to user address of the data buffer
- * @metadata_len:Length of metadata transfered in this command
+ * @metadata_len:Length of metadata transferred in this command
  * @metadata:	Pointer to user address of the metadata buffer
  * @timeout_ms:	How long the kernel waits for the command to complete
  * @result:	Optional field to return the result from the CQE dword 0
@@ -361,7 +364,7 @@ int nvme_submit_io_passthru(int fd, struct nvme_passthru_cmd *cmd,
  * @fd:		File descriptor of nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
- * @rsvd:	Reserevd for future use
+ * @rsvd:	Reserved for future use
  * @nsid:	Namespace identifier
  * @cdw2:	Command dword 2
  * @cdw3:	Command dword 3
@@ -371,9 +374,9 @@ int nvme_submit_io_passthru(int fd, struct nvme_passthru_cmd *cmd,
  * @cdw13:	Command dword 13
  * @cdw14:	Command dword 14
  * @cdw15:	Command dword 15
- * @data_len:	Length of the data transfered in this command in bytes
+ * @data_len:	Length of the data transferred in this command in bytes
  * @data:	Pointer to user address of the data buffer
- * @metadata_len:Length of metadata transfered in this command
+ * @metadata_len:Length of metadata transferred in this command
  * @metadata:	Pointer to user address of the metadata buffer
  * @timeout_ms:	How long the kernel waits for the command to complete
  * @result:	Optional field to return the result from the CQE dword 0
@@ -532,7 +535,7 @@ static inline int nvme_identify_allocated_ns(int fd, __u32 nsid,
 /**
  * nvme_identify_active_ns_list() - Retrieves active namespaces id list
  * @fd:		File descriptor of nvme device
- * @nsid:	Return namespaces greater than this identifer
+ * @nsid:	Return namespaces greater than this identifier
  * @list:	User space destination address to transfer the data
  *
  * A list of 1024 namespace IDs is returned to the host containing NSIDs in
@@ -554,7 +557,7 @@ static inline int nvme_identify_active_ns_list(int fd, __u32 nsid,
 /**
  * nvme_identify_allocated_ns_list() - Retrieves allocated namespace id list
  * @fd:		File descriptor of nvme device
- * @nsid:	Return namespaces greater than this identifer
+ * @nsid:	Return namespaces greater than this identifier
  * @list:	User space destination address to transfer the data
  *
  * A list of 1024 namespace IDs is returned to the host containing NSIDs in
@@ -647,14 +650,14 @@ static inline int nvme_identify_nsid_ctrl_list(int fd, __u32 nsid, __u16 cntid,
 /**
  * nvme_identify_ns_descs() - Retrieves namespace descriptor list
  * @fd:		File descriptor of nvme device
- * @nsid:	The namespace id to retrieve destriptors
+ * @nsid:	The namespace id to retrieve descriptors
  * @descs:	User space destination address to transfer the data
  *
  * A list of Namespace Identification Descriptor structures is returned to the
  * host for the namespace specified in the Namespace Identifier (NSID) field if
  * it is an active NSID.
  *
- * The data returned is in the form of an arrray of 'struct nvme_ns_id_desc'.
+ * The data returned is in the form of an array of 'struct nvme_ns_id_desc'.
  *
  * See &struct nvme_ns_id_desc for the definition of the returned structure.
  *
@@ -679,7 +682,7 @@ static inline int nvme_identify_ns_descs(int fd, __u32 nsid,
  * Identifier supported by the NVM subsystem that is equal to or greater than
  * the NVM Set Identifier.
  *
- * See &struct nvme_id_nvmset_list for the defintion of the returned structure.
+ * See &struct nvme_id_nvmset_list for the definition of the returned structure.
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
@@ -711,7 +714,7 @@ static inline int nvme_identify_nvmset_list(int fd, __u16 nvmsetid,
  * @cntid:	Return controllers starting at this identifier
  * @cap:	User space destination buffer address to transfer the data
  *
- * See &struct nvme_primary_ctrl_cap for the defintion of the returned structure, @cap.
+ * See &struct nvme_primary_ctrl_cap for the definition of the returned structure, @cap.
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
@@ -748,7 +751,7 @@ static inline int nvme_identify_primary_ctrl(int fd, __u16 cntid,
  * The list contains entries for controller identifiers greater than or equal
  * to the value specified in the Controller Identifier (cntid).
  *
- * See &struct nvme_secondary_ctrls_list for a defintion of the returned
+ * See &struct nvme_secondary_ctrls_list for a definition of the returned
  * structure.
  *
  * Return: The nvme command status if a response was received (see
@@ -824,7 +827,7 @@ static inline int nvme_identify_uuid(int fd, struct nvme_id_uuid_list *uuid_list
  * @csi:	Command Set Identifier
  * @data:	User space destination address to transfer the data
  *
- * An I/O Command Set specific Identify Namespace data structre is returned
+ * An I/O Command Set specific Identify Namespace data structure is returned
  * for the namespace specified in @nsid.
  *
  * Return: The nvme command status if a response was received (see
@@ -990,11 +993,12 @@ static inline int nvme_identify_independent_identify_ns(int fd, __u32 nsid,
 }
 
 /**
- * nvme_identify_ns_csi_user_data_format() -
+ * nvme_identify_ns_csi_user_data_format() - Identify namespace user data format
  * @fd:		File descriptor of nvme device
  * @user_data_format: Return namespaces capability of identifier
  * @uuidx:	UUID selection, if supported
  * @csi:	Command Set Identifier
+ * @data:	User space destination address to transfer the data
  *
  * Identify Namespace data structure for the specified User Data Format
  * index containing the namespace capabilities for the NVM Command Set.
@@ -1024,11 +1028,12 @@ static inline int nvme_identify_ns_csi_user_data_format(int fd,
 }
 
 /**
- * nvme_identify_iocs_ns_csi_user_data_format() -
+ * nvme_identify_iocs_ns_csi_user_data_format() - Identify I/O command set namespace data structure
  * @fd:		File descriptor of nvme device
  * @user_data_format: Return namespaces capability of identifier
  * @uuidx:	UUID selection, if supported
  * @csi:	Command Set Identifier
+ * @data:	User space destination address to transfer the data
  *
  * I/O Command Set specific Identify Namespace data structure for
  * the specified User Data Format index containing the namespace
@@ -1078,7 +1083,7 @@ static inline int nvme_nvm_identify_ctrl(int fd, struct nvme_id_ctrl_nvm *id)
  * nvme_identify_domain_list() - Domain list data
  * @fd:		File descriptor of nvme device
  * @domid:	Domain ID
- * @list:	User space destiantion address to transfer data
+ * @list:	User space destination address to transfer data
  *
  * A list of 31 domain IDs is returned to the host containing domain
  * attributes in increasing order that are greater than the value
@@ -1412,6 +1417,9 @@ static inline int nvme_get_log_device_self_test(int fd,
  * nvme_get_log_create_telemetry_host() - Create host telemetry log
  * @fd:		File descriptor of nvme device
  * @log:	Userspace address of the log payload
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_log_create_telemetry_host(int fd,
 			struct nvme_telemetry_log *log)
@@ -1437,13 +1445,13 @@ static inline int nvme_get_log_create_telemetry_host(int fd,
 }
 
 /**
- * nvme_get_log_telemetry_host() -
+ * nvme_get_log_telemetry_host() - Get Telemetry Host-Initiated log page
  * @fd:		File descriptor of nvme device
  * @offset:	Offset into the telemetry data
  * @len:	Length of provided user buffer to hold the log data in bytes
  * @log:	User address for log page data
  *
- * Retreives the Telemetry Host-Initiated log page at the requested offset
+ * Retrieves the Telemetry Host-Initiated log page at the requested offset
  * using the previously existing capture.
  *
  * Return: The nvme command status if a response was received (see
@@ -1473,12 +1481,18 @@ static inline int nvme_get_log_telemetry_host(int fd, __u64 offset,
 }
 
 /**
- * nvme_get_log_telemetry_ctrl() -
+ * nvme_get_log_telemetry_ctrl() - Get Telemetry Controller-Initiated log page
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset into the telemetry data
  * @len:	Length of provided user buffer to hold the log data in bytes
  * @log:	User address for log page data
+ *
+ * Retrieves the Telemetry Controller-Initiated log page at the requested offset
+ * using the previously existing capture.
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_log_telemetry_ctrl(int fd, bool rae,
 			__u64 offset, __u32 len, void *log)
@@ -1504,7 +1518,7 @@ static inline int nvme_get_log_telemetry_ctrl(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_endurance_group() -
+ * nvme_get_log_endurance_group() - Get Endurance Group log
  * @fd:		File descriptor of nvme device
  * @endgid:	Starting group identifier to return in the list
  * @log:	User address to store the endurance log
@@ -1543,7 +1557,7 @@ static inline int nvme_get_log_endurance_group(int fd, __u16 endgid,
 }
 
 /**
- * nvme_get_log_predictable_lat_nvmset() -
+ * nvme_get_log_predictable_lat_nvmset() - Predictable Latency Per NVM Set
  * @fd:		File descriptor of nvme device
  * @nvmsetid:	NVM set id
  * @log:	User address to store the predictable latency log
@@ -1575,12 +1589,15 @@ static inline int nvme_get_log_predictable_lat_nvmset(int fd, __u16 nvmsetid,
 }
 
 /**
- * nvme_get_log_predictable_lat_event() -
+ * nvme_get_log_predictable_lat_event() - Retrieve Predictable Latency Event Aggregate Log Page
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset into the predictable latency event
  * @len:	Length of provided user buffer to hold the log data in bytes
  * @log:	User address for log page data
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_log_predictable_lat_event(int fd, bool rae,
 			__u32 offset, __u32 len, void *log)
@@ -1606,19 +1623,19 @@ static inline int nvme_get_log_predictable_lat_event(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_ana() -
+ * nvme_get_log_ana() - Retrieve Asymmetric Namespace Access log page
  * @fd:		File descriptor of nvme device
  * @lsp:	Log specific, see &enum nvme_get_log_ana_lsp
  * @rae:	Retain asynchronous events
  * @offset:	Offset to the start of the log page
  * @len:	The allocated length of the log page
- * @log: 	User address to store the ana log
+ * @log:	User address to store the ana log
  *
  * This log consists of a header describing the log and descriptors containing
  * the asymmetric namespace access information for ANA Groups that contain
  * namespaces that are attached to the controller processing the command.
  *
- * See &struct nvme_ana_rsp_hdr for the defintion of the returned structure.
+ * See &struct nvme_ana_rsp_hdr for the definition of the returned structure.
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
@@ -1647,13 +1664,16 @@ static inline int nvme_get_log_ana(int fd, enum nvme_log_ana_lsp lsp, bool rae,
 }
 
 /**
- * nvme_get_log_ana_groups() -
+ * nvme_get_log_ana_groups() - Retrieve Asymmetric Namespace Access groups only log page
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @len:	The allocated length of the log page
- * @log: 	User address to store the ana group log
+ * @log:	User address to store the ana group log
  *
- * See &struct nvme_ana_group_desc for the defintion of the returned structure.
+ * See &struct nvme_ana_group_desc for the definition of the returned structure.
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_log_ana_groups(int fd, bool rae, __u32 len,
 			    struct nvme_ana_group_desc *log)
@@ -1663,12 +1683,15 @@ static inline int nvme_get_log_ana_groups(int fd, bool rae, __u32 len,
 }
 
 /**
- * nvme_get_log_lba_status() -
+ * nvme_get_log_lba_status() - Retrieve LBA Status
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset to the start of the log page
  * @len:	The allocated length of the log page
- * @log: 	User address to store the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_log_lba_status(int fd, bool rae,
 			__u64 offset, __u32 len, void *log)
@@ -1694,12 +1717,15 @@ static inline int nvme_get_log_lba_status(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_endurance_grp_evt() -
+ * nvme_get_log_endurance_grp_evt() - Retrieve Rotational Media Information
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset to the start of the log page
  * @len:	The allocated length of the log page
- * @log: 	User address to store the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_log_endurance_grp_evt(int fd, bool rae,
 			__u32 offset, __u32 len, void *log)
@@ -1725,7 +1751,7 @@ static inline int nvme_get_log_endurance_grp_evt(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_fid_supported_effects() -
+ * nvme_get_log_fid_supported_effects() - Retrieve Feature Identifiers Supported and Effects
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @log:	FID Supported and Effects data structure
@@ -1741,7 +1767,7 @@ static inline int nvme_get_log_fid_supported_effects(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_mi_cmd_supported_effects() - displays the MI Commands Supported byt the controller
+ * nvme_get_log_mi_cmd_supported_effects() - displays the MI Commands Supported by the controller
  * @fd:     File descriptor of nvme device
  * @rae:    Retain asynchronous events
  * @log:    MI Command Supported and Effects data structure
@@ -1757,13 +1783,13 @@ static inline int nvme_get_log_mi_cmd_supported_effects(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_boot_partition() -
+ * nvme_get_log_boot_partition() - Retrieve Boot Partition
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @lsp:	The log specified field of LID
  * @len:	The allocated size, minimum
  *		struct nvme_boot_partition
- * @part: 	User address to store the log page
+ * @part:	User address to store the log page
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
@@ -1792,7 +1818,7 @@ static inline int nvme_get_log_boot_partition(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_discovery() -
+ * nvme_get_log_discovery() - Retrieve Discovery log page
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset of this log to retrieve
@@ -1829,7 +1855,7 @@ static inline int nvme_get_log_discovery(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_media_unit_stat() -
+ * nvme_get_log_media_unit_stat() - Retrieve Media Unit Status
  * @fd:		File descriptor of nvme device
  * @domid:	Domain Identifier selection, if supported
  * @mus:	User address to store the Media Unit statistics log
@@ -1861,9 +1887,10 @@ static inline int nvme_get_log_media_unit_stat(int fd, __u16 domid,
 }
 
 /**
- * nvme_get_log_support_cap_config_list() -
+ * nvme_get_log_support_cap_config_list() - Retrieve Supported Capacity Configuration List
  * @fd:		File descriptor of nvme device
  * @domid:	Domain Identifier selection, if supported
+ * @cap:	User address to store supported capabilities config list
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
@@ -1892,10 +1919,13 @@ static inline int nvme_get_log_support_cap_config_list(int fd, __u16 domid,
 }
 
 /**
- * nvme_get_log_reservation() -
+ * nvme_get_log_reservation() - Retrieve Reservation Notification
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @log:	User address to store the reservation log
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
  */
 static inline int nvme_get_log_reservation(int fd, bool rae,
 			struct nvme_resv_notification_log *log)
@@ -1905,7 +1935,7 @@ static inline int nvme_get_log_reservation(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_sanitize() -
+ * nvme_get_log_sanitize() - Retrieve Sanitize Status
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events
  * @log:	User address to store the sanitize log
@@ -1924,7 +1954,7 @@ static inline int nvme_get_log_sanitize(int fd, bool rae,
 }
 
 /**
- * nvme_get_log_zns_changed_zones() -
+ * nvme_get_log_zns_changed_zones() - Retrieve list of zones that have changed
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @rae:	Retain asynchronous events
@@ -1959,11 +1989,14 @@ static inline int nvme_get_log_zns_changed_zones(int fd, __u32 nsid, bool rae,
 }
 
 /**
- * nvme_get_log_persistent_event() -
+ * nvme_get_log_persistent_event() - Retrieve Persistent Event Log
  * @fd:		File descriptor of nvme device
  * @action:	Action the controller should take during processing this command
  * @size:	Size of @pevent_log
  * @pevent_log:	User address to store the persistent event log
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_log_persistent_event(int fd,
 			enum nvme_pevent_log_action action,
@@ -2008,6 +2041,9 @@ int nvme_set_features(struct nvme_set_features_args *args);
  * @data_len:	Length of feature data, if applicable, in bytes
  * @data:	User address of feature data, if applicable
  * @result:	The command completion result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_set_features_data(int fd, __u8 fid, __u32 nsid,
 			__u32 cdw11, bool save, __u32 data_len, void *data,
@@ -2033,13 +2069,16 @@ static inline int nvme_set_features_data(int fd, __u8 fid, __u32 nsid,
 }
 
 /**
- * nvme_set_features_simple() - Helper functionn for @nvme_set_features()
+ * nvme_set_features_simple() - Helper function for @nvme_set_features()
  * @fd:		File descriptor of nvme device
  * @fid:	Feature identifier
  * @nsid:	Namespace ID, if applicable
  * @cdw11:	Value to set the feature to
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_set_features_simple(int fd, __u8 fid, __u32 nsid,
 			__u32 cdw11, bool save, __u32 *result)
@@ -2049,7 +2088,7 @@ static inline int nvme_set_features_simple(int fd, __u8 fid, __u32 nsid,
 }
 
 /**
- * nvme_set_features_arbitration() -
+ * nvme_set_features_arbitration() - Set arbitration features
  * @fd:		File descriptor of nvme device
  * @ab:		Arbitration Burst
  * @lpw:	Low Priority Weight
@@ -2065,7 +2104,7 @@ int nvme_set_features_arbitration(int fd, __u8 ab, __u8 lpw, __u8 mpw,
 				  __u8 hpw, bool  save, __u32 *result);
 
 /**
- * nvme_set_features_power_mgmt() -
+ * nvme_set_features_power_mgmt() - Set power management feature
  * @fd:		File descriptor of nvme device
  * @ps:		Power State
  * @wh:		Workload Hint
@@ -2079,7 +2118,7 @@ int nvme_set_features_power_mgmt(int fd, __u8 ps, __u8 wh, bool save,
 				 __u32 *result);
 
 /**
- * nvme_set_features_lba_range() -
+ * nvme_set_features_lba_range() - Set LBA range feature
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @nr_ranges:	Number of ranges in @data
@@ -2094,7 +2133,7 @@ int nvme_set_features_lba_range(int fd, __u32 nsid, __u32 nr_ranges, bool save,
 				struct nvme_lba_range_type *data, __u32 *result);
 
 /**
- * nvme_set_features_temp_thresh() -
+ * nvme_set_features_temp_thresh() - Set temperature threshold feature
  * @fd:		File descriptor of nvme device
  * @tmpth:	Temperature Threshold
  * @tmpsel:	Threshold Temperature Select
@@ -2110,7 +2149,7 @@ int nvme_set_features_temp_thresh(int fd, __u16 tmpth, __u8 tmpsel,
 				  bool save, __u32 *result);
 
 /**
- * nvme_set_features_err_recovery() -
+ * nvme_set_features_err_recovery() - Set error recovery feature
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @tler:	Time-limited error recovery value
@@ -2125,7 +2164,7 @@ int nvme_set_features_err_recovery(int fd, __u32 nsid, __u16 tler,
 				   bool dulbe, bool save, __u32 *result);
 
 /**
- * nvme_set_features_volatile_wc() -
+ * nvme_set_features_volatile_wc() - Set volatile write cache feature
  * @fd:		File descriptor of nvme device
  * @wce:	Write cache enable
  * @save:	Save value across power states
@@ -2138,7 +2177,7 @@ int nvme_set_features_volatile_wc(int fd, bool wce, bool save,
 				  __u32 *result);
 
 /**
- * nvme_set_features_irq_coalesce() -
+ * nvme_set_features_irq_coalesce() - Set IRQ coalesce feature
  * @fd:		File descriptor of nvme device
  * @thr:	Aggregation Threshold
  * @time:	Aggregation Time
@@ -2152,7 +2191,7 @@ int nvme_set_features_irq_coalesce(int fd, __u8 thr, __u8 time,
 				   bool save, __u32 *result);
 
 /**
- * nvme_set_features_irq_config() -
+ * nvme_set_features_irq_config() - Set IRQ config feature
  * @fd:		File descriptor of nvme device
  * @iv:		Interrupt Vector
  * @cd:		Coalescing Disable
@@ -2166,7 +2205,7 @@ int nvme_set_features_irq_config(int fd, __u16 iv, bool cd, bool save,
 				 __u32 *result);
 
 /**
- * nvme_set_features_write_atomic() -
+ * nvme_set_features_write_atomic() - Set write atomic feature
  * @fd:		File descriptor of nvme device
  * @dn:		Disable Normal
  * @save:	Save value across power states
@@ -2179,7 +2218,7 @@ int nvme_set_features_write_atomic(int fd, bool dn, bool save,
 				   __u32 *result);
 
 /**
- * nvme_set_features_async_event() -
+ * nvme_set_features_async_event() - Set asynchronous event feature
  * @fd:		File descriptor of nvme device
  * @events:	Events to enable
  * @save:	Save value across power states
@@ -2192,7 +2231,7 @@ int nvme_set_features_async_event(int fd, __u32 events, bool save,
 				  __u32 *result);
 
 /**
- * nvme_set_features_auto_pst() -
+ * nvme_set_features_auto_pst() - Set autonomous power state feature
  * @fd:		File descriptor of nvme device
  * @apste:	Autonomous Power State Transition Enable
  * @apst:	Autonomous Power State Transition
@@ -2207,7 +2246,7 @@ int nvme_set_features_auto_pst(int fd, bool apste, bool save,
 			       __u32 *result);
 
 /**
- * nvme_set_features_timestamp() -
+ * nvme_set_features_timestamp() - Set timestamp feature
  * @fd:		File descriptor of nvme device
  * @save:	Save value across power states
  * @timestamp:	The current timestamp value to assign to this this feature
@@ -2218,7 +2257,7 @@ int nvme_set_features_auto_pst(int fd, bool apste, bool save,
 int nvme_set_features_timestamp(int fd, bool save, __u64 timestamp);
 
 /**
- * nvme_set_features_hctm() -
+ * nvme_set_features_hctm() - Set thermal management feature
  * @fd:		File descriptor of nvme device
  * @tmt2:	Thermal Management Temperature 2
  * @tmt1:	Thermal Management Temperature 1
@@ -2232,7 +2271,7 @@ int nvme_set_features_hctm(int fd, __u16 tmt2, __u16 tmt1, bool save,
 			   __u32 *result);
 
 /**
- * nvme_set_features_nopsc() -
+ * nvme_set_features_nopsc() - Set non-operational power state feature
  * @fd:		File descriptor of nvme device
  * @noppme:	Non-Operational Power State Permissive Mode Enable
  * @save:	Save value across power states
@@ -2244,7 +2283,7 @@ int nvme_set_features_hctm(int fd, __u16 tmt2, __u16 tmt1, bool save,
 int nvme_set_features_nopsc(int fd, bool noppme, bool save, __u32 *result);
 
 /**
- * nvme_set_features_rrl() -
+ * nvme_set_features_rrl() - Set read recovery level feature
  * @fd:		File descriptor of nvme device
  * @rrl:	Read recovery level setting
  * @nvmsetid:	NVM set id
@@ -2258,7 +2297,7 @@ int nvme_set_features_rrl(int fd, __u8 rrl, __u16 nvmsetid, bool save,
 			  __u32 *result);
 
 /**
- * nvme_set_features_plm_config() -
+ * nvme_set_features_plm_config() - Set predictable latency feature
  * @fd:		File descriptor of nvme device
  * @enable:	Predictable Latency Enable
  * @nvmsetid:	NVM Set Identifier
@@ -2274,7 +2313,7 @@ int nvme_set_features_plm_config(int fd, bool enable, __u16 nvmsetid,
 				 __u32*result);
 
 /**
- * nvme_set_features_plm_window() -
+ * nvme_set_features_plm_window() - Set window select feature
  * @fd:		File descriptor of nvme device
  * @sel:	Window Select
  * @nvmsetid:	NVM Set Identifier
@@ -2288,7 +2327,7 @@ int nvme_set_features_plm_window(int fd, enum nvme_feat_plm_window_select sel,
 				 __u16 nvmsetid, bool save, __u32 *result);
 
 /**
- * nvme_set_features_lba_sts_interval() -
+ * nvme_set_features_lba_sts_interval() - Set LBA status information feature
  * @fd:		File descriptor of nvme device
  * @save:	Save value across power states
  * @lsiri:	LBA Status Information Report Interval
@@ -2302,7 +2341,7 @@ int nvme_set_features_lba_sts_interval(int fd, __u16 lsiri, __u16 lsipi,
 				       bool save, __u32 *result);
 
 /**
- * nvme_set_features_host_behavior() -
+ * nvme_set_features_host_behavior() - Set host behavior feature
  * @fd:		File descriptor of nvme device
  * @save:	Save value across power states
  * @data:	Pointer to structure nvme_feat_host_behavior
@@ -2314,7 +2353,7 @@ int nvme_set_features_host_behavior(int fd, bool save,
 				    struct nvme_feat_host_behavior *data);
 
 /**
- * nvme_set_features_sanitize() -
+ * nvme_set_features_sanitize() - Set sanitize feature
  * @fd:		File descriptor of nvme device
  * @nodrm:	No-Deallocate Response Mode
  * @save:	Save value across power states
@@ -2326,7 +2365,7 @@ int nvme_set_features_host_behavior(int fd, bool save,
 int nvme_set_features_sanitize(int fd, bool nodrm, bool save, __u32 *result);
 
 /**
- * nvme_set_features_endurance_evt_cfg() -
+ * nvme_set_features_endurance_evt_cfg() - Set endurance event config feature
  * @fd:		File descriptor of nvme device
  * @endgid:	Endurance Group Identifier
  * @egwarn:	Flags to enable warning, see &enum nvme_eg_critical_warning_flags
@@ -2340,7 +2379,7 @@ int nvme_set_features_endurance_evt_cfg(int fd, __u16 endgid, __u8 egwarn,
 					bool save, __u32 *result);
 
 /**
- * nvme_set_features_sw_progress() -
+ * nvme_set_features_sw_progress() - Set pre-boot software load count feature
  * @fd:		File descriptor of nvme device
  * @pbslc:	Pre-boot Software Load Count
  * @save:	Save value across power states
@@ -2353,7 +2392,7 @@ int nvme_set_features_sw_progress(int fd, __u8 pbslc, bool save,
 				  __u32 *result);
 
 /**
- * nvme_set_features_host_id() -
+ * nvme_set_features_host_id() - Set enable extended host identifers feature
  * @fd:		File descriptor of nvme device
  * @exhid:	Enable Extended Host Identifier
  * @save:	Save value across power states
@@ -2365,7 +2404,7 @@ int nvme_set_features_sw_progress(int fd, __u8 pbslc, bool save,
 int nvme_set_features_host_id(int fd, bool exhid, bool save, __u8 *hostid);
 
 /**
- * nvme_set_features_resv_mask() -
+ * nvme_set_features_resv_mask() - Set reservation notification mask feature
  * @fd:		File descriptor of nvme device
  * @mask:	Reservation Notification Mask Field
  * @save:	Save value across power states
@@ -2377,7 +2416,7 @@ int nvme_set_features_host_id(int fd, bool exhid, bool save, __u8 *hostid);
 int nvme_set_features_resv_mask(int fd, __u32 mask, bool save, __u32 *result);
 
 /**
- * nvme_set_features_resv_persist() -
+ * nvme_set_features_resv_persist() - Set persist through power loss feature
  * @fd:		File descriptor of nvme device
  * @ptpl:	Persist Through Power Loss
  * @save:	Save value across power states
@@ -2389,7 +2428,7 @@ int nvme_set_features_resv_mask(int fd, __u32 mask, bool save, __u32 *result);
 int nvme_set_features_resv_persist(int fd, bool ptpl, bool save, __u32 *result);
 
 /**
- * nvme_set_features_write_protect() -
+ * nvme_set_features_write_protect() - Set write protect feature
  * @fd:		File descriptor of nvme device
  * @state:	Write Protection State
  * @save:	Save value across power states
@@ -2418,6 +2457,9 @@ int nvme_get_features(struct nvme_get_features_args *args);
  * @data_len:	Length of feature data, if applicable, in bytes
  * @data:	User address of feature data, if applicable
  * @result:	The command completion result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_features_data(int fd, enum nvme_features_id fid,
 			__u32 nsid, __u32 data_len, void *data, __u32 *result)
@@ -2445,6 +2487,9 @@ static inline int nvme_get_features_data(int fd, enum nvme_features_id fid,
  * @fid:	Feature identifier
  * @nsid:	Namespace ID, if applicable
  * @result:	The command completion result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_get_features_simple(int fd, enum nvme_features_id fid,
 			__u32 nsid, __u32 *result)
@@ -2453,7 +2498,7 @@ static inline int nvme_get_features_simple(int fd, enum nvme_features_id fid,
 }
 
 /**
- * nvme_get_features_arbitration() -
+ * nvme_get_features_arbitration() - Get arbitration feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2465,7 +2510,7 @@ int nvme_get_features_arbitration(int fd, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
- * nvme_get_features_power_mgmt() -
+ * nvme_get_features_power_mgmt() - Get power management feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2477,7 +2522,7 @@ int nvme_get_features_power_mgmt(int fd, enum nvme_get_features_sel sel,
 				 __u32 *result);
 
 /**
- * nvme_get_features_lba_range() -
+ * nvme_get_features_lba_range() - Get LBA range feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @data:	User address of feature data, if applicable
@@ -2491,7 +2536,7 @@ int nvme_get_features_lba_range(int fd, enum nvme_get_features_sel sel,
 				__u32 *result);
 
 /**
- * nvme_get_features_temp_thresh() -
+ * nvme_get_features_temp_thresh() - Get temperature threshold feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2503,7 +2548,7 @@ int nvme_get_features_temp_thresh(int fd, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
- * nvme_get_features_err_recovery() -
+ * nvme_get_features_err_recovery() - Get error recovery feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2515,7 +2560,7 @@ int nvme_get_features_err_recovery(int fd, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
- * nvme_get_features_volatile_wc() -
+ * nvme_get_features_volatile_wc() - Get volatile write cache feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2527,7 +2572,7 @@ int nvme_get_features_volatile_wc(int fd, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
- * nvme_get_features_num_queues() -
+ * nvme_get_features_num_queues() - Get number of queues feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2539,7 +2584,7 @@ int nvme_get_features_num_queues(int fd, enum nvme_get_features_sel sel,
 				 __u32 *result);
 
 /**
- * nvme_get_features_irq_coalesce() -
+ * nvme_get_features_irq_coalesce() - Get IRQ coalesce feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2551,7 +2596,7 @@ int nvme_get_features_irq_coalesce(int fd, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
- * nvme_get_features_irq_config() -
+ * nvme_get_features_irq_config() - Get IRQ config feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @iv:
@@ -2564,7 +2609,7 @@ int nvme_get_features_irq_config(int fd, enum nvme_get_features_sel sel,
 				 __u16 iv, __u32 *result);
 
 /**
- * nvme_get_features_write_atomic() -
+ * nvme_get_features_write_atomic() - Get write atomic feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2576,7 +2621,7 @@ int nvme_get_features_write_atomic(int fd, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
- * nvme_get_features_async_event() -
+ * nvme_get_features_async_event() - Get asynchronous event feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2588,7 +2633,7 @@ int nvme_get_features_async_event(int fd, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
- * nvme_get_features_auto_pst() -
+ * nvme_get_features_auto_pst() - Get autonomous power state feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @apst:
@@ -2601,7 +2646,7 @@ int nvme_get_features_auto_pst(int fd, enum nvme_get_features_sel sel,
 			       struct nvme_feat_auto_pst *apst, __u32 *result);
 
 /**
- * nvme_get_features_host_mem_buf() -
+ * nvme_get_features_host_mem_buf() - Get host memory buffer feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2613,7 +2658,7 @@ int nvme_get_features_host_mem_buf(int fd, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
- * nvme_get_features_timestamp() -
+ * nvme_get_features_timestamp() - Get timestamp feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @ts:		Current timestamp
@@ -2625,7 +2670,7 @@ int nvme_get_features_timestamp(int fd, enum nvme_get_features_sel sel,
 				struct nvme_timestamp *ts);
 
 /**
- * nvme_get_features_kato() -
+ * nvme_get_features_kato() - Get keep alive timeout feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2636,7 +2681,7 @@ int nvme_get_features_timestamp(int fd, enum nvme_get_features_sel sel,
 int nvme_get_features_kato(int fd, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
- * nvme_get_features_hctm() -
+ * nvme_get_features_hctm() - Get thermal management feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2647,7 +2692,7 @@ int nvme_get_features_kato(int fd, enum nvme_get_features_sel sel, __u32 *result
 int nvme_get_features_hctm(int fd, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
- * nvme_get_features_nopsc() -
+ * nvme_get_features_nopsc() - Get non-operational power state feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2658,7 +2703,7 @@ int nvme_get_features_hctm(int fd, enum nvme_get_features_sel sel, __u32 *result
 int nvme_get_features_nopsc(int fd, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
- * nvme_get_features_rrl() -
+ * nvme_get_features_rrl() - Get read recovery level feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2669,7 +2714,7 @@ int nvme_get_features_nopsc(int fd, enum nvme_get_features_sel sel, __u32 *resul
 int nvme_get_features_rrl(int fd, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
- * nvme_get_features_plm_config() -
+ * nvme_get_features_plm_config() - Get predictable latency feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @nvmsetid:	NVM set id
@@ -2684,7 +2729,7 @@ int nvme_get_features_plm_config(int fd, enum nvme_get_features_sel sel,
 				 __u32 *result);
 
 /**
- * nvme_get_features_plm_window() -
+ * nvme_get_features_plm_window() - Get window select feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @nvmsetid:	NVM set id
@@ -2697,7 +2742,7 @@ int nvme_get_features_plm_window(int fd, enum nvme_get_features_sel sel,
 	__u16 nvmsetid, __u32 *result);
 
 /**
- * nvme_get_features_lba_sts_interval() -
+ * nvme_get_features_lba_sts_interval() - Get LBA status information feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2709,10 +2754,10 @@ int nvme_get_features_lba_sts_interval(int fd, enum nvme_get_features_sel sel,
 				       __u32 *result);
 
 /**
- * nvme_get_features_host_behavior() -
+ * nvme_get_features_host_behavior() - Get host behavior feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
- * @data:	Poniter to structure nvme_feat_host_behavior
+ * @data:	Pointer to structure nvme_feat_host_behavior
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
@@ -2723,7 +2768,7 @@ int nvme_get_features_host_behavior(int fd, enum nvme_get_features_sel sel,
 				    __u32 *result);
 
 /**
- * nvme_get_features_sanitize() -
+ * nvme_get_features_sanitize() - Get sanitize feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2735,7 +2780,7 @@ int nvme_get_features_sanitize(int fd, enum nvme_get_features_sel sel,
 				__u32 *result);
 
 /**
- * nvme_get_features_endurance_event_cfg() -
+ * nvme_get_features_endurance_event_cfg() - Get endurance event config feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @endgid:	Endurance Group Identifier
@@ -2748,7 +2793,7 @@ int nvme_get_features_endurance_event_cfg(int fd, enum nvme_get_features_sel sel
 					  __u16 endgid, __u32 *result);
 
 /**
- * nvme_get_features_sw_progress() -
+ * nvme_get_features_sw_progress() - Get software progress feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2760,7 +2805,7 @@ int nvme_get_features_sw_progress(int fd, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
- * nvme_get_features_host_id() -
+ * nvme_get_features_host_id() - Get host id feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @exhid:	Enable Extended Host Identifier
@@ -2774,7 +2819,7 @@ int nvme_get_features_host_id(int fd, enum nvme_get_features_sel sel,
 			      bool exhid, __u32 len, __u8 *hostid);
 
 /**
- * nvme_get_features_resv_mask() -
+ * nvme_get_features_resv_mask() - Get reservation mask feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2786,7 +2831,7 @@ int nvme_get_features_resv_mask(int fd, enum nvme_get_features_sel sel,
 				__u32 *result);
 
 /**
- * nvme_get_features_resv_persist() -
+ * nvme_get_features_resv_persist() - Get reservation persist feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2798,7 +2843,7 @@ int nvme_get_features_resv_persist(int fd, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
- * nvme_get_features_write_protect() -
+ * nvme_get_features_write_protect() - Get write protect feature
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
@@ -2812,7 +2857,7 @@ int nvme_get_features_write_protect(int fd, __u32 nsid,
 				    __u32 *result);
 
 /**
- * nvme_get_features_iocs_profile() -
+ * nvme_get_features_iocs_profile() - Get IOCS profile feature
  * @fd:		File descriptor of nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2840,16 +2885,19 @@ int nvme_format_nvm(struct nvme_format_nvm_args *args);
 /**
  * nvme_ns_mgmt() - Issue a Namespace management command
  * @args:	&struct nvme_ns_mgmt_args Argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 int nvme_ns_mgmt(struct nvme_ns_mgmt_args *args);
 
 /**
- * nvme_ns_mgmt_create() -
+ * nvme_ns_mgmt_create() - Create a non attached namespace
  * @fd:		File descriptor of nvme device
  * @ns:		Namespace identification that defines ns creation parameters
  * @nsid:		On success, set to the namespace id that was created
- * @timeout:		Overide the default timeout to this value in milliseconds;
- * 			set to 0 to use the system default.
+ * @timeout:		Override the default timeout to this value in milliseconds;
+ *			set to 0 to use the system default.
  * @csi:		Command Set Identifier
  *
  * On successful creation, the namespace exists in the subsystem, but is not
@@ -2877,7 +2925,7 @@ static inline int nvme_ns_mgmt_create(int fd, struct nvme_id_ns *ns,
 }
 
 /**
- * nvme_ns_mgmt_delete() -
+ * nvme_ns_mgmt_delete() - Delete a non attached namespace
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace identifier to delete
  *
@@ -2907,14 +2955,20 @@ static inline int nvme_ns_mgmt_delete(int fd, __u32 nsid)
 /**
  * nvme_ns_attach() - Attach or detach namespace to controller(s)
  * @args:	&struct nvme_ns_attach_args Argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 int nvme_ns_attach(struct nvme_ns_attach_args *args);
 
 /**
- * nvme_ns_attach_ctrls() -
+ * nvme_ns_attach_ctrls() - Attach namespace to controllers
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID to attach
  * @ctrlist:	Controller list to modify attachment state of nsid
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_ns_attach_ctrls(int fd, __u32 nsid,
 			struct nvme_ctrl_list *ctrlist)
@@ -2933,10 +2987,13 @@ static inline int nvme_ns_attach_ctrls(int fd, __u32 nsid,
 }
 
 /**
- * nvme_ns_detach_ctrls() -
+ * nvme_ns_detach_ctrls() - Detach namespace from controllers
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID to detach
  * @ctrlist:	Controller list to modify attachment state of nsid
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 static inline int nvme_ns_detach_ctrls(int fd, __u32 nsid,
 			struct nvme_ctrl_list *ctrlist)
@@ -2956,7 +3013,7 @@ static inline int nvme_ns_detach_ctrls(int fd, __u32 nsid,
 
 /**
  * nvme_fw_download() - Download part or all of a firmware image to the
- * 			controller
+ *			controller
  * @args:	&struct nvme_fw_download_args argument structure
  *
  * The Firmware Image Download command downloads all or a portion of an image
@@ -2991,7 +3048,7 @@ int nvme_fw_download(struct nvme_fw_download_args *args);
 int nvme_fw_commit(struct nvme_fw_commit_args *args);
 
 /**
- * nvme_security_send() -
+ * nvme_security_send() - Security Send command
  * @args:	&struct nvme_security_send argument structure
  *
  * The Security Send command transfers security protocol data to the
@@ -3009,7 +3066,7 @@ int nvme_fw_commit(struct nvme_fw_commit_args *args);
 int nvme_security_send(struct nvme_security_send_args *args);
 
 /**
- * nvme_security_receive() -
+ * nvme_security_receive() - Security Receive command
  * @args:	&struct nvme_security_recevice argument structure
  *
  * Return: The nvme command status if a response was received (see
@@ -3045,7 +3102,7 @@ int nvme_get_lba_status(struct nvme_get_lba_status_args *args);
 int nvme_directive_send(struct nvme_directive_send_args *args);
 
 /**
- * nvme_directive_send_id_endir() -
+ * nvme_directive_send_id_endir() - Directive Send Enable Directive
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace Identifier
  * @endir:	Enable Directive
@@ -3060,7 +3117,7 @@ int nvme_directive_send_id_endir(int fd, __u32 nsid, bool endir,
 				 struct nvme_id_directives *id);
 
 /**
- * nvme_directive_send_stream_release_identifier() -
+ * nvme_directive_send_stream_release_identifier() - Directive Send Stream release
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @stream_id:	Stream identifier
@@ -3089,7 +3146,7 @@ static inline int nvme_directive_send_stream_release_identifier(int fd,
 }
 
 /**
- * nvme_directive_send_stream_release_resource() -
+ * nvme_directive_send_stream_release_resource() - Directive Send Stream release resources
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  *
@@ -3125,7 +3182,7 @@ static inline int nvme_directive_send_stream_release_resource(int fd, __u32 nsid
 int nvme_directive_recv(struct nvme_directive_recv_args *args);
 
 /**
- * nvme_directive_recv_identify_parameters() -
+ * nvme_directive_recv_identify_parameters() - Directive receive identifier parameters
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @id:		Identify parameters buffer
@@ -3154,7 +3211,7 @@ static inline int nvme_directive_recv_identify_parameters(int fd, __u32 nsid,
 }
 
 /**
- * nvme_directive_recv_stream_parameters() -
+ * nvme_directive_recv_stream_parameters() - Directive receive stream parameters
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @parms:	Streams directive parameters buffer
@@ -3183,7 +3240,7 @@ static inline int nvme_directive_recv_stream_parameters(int fd, __u32 nsid,
 }
 
 /**
- * nvme_directive_recv_stream_status() -
+ * nvme_directive_recv_stream_status() - Directive receive stream status
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @nr_entries: Number of streams to receive
@@ -3214,7 +3271,7 @@ static inline int nvme_directive_recv_stream_status(int fd, __u32 nsid,
 }
 
 /**
- * nvme_directive_recv_stream_allocate() -
+ * nvme_directive_recv_stream_allocate() - Directive receive stream allocate
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace ID
  * @nsr:	Namespace Streams Requested
@@ -3244,7 +3301,7 @@ static inline int nvme_directive_recv_stream_allocate(int fd, __u32 nsid,
 }
 
 /**
- * nvme_capacity_mgmt() -
+ * nvme_capacity_mgmt() - Capacity management command
  * @args:	&struct nvme_capacity_mgmt_args argument structure
  *
  * Return: The nvme command status if a response was received (see
@@ -3473,7 +3530,7 @@ static inline int nvme_verify(struct nvme_io_args *args)
 int nvme_dsm(struct nvme_dsm_args *args);
 
 /**
- * nvme_copy() -
+ * nvme_copy() - Copy command
  *
  * @args:	&struct nvme_copy_args argument structure
  *
@@ -3521,7 +3578,7 @@ int nvme_resv_release(struct nvme_resv_release_args *args);
  * @args:	struct nvme_resv_report_args argument structure
  *
  * Returns a Reservation Status data structure to memory that describes the
- * registration and reservation status of a namespace. See the defintion for
+ * registration and reservation status of a namespace. See the definition for
  * the returned structure, &struct nvme_reservation_status, for more details.
  *
  * Return: The nvme command status if a response was received (see
@@ -3530,7 +3587,7 @@ int nvme_resv_release(struct nvme_resv_release_args *args);
 int nvme_resv_report(struct nvme_resv_report_args *args);
 
 /**
- * nvme_zns_mgmt_send() -
+ * nvme_zns_mgmt_send() - ZNS management send command
  * @args:	&struct nvme_zns_mgmt_send_args argument structure
  *
  * Return: The nvme command status if a response was received (see
@@ -3540,7 +3597,7 @@ int nvme_zns_mgmt_send(struct nvme_zns_mgmt_send_args *args);
 
 
 /**
- * nvme_zns_mgmt_recv() -
+ * nvme_zns_mgmt_recv() - ZNS management receive command
  * @args:	&struct nvme_zns_mgmt_recv_args argument structure
  *
  * Return: The nvme command status if a response was received (see

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -232,7 +232,7 @@ nvme_path_t nvme_namespace_first_path(nvme_ns_t ns);
  *
  * Return: Next &nvme_path_t object of an @ns iterator
  */
-nvme_path_t nvme_namespace_next_path(nvme_ns_t c, nvme_path_t p);
+nvme_path_t nvme_namespace_next_path(nvme_ns_t ns, nvme_path_t p);
 
 /**
  * nvme_lookup_ctrl() - Lookup nvme_ctrl_t object
@@ -423,7 +423,7 @@ nvme_ns_t nvme_subsystem_next_ns(nvme_subsystem_t s, nvme_ns_t n);
 
 /**
  * nvme_namespace_for_each_path_safe() - Traverse paths
- * @ns:	Namespace instance
+ * @n:	Namespace instance
  * @p:	&nvme_path_t object
  * @_p:	A &nvme_path_t_node to use as temporary storage
  */
@@ -435,12 +435,12 @@ nvme_ns_t nvme_subsystem_next_ns(nvme_subsystem_t s, nvme_ns_t n);
 
 /**
  * nvme_namespace_for_each_path() - Traverse paths
- * @ns:	Namespace instance
+ * @n:	Namespace instance
  * @p:	&nvme_path_t object
  */
-#define nvme_namespace_for_each_path(c, p)			\
-	for (p = nvme_namespace_first_path(c); p != NULL;	\
-		p = nvme_namespace_next_path(c, p))
+#define nvme_namespace_for_each_path(n, p)			\
+	for (p = nvme_namespace_first_path(n); p != NULL;	\
+		p = nvme_namespace_next_path(n, p))
 
 /**
  * nvme_ns_get_fd() - Get associated filedescriptor

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -208,7 +208,7 @@ enum nvme_register_offsets {
  * specific transport. For example, BPMBL(Boot Partition Memory Buffer
  * Location) register is not supported by fabrics, but it can be checked here.
  *
- * Returns true if given offset is 64bit register, otherwise it returns false.
+ * Returns: true if given offset is 64bit register, otherwise it returns false.
  */
 static inline bool nvme_is_64bit_reg(__u32 offset)
 {
@@ -427,7 +427,7 @@ enum nvme_cmbsz {
  * nvme_cmb_size() - Calculate size of the controller memory buffer
  * @cmbsz:	Value from controller register %NVME_REG_CMBSZ
  *
- * Returns size of controller memory buffer in bytes
+ * Returns: size of controller memory buffer in bytes
  */
 static inline __u64 nvme_cmb_size(__u32 cmbsz)
 {
@@ -567,7 +567,7 @@ enum nvme_pmrebs {
  * 		     buffer
  * @pmrebs:	Value from controller register %NVME_REG_PMREBS
  *
- * Returns size of controller persistent memory buffer in bytes
+ * Returns: size of controller persistent memory buffer in bytes
  */
 static inline __u64 nvme_pmr_size(__u32 pmrebs)
 {
@@ -593,7 +593,7 @@ enum nvme_pmrswtp {
  * nvme_pmr_throughput() - Calculate throughput of persistent memory buffer
  * @pmrswtp:	Value from controller register %NVME_REG_PMRSWTP
  *
- * Returns throughput of controller persistent memory buffer in bytes/second
+ * Returns: throughput of controller persistent memory buffer in bytes/second
  */
 static inline __u64 nvme_pmr_throughput(__u32 pmrswtp)
 {
@@ -646,6 +646,8 @@ enum nvme_psd_ps {
 /**
  * nvme_psd_power_scale() - power scale occupies the upper 3 bits
  * @ps: power scale value
+ *
+ * Returns: power scale value
  */
 static inline unsigned int nvme_psd_power_scale(__u8 ps)
 {
@@ -679,7 +681,7 @@ enum nvme_psd_workload {
 };
 
 /**
- * struct nvme_id_psd -
+ * struct nvme_id_psd - Power Managmenet data structure
  * @mp:	   Maximum Power indicates the sustained maximum power consumed by the
  * 	   NVM subsystem in this power state. The power in Watts is equal to
  * 	   the value in this field multiplied by the scale specified in the Max
@@ -1270,9 +1272,9 @@ enum nvme_id_ctrl_oacs {
  * 				    firmware slots that the controller supports.
  * @NVME_CTRL_FRMW_FW_ACT_NO_RESET: If set, the controller supports firmware
  * 				    activation without a reset.
- * @NVME_CTRL_FRMW_FW_MP_UP_DETECTION: If set, the controller is able to detect
- * 				       overlapping firmware/boot partition
- * 				       image update.
+ * @NVME_CTRL_FRMW_MP_UP_DETECTION: If set, the controller is able to detect
+ * 				    overlapping firmware/boot partition
+ * 				    image update.
  */
 enum nvme_id_ctrl_frmw {
 	NVME_CTRL_FRMW_1ST_RO			= 1 << 0,
@@ -1542,7 +1544,7 @@ enum nvme_id_ctrl_fna {
 };
 
 /**
- * enum nvme_id_ctrl_vwc -
+ * enum nvme_id_ctrl_vwc - Volatile write cache
  * @NVME_CTRL_VWC_PRESENT: If set, indicates a volatile write cache is present.
  * 			   If a volatile write cache is present, then the host
  * 			   controls whether the volatile write cache is enabled
@@ -2034,7 +2036,7 @@ enum nvme_id_ns_attr {
 };
 
 /**
- * struct nvme_ns_id_desc -
+ * struct nvme_ns_id_desc - Namespace identifier type descriptor
  * @nidt: Namespace Identifier Type, see &enum nvme_ns_id_desc_nidt
  * @nidl: Namespace Identifier Length contains the length in bytes of the
  * 	  &struct nvme_id_ns.nid.
@@ -2100,7 +2102,7 @@ struct nvme_nvmset_attr {
 };
 
 /**
- * struct nvme_id_nvmset_list -
+ * struct nvme_id_nvmset_list - NVM set list
  * @nid:	Nvmset id
  * @rsvd1:	Reserved
  * @ent:	nvmset id list
@@ -2112,7 +2114,7 @@ struct nvme_id_nvmset_list {
 };
 
 /**
- * struct nvme_id_independent_id_ns -
+ * struct nvme_id_independent_id_ns - Identify - I/O Command Set Independent Identify Namespace Data Structure
  * @nsfeat:	common namespace features
  * @nmic:	Namespace Multi-path I/O and Namespace
  * 		Sharing Capabilities
@@ -2141,7 +2143,7 @@ struct nvme_id_independent_id_ns {
 };
 
 /**
- * struct nvme_id_ns_granularity_desc -
+ * struct nvme_id_ns_granularity_desc -  Namespace Granularity Descriptor
  * @nszegran:	Namespace Size Granularity
  * @ncapgran:	Namespace Capacity Granularity
  */
@@ -2151,7 +2153,7 @@ struct nvme_id_ns_granularity_desc {
 };
 
 /**
- * struct nvme_id_ns_granularity_list -
+ * struct nvme_id_ns_granularity_list - Namespace Granularity List
  * @attributes:		Namespace Granularity Attributes
  * @num_descriptors:	Number of Descriptors
  * @rsvd5:		reserved
@@ -2167,7 +2169,7 @@ struct nvme_id_ns_granularity_list {
 };
 
 /**
- * struct nvme_id_uuid_list_entry -
+ * struct nvme_id_uuid_list_entry - UUID List Entry
  * @header:	UUID Lists Entry Header
  * @rsvd1:	reserved
  * @uuid:	128-bit Universally Unique Identifier
@@ -2179,7 +2181,7 @@ struct nvme_id_uuid_list_entry {
 };
 
 /**
- * enum nvme_id_uuid -
+ * enum nvme_id_uuid - Identifier Association
  * @NVME_ID_UUID_HDR_ASSOCIATION_MASK:
  * @NVME_ID_UUID_ASSOCIATION_NONE:
  * @NVME_ID_UUID_ASSOCIATION_VENDOR:
@@ -2193,7 +2195,7 @@ enum nvme_id_uuid {
 };
 
 /**
- * struct nvme_id_uuid_list -
+ * struct nvme_id_uuid_list - UUID list
  * @rsvd0:	reserved
  * @entry:	UUID list entry
  */
@@ -2203,7 +2205,7 @@ struct nvme_id_uuid_list {
 };
 
 /**
- * struct nvme_ctrl_list -
+ * struct nvme_ctrl_list - Controller List
  * @num:	Number of Identifiers
  * @identifier:	NVM subsystem unique controller identifier
  */
@@ -2213,7 +2215,7 @@ struct nvme_ctrl_list {
 };
 
 /**
- * struct nvme_ns_list -
+ * struct nvme_ns_list - Namespace List
  * @ns:	Namespace Identifier
  */
 struct nvme_ns_list {
@@ -2221,7 +2223,7 @@ struct nvme_ns_list {
 };
 
 /**
- * struct nvme_id_ctrl_nvm -
+ * struct nvme_id_ctrl_nvm - I/O Command Set Specific Identify Controller data structure
  * @vsl:	Verify Size Limit
  * @wzsl:	Write Zeroes Size Limit
  * @wusl:	Write Uncorrectable Size Limit
@@ -2241,7 +2243,7 @@ struct nvme_id_ctrl_nvm {
 };
 
 /**
- * struct nvme_nvm_id_ns -
+ * struct nvme_nvm_id_ns - NVME Command Set I/O Command Set Specific Identify Namespace Data Structure
  * @lbstm:	Logical Block Storage Tag Mask
  * @pic:	Protection Information Capabilities
  * @rsvd9:	Reserved
@@ -2257,7 +2259,7 @@ struct nvme_nvm_id_ns {
 };
 
 /**
- * struct nvme_zns_lbafe -
+ * struct nvme_zns_lbafe - LBA Format Extension Data Structure
  * @zsze:	Zone Size
  * @zdes:	Zone Descriptor Extension Size
  * @rsvd9:	reserved
@@ -2269,8 +2271,7 @@ struct nvme_zns_lbafe {
 };
 
 /**
- * struct nvme_zns_id_ns -  Zoned Namespace Command Set Specific
- *			    Identify Namespace Data Structure
+ * struct nvme_zns_id_ns -  Zoned Namespace Command Set Specific  Identify Namespace Data Structure
  * @zoc:     Zone Operation Characteristics
  * @ozcs:    Optional Zoned Command Support
  * @mar:     Maximum Active Resources
@@ -2314,9 +2315,9 @@ struct nvme_zns_id_ns {
 };
 
 /**
- * struct nvme_zns_id_ctrl -
- * @zasl:
- * @rsvd1: Reserved
+ * struct nvme_zns_id_ctrl -  I/O Command Set Specific Identify Controller Data Structure for the Zoned Namespace Command Set
+ * @zasl:	Zone Append Size Limit
+ * @rsvd1:	Reserved
  */
 struct nvme_zns_id_ctrl {
 	__u8	zasl;
@@ -2324,7 +2325,7 @@ struct nvme_zns_id_ctrl {
 };
 
 /**
- * struct nvme_primary_ctrl_cap -
+ * struct nvme_primary_ctrl_cap -  Identify - Controller Capabilities Structure
  * @cntlid:	Controller Identifier
  * @portid:	Port Identifier
  * @crt:	Controller Resource Types
@@ -2366,7 +2367,7 @@ struct nvme_primary_ctrl_cap {
 };
 
 /**
- * struct nvme_secondary_ctrl -
+ * struct nvme_secondary_ctrl -  Secondary Controller Entry
  * @scid:	Secondary Controller Identifier
  * @pcid:	Primary Controller Identifier
  * @scs:	Secondary Controller State
@@ -2388,7 +2389,7 @@ struct nvme_secondary_ctrl {
 };
 
 /**
- * struct nvme_secondary_ctrl_list -
+ * struct nvme_secondary_ctrl_list - Secondary Controller List
  * @num:	Number of Identifiers
  * @rsvd:	Reserved
  * @sc_entry:	Secondary Controller Entry
@@ -2426,7 +2427,7 @@ struct nvme_id_domain_attr {
 };
 
 /**
- * struct nvme_id_domain_list -
+ * struct nvme_id_domain_list - Domain List
  * @num:		Number of domain attributes
  * @rsvd:		Reserved
  * @domain_attr:	List of domain attributes
@@ -2438,7 +2439,7 @@ struct nvme_id_domain_list {
 };
 
 /**
- * struct nvme_id_endurance_group_list -
+ * struct nvme_id_endurance_group_list - Endurance Group List
  * @num:	Number of Identifiers
  * @identifier: Endurance Group Identifier
  */
@@ -2448,7 +2449,7 @@ struct nvme_id_endurance_group_list {
 };
 
 /**
- * struct nvme_supported_log_pages -
+ * struct nvme_supported_log_pages - Supported Log Pages - Log
  * @lid_support: Log Page Identifier Supported
  *
  * Supported Log Pages (Log Identifier 00h)
@@ -2535,11 +2536,6 @@ struct nvme_error_log_page {
 	__u8	rsvd2[22];
 };
 
-/**
- * enum nvme_err_pel -
- * @NVME_ERR_PEL_BYTE_MASK:
- * @NVME_ERR_PEL_BIT_MASK:
- */
 enum nvme_err_pel {
 	NVME_ERR_PEL_BYTE_MASK	= 0xf,
 	NVME_ERR_PEL_BIT_MASK	= 0x70,
@@ -2775,7 +2771,7 @@ enum nvme_smart_egcw {
 };
 
 /**
- * struct nvme_firmware_slot -
+ * struct nvme_firmware_slot - Firmware Slot Information Log
  * @afi:	Active Firmware Info
  * @rsvd1:	Reserved
  * @frs:	Firmware Revision for Slot
@@ -2789,7 +2785,7 @@ struct nvme_firmware_slot {
 };
 
 /**
- * struct nvme_cmd_effects_log -
+ * struct nvme_cmd_effects_log - Commands Supported and Effects Log
  * @acs:	Admin Command Supported
  * @iocs:	I/O Command Supported
  * @rsvd:	Reserved
@@ -2801,7 +2797,7 @@ struct nvme_cmd_effects_log {
 };
 
 /**
- * enum nvme_cmd_effects -
+ * enum nvme_cmd_effects - Commands Supported and Effects
  * @NVME_CMD_EFFECTS_CSUPP:	Command Supported
  * @NVME_CMD_EFFECTS_LBCC:	Logical Block Content Change
  * @NVME_CMD_EFFECTS_NCC:	Namespace Capability Change
@@ -2999,9 +2995,9 @@ struct nvme_self_test_log {
 } __attribute__((packed));
 
 /**
- * enum nvme_cmd_get_log_telemetry_host_lsp -
- * @NVME_LOG_TELEM_HOST_LSP_RETAIN:
- * @NVME_LOG_TELEM_HOST_LSP_CREATE:
+ * enum nvme_cmd_get_log_telemetry_host_lsp - Telemetry Host-Initiated Log log specific field
+ * @NVME_LOG_TELEM_HOST_LSP_RETAIN:	Get Telemetry Data Blocks
+ * @NVME_LOG_TELEM_HOST_LSP_CREATE:	Create Telemetry Data Blocks
  */
 enum nvme_cmd_get_log_telemetry_host_lsp {
 	NVME_LOG_TELEM_HOST_LSP_RETAIN			= 0,
@@ -3065,7 +3061,7 @@ struct nvme_telemetry_log {
 };
 
 /**
- * struct nvme_endurance_group_log -
+ * struct nvme_endurance_group_log -  Endurance Group Information Log
  * @critical_warning:		Critical Warning
  * @rsvd1:			Reserved
  * @avl_spare:			Available Spare
@@ -3101,10 +3097,12 @@ struct nvme_endurance_group_log {
 };
 
 /**
- * enum nvme_eg_critical_warning_flags -
- * @NVME_EG_CRITICAL_WARNING_SPARE:
- * @NVME_EG_CRITICAL_WARNING_DEGRADED:
- * @NVME_EG_CRITICAL_WARNING_READ_ONLY:
+ * enum nvme_eg_critical_warning_flags - Endurance Group Information Log - Critical Warning
+ * @NVME_EG_CRITICAL_WARNING_SPARE:	Available spare capacity of the Endurance Group
+ *					has fallen below the threshold
+ * @NVME_EG_CRITICAL_WARNING_DEGRADED:	Endurance Group reliability has been degraded
+ * @NVME_EG_CRITICAL_WARNING_READ_ONLY:	Endurance Group have been placed in read only
+ *					mode
  */
 enum nvme_eg_critical_warning_flags {
 	NVME_EG_CRITICAL_WARNING_SPARE		= 1 << 0,
@@ -3113,7 +3111,7 @@ enum nvme_eg_critical_warning_flags {
 };
 
 /**
- * struct nvme_aggregate_endurance_group_event - 
+ * struct nvme_aggregate_endurance_group_event -  Endurance Group Event Aggregate
  * @num_entries:	Number or entries
  * @entries:		List of entries
  */
@@ -3123,7 +3121,7 @@ struct nvme_aggregate_endurance_group_event {
 };
 
 /**
- * struct nvme_nvmset_predictable_lat_log -
+ * struct nvme_nvmset_predictable_lat_log - Predictable Latency Mode - Deterministic Threshold Configuration Data
  * @status:		Status
  * @rsvd1:		Reserved
  * @event_type:		Event Type
@@ -3157,10 +3155,10 @@ struct nvme_nvmset_predictable_lat_log {
 };
 
 /**
- * enum nvme_nvmeset_pl_status -
- * @NVME_NVMSET_PL_STATUS_DISABLED:
- * @NVME_NVMSET_PL_STATUS_DTWIN:
- * @NVME_NVMSET_PL_STATUS_NDWIN:
+ * enum nvme_nvmeset_pl_status -  Predictable Latency Per NVM Set Log - Status
+ * @NVME_NVMSET_PL_STATUS_DISABLED:	Not used (Predictable Latency Mode not enabled)
+ * @NVME_NVMSET_PL_STATUS_DTWIN:	Deterministic Window (DTWIN)
+ * @NVME_NVMSET_PL_STATUS_NDWIN:	Non-Deterministic Window (NDWIN)
  */
 enum nvme_nvmeset_pl_status {
 	NVME_NVMSET_PL_STATUS_DISABLED	= 0,
@@ -3169,12 +3167,16 @@ enum nvme_nvmeset_pl_status {
 };
 
 /**
- * enum nvme_nvmset_pl_events -
- * @NVME_NVMSET_PL_EVENT_DTWIN_READ_WARN:
- * @NVME_NVMSET_PL_EVENT_DTWIN_WRITE_WARN:
- * @NVME_NVMSET_PL_EVENT_DTWIN_TIME_WARN:
- * @NVME_NVMSET_PL_EVENT_DTWIN_EXCEEDED:
- * @NVME_NVMSET_PL_EVENT_DTWIN_EXCURSION:
+ * enum nvme_nvmset_pl_events - Predictable Latency Per NVM Set Log - Event Type
+ * @NVME_NVMSET_PL_EVENT_DTWIN_READ_WARN:	DTWIN Reads Warning
+ * @NVME_NVMSET_PL_EVENT_DTWIN_WRITE_WARN:	DTWIN Writes Warning
+ * @NVME_NVMSET_PL_EVENT_DTWIN_TIME_WARN:	DTWIN Time Warning
+ * @NVME_NVMSET_PL_EVENT_DTWIN_EXCEEDED:	Autonomous transition from DTWIN
+ *						to NDWIN due to typical or
+ *						maximum value exceeded
+ * @NVME_NVMSET_PL_EVENT_DTWIN_EXCURSION:	Autonomous transition from DTWIN
+ *						to NDWIN due to Deterministic
+ *						Excursion
  */
 enum nvme_nvmset_pl_events {
 	NVME_NVMSET_PL_EVENT_DTWIN_READ_WARN	= 1 << 0,
@@ -3185,7 +3187,7 @@ enum nvme_nvmset_pl_events {
 };
 
 /**
- * struct nvme_aggregate_predictable_lat_event -
+ * struct nvme_aggregate_predictable_lat_event - Predictable Latency Event Aggregate Log Page
  * @num_entries:	Number of entries
  * @entries:		Entry list
  */
@@ -3195,7 +3197,7 @@ struct nvme_aggregate_predictable_lat_event {
 };
 
 /**
- * struct nvme_ana_group_desc -
+ * struct nvme_ana_group_desc - ANA Group Descriptor
  * @grpid:	ANA group id
  * @nnsids:	Number of namespaces in @nsids
  * @chgcnt:	Change counter
@@ -3213,12 +3215,12 @@ struct nvme_ana_group_desc {
 };
 
 /**
- * enum nvme_ana_state -
- * @NVME_ANA_STATE_OPTIMIZED:
- * @NVME_ANA_STATE_NONOPTIMIZED:
- * @NVME_ANA_STATE_INACCESSIBLE:
- * @NVME_ANA_STATE_PERSISTENT_LOSS:
- * @NVME_ANA_STATE_CHANGE:
+ * enum nvme_ana_state - ANA Group Descriptor - Asymmetric Namespace Access State
+ * @NVME_ANA_STATE_OPTIMIZED:		ANA Optimized state
+ * @NVME_ANA_STATE_NONOPTIMIZED:	ANA Non-Optimized state
+ * @NVME_ANA_STATE_INACCESSIBLE:	ANA Inaccessible state
+ * @NVME_ANA_STATE_PERSISTENT_LOSS:	ANA Persistent Loss state
+ * @NVME_ANA_STATE_CHANGE:		ANA Change state
  */
 enum nvme_ana_state {
 	NVME_ANA_STATE_OPTIMIZED	= 0x1,
@@ -3229,7 +3231,7 @@ enum nvme_ana_state {
 };
 
 /**
- * struct nvme_ana_log -
+ * struct nvme_ana_log -  Asymmetric Namespace Access Log
  * @chgcnt:	Change Count
  * @ngrps:	Number of ANA Group Descriptors
  * @rsvd10:	Reserved
@@ -3243,7 +3245,7 @@ struct nvme_ana_log {
 };
 
 /**
- * struct nvme_persistent_event_log -
+ * struct nvme_persistent_event_log - Persistent Event Log
  * @lid:	Log Identifier
  * @rsvd1:	Reserved
  * @tnev:	Total Number of Events
@@ -3287,7 +3289,7 @@ struct nvme_persistent_event_log {
 } __attribute__((packed));
 
 /**
- * struct nvme_persistent_event_entry -
+ * struct nvme_persistent_event_entry - Persistent Event
  * @etype:	Event Type
  * @etype_rev:	Event Type Revision
  * @ehl:	Event Header Length
@@ -3313,20 +3315,20 @@ struct nvme_persistent_event_entry {
 } __attribute__((packed));
 
 /**
- * enum nvme_persistent_event_types -
- * @NVME_PEL_SMART_HEALTH_EVENT:
- * @NVME_PEL_FW_COMMIT_EVENT:
- * @NVME_PEL_TIMESTAMP_EVENT:
- * @NVME_PEL_POWER_ON_RESET_EVENT:
- * @NVME_PEL_NSS_HW_ERROR_EVENT:
- * @NVME_PEL_CHANGE_NS_EVENT:
- * @NVME_PEL_FORMAT_START_EVENT:
- * @NVME_PEL_FORMAT_COMPLETION_EVENT:
- * @NVME_PEL_SANITIZE_START_EVENT:
- * @NVME_PEL_SANITIZE_COMPLETION_EVENT:
- * @NVME_PEL_SET_FEATURE_EVENT:
- * @NVME_PEL_TELEMETRY_CRT:
- * @NVME_PEL_THERMAL_EXCURSION_EVENT:
+ * enum nvme_persistent_event_types - Persistent event log events
+ * @NVME_PEL_SMART_HEALTH_EVENT:	SMART / Health Log Snapshot Event
+ * @NVME_PEL_FW_COMMIT_EVENT:		Firmware Commit Event
+ * @NVME_PEL_TIMESTAMP_EVENT:		Timestamp Change Event
+ * @NVME_PEL_POWER_ON_RESET_EVENT:	Power-on or Reset Event
+ * @NVME_PEL_NSS_HW_ERROR_EVENT:	NVM Subsystem Hardware Error Event
+ * @NVME_PEL_CHANGE_NS_EVENT:		Change Namespace Event
+ * @NVME_PEL_FORMAT_START_EVENT:	Format NVM Start Event
+ * @NVME_PEL_FORMAT_COMPLETION_EVENT:	Format NVM Completion Event
+ * @NVME_PEL_SANITIZE_START_EVENT:	Sanitize Start Event
+ * @NVME_PEL_SANITIZE_COMPLETION_EVENT:	Sanitize Completion Event
+ * @NVME_PEL_SET_FEATURE_EVENT:		Set Feature Event
+ * @NVME_PEL_TELEMETRY_CRT:		Telemetry Log Create Event
+ * @NVME_PEL_THERMAL_EXCURSION_EVENT:	Thermal Excursion Event
  */
 enum nvme_persistent_event_types {
     NVME_PEL_SMART_HEALTH_EVENT		= 0x01,
@@ -3345,7 +3347,7 @@ enum nvme_persistent_event_types {
 };
 
 /**
- * struct nvme_fw_commit_event -
+ * struct nvme_fw_commit_event - Firmware Commit Event Data
  * @old_fw_rev:			Old Firmware Revision
  * @new_fw_rev:			New Firmware Revision
  * @fw_commit_action:		Firmware Commit Action
@@ -3365,7 +3367,7 @@ struct nvme_fw_commit_event {
 } __attribute__((packed));
 
 /**
- * struct nvme_time_stamp_change_event -
+ * struct nvme_time_stamp_change_event - Timestamp Change Event
  * @previous_timestamp:		Previous Timestamp
  * @ml_secs_since_reset:	Milliseconds Since Reset
  */
@@ -3375,7 +3377,7 @@ struct nvme_time_stamp_change_event {
 };
 
 /**
- * struct nvme_power_on_reset_info_list -
+ * struct nvme_power_on_reset_info_list - Controller Reset Information
  * @cid:			Controller ID
  * @fw_act:			Firmware Activation
  * @op_in_prog:			Operation in Progress
@@ -3395,7 +3397,7 @@ struct nvme_power_on_reset_info_list {
 } __attribute__((packed));
 
 /**
- * struct nvme_nss_hw_err_event -
+ * struct nvme_nss_hw_err_event -  NVM Subsystem Hardware Error Event
  * @nss_hw_err_event_code:	NVM Subsystem Hardware Error Event Code
  * @rsvd2:			Reserved
  * @add_hw_err_info:		Additional Hardware Error Information
@@ -3407,7 +3409,7 @@ struct nvme_nss_hw_err_event {
 };
 
 /**
- * struct nvme_change_ns_event -
+ * struct nvme_change_ns_event - Change Namespace Event Data
  * @nsmgt_cdw10:	Namespace Management CDW10
  * @rsvd4:		Reserved
  * @nsze:		Namespace Size
@@ -3439,7 +3441,7 @@ struct nvme_change_ns_event {
 };
 
 /**
- * struct nvme_format_nvm_start_event -
+ * struct nvme_format_nvm_start_event - Format NVM Start Event Data
  * @nsid:		Namespace Identifier
  * @fna:		Format NVM Attributes
  * @rsvd5:		Reserved
@@ -3453,7 +3455,7 @@ struct nvme_format_nvm_start_event {
 };
 
 /**
- * struct nvme_format_nvm_compln_event -
+ * struct nvme_format_nvm_compln_event - Format NVM Completion Event Data
  * @nsid:		Namespace Identifier
  * @smallest_fpi:	Smallest Format Progress Indicator
  * @format_nvm_status:	Format NVM Status
@@ -3469,7 +3471,7 @@ struct nvme_format_nvm_compln_event {
 };
 
 /**
- * struct nvme_sanitize_start_event -
+ * struct nvme_sanitize_start_event - Sanitize Start Event Data
  * @sani_cap:	SANICAP
  * @sani_cdw10:	Sanitize CDW10
  * @sani_cdw11:	Sanitize CDW11
@@ -3481,7 +3483,7 @@ struct nvme_sanitize_start_event {
 };
 
 /**
- * struct nvme_sanitize_compln_event -
+ * struct nvme_sanitize_compln_event - Sanitize Completion Event Data
  * @sani_prog:		Sanitize Progress
  * @sani_status:	Sanitize Status
  * @cmpln_info:		Completion Information
@@ -3495,7 +3497,7 @@ struct nvme_sanitize_compln_event {
 };
 
 /**
- * struct nvme_set_feature_event -
+ * struct nvme_set_feature_event - Set Feature Event Data
  * @layout:	Set Feature Event Layout
  * @cdw_mem:	Command Dwords Memory buffer
  */
@@ -3505,7 +3507,7 @@ struct nvme_set_feature_event {
 };
 
 /**
- * struct nvme_thermal_exc_event -
+ * struct nvme_thermal_exc_event -  Thermal Excursion Event Data
  * @over_temp:	Over Temperature
  * @threshold:	temperature threshold
  */
@@ -3515,7 +3517,7 @@ struct nvme_thermal_exc_event {
 };
 
 /**
- * struct nvme_lba_rd -
+ * struct nvme_lba_rd - LBA Range Descriptor
  * @rslba:	Range Starting LBA
  * @rnlb:	Range Number of Logical Blocks
  * @rsvd12:	Reserved
@@ -3527,10 +3529,10 @@ struct nvme_lba_rd {
 };
 
 /**
- * struct nvme_lbas_ns_element -
+ * struct nvme_lbas_ns_element - LBA Status Log Namespace Element
  * @neid:	Namespace Element Identifier
  * @nlrd:	Number of LBA Range Descriptors
- * @ratype:	Recommended Action Type
+ * @ratype:	Recommended Action Type. see @enum nvme_lba_status_atype
  * @rsvd8:	Reserved
  * @lba_rd:	LBA Range Descriptor
  */
@@ -3543,9 +3545,10 @@ struct nvme_lbas_ns_element {
 };
 
 /**
- * enum nvme_lba_status_atype -
- * @NVME_LBA_STATUS_ATYPE_SCAN_UNTRACKED:
- * @NVME_LBA_STATUS_ATYPE_SCAN_TRACKED:
+ * enum nvme_lba_status_atype - Potentially Unrecoverable LBAs
+ * @NVME_LBA_STATUS_ATYPE_SCAN_UNTRACKED:	Potentially Unrecoverable LBAs
+ * @NVME_LBA_STATUS_ATYPE_SCAN_TRACKED:		Potentially Unrecoverable LBAs
+ *						associated with physical storage
  */
 enum nvme_lba_status_atype {
 	NVME_LBA_STATUS_ATYPE_SCAN_UNTRACKED			= 0x10,
@@ -3553,7 +3556,7 @@ enum nvme_lba_status_atype {
 };
 
 /**
- * struct nvme_lba_status_log -
+ * struct nvme_lba_status_log - LBA Status Information Log
  * @lslplen:	LBA Status Log Page Length
  * @nlslne:	Number of LBA Status Log Namespace Elements
  * @estulb:	Estimate of Unrecoverable Logical Blocks
@@ -3571,7 +3574,7 @@ struct nvme_lba_status_log {
 };
 
 /**
- * struct nvme_eg_event_aggregate_log -
+ * struct nvme_eg_event_aggregate_log - Endurance Group Event Aggregate
  * @nr_entries:	Number of Entries
  * @egids:	Endurance Group Identifier
  */
@@ -3581,23 +3584,21 @@ struct nvme_eg_event_aggregate_log {
 };
 
 /**
- * enum nvme_fid_supported_effects -
- * @NVME_FID_SUPPORTED_EFFECTS_FSUPP:
- * @NVME_FID_SUPPORTED_EFFECTS_UDCC:
- * @NVME_FID_SUPPORTED_EFFECTS_NCC:
- * @NVME_FID_SUPPORTED_EFFECTS_NIC:
- * @NVME_FID_SUPPORTED_EFFECTS_CCC:
- * @NVME_FID_SUPPORTED_EFFECTS_UUID_SEL:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_SHIFT:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_MASK:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_NS:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_CTRL:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_NVM_SET:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_ENDGRP:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_DOMAIN:
- * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_NSS:
- *
- * FID Supported and Effects Data Structure definitions
+ * enum nvme_fid_supported_effects - FID Supported and Effects Data Structure definitions
+ * @NVME_FID_SUPPORTED_EFFECTS_FSUPP:		FID Supported
+ * @NVME_FID_SUPPORTED_EFFECTS_UDCC:		User Data Content Change
+ * @NVME_FID_SUPPORTED_EFFECTS_NCC:		Namespace Capability Change
+ * @NVME_FID_SUPPORTED_EFFECTS_NIC:		Namespace Inventory Change
+ * @NVME_FID_SUPPORTED_EFFECTS_CCC:		Controller Capability Change
+ * @NVME_FID_SUPPORTED_EFFECTS_UUID_SEL:	UUID Selection Supported
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_SHIFT:	FID Scope Shift
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_MASK:	FID Scope Mask
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_NS:	Namespace Scope
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_CTRL:	Controller Scope
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_NVM_SET:	NVM Set Scope
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_ENDGRP:	Endurance Group Scope
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_DOMAIN:	Domain Scope
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_NSS:	NVM Subsystem Scope
  */
 enum nvme_fid_supported_effects {
 	NVME_FID_SUPPORTED_EFFECTS_FSUPP	= 1 << 0,
@@ -3617,17 +3618,16 @@ enum nvme_fid_supported_effects {
 };
 
 /**
- * struct nvme_fid_supported_effects_log -
+ * struct nvme_fid_supported_effects_log - Feature Identifiers Supported and Effects
  * @fid_support: Feature Identifier Supported
  *
- * Feature Identifiers Supported and Effects (Log Identifier 12h)
  */
 struct nvme_fid_supported_effects_log {
 	__le32	fid_support[NVME_LOG_FID_SUPPORTED_EFFECTS_MAX];
 };
 
 /**
- * enum nvme_mi_cmd_supported_effects - bit field definitions
+ * enum nvme_mi_cmd_supported_effects - MI Command Supported and Effects Data Structure
  * @NVME_MI_CMD_SUPPORTED_EFFECTS_CSUPP:	Command Supported
  * @NVME_MI_CMD_SUPPORTED_EFFECTS_UDCC:		User Data Conttent Change
  * @NVME_MI_CMD_SUPPORTED_EFFECTS_NCC:		Namespace Capability Change
@@ -3641,8 +3641,6 @@ struct nvme_fid_supported_effects_log {
  * @NVME_MI_CMD_SUPPORTED_EFFECTS_SCOPE_ENDGRP:	Endurance Group Scope
  * @NVME_MI_CMD_SUPPORTED_EFFECTS_SCOPE_DOMAIN:	Domain Scope
  * @NVME_MI_CMD_SUPPORTED_EFFECTS_SCOPE_NSS:	NVM Subsystem Scope
- *
- * MI Command Supported and Effects Data Structure definitions
  */
 enum nvme_mi_cmd_supported_effects {
 	NVME_MI_CMD_SUPPORTED_EFFECTS_CSUPP         = 1 << 0,
@@ -3661,10 +3659,9 @@ enum nvme_mi_cmd_supported_effects {
 };
 
 /**
- * struct nvme_mi_cmd_supported_effects_log -
- * @mi_cmd_support: NVMe-MI Commands Supported
- *
- * NVMe-MI Commands Supported and Effects (Log Identifier 13h)
+ * struct nvme_mi_cmd_supported_effects_log - NVMe-MI Commands Supported and Effects Log
+ * @mi_cmd_support:	NVMe-MI Commands Supported
+ * @reserved1:		Reserved
  */
 struct nvme_mi_cmd_supported_effects_log {
 	__le32	mi_cmd_support[NVME_LOG_MI_CMD_SUPPORTED_EFFECTS_MAX];
@@ -3672,7 +3669,7 @@ struct nvme_mi_cmd_supported_effects_log {
 };
 
 /**
- * struct nvme_boot_partition -
+ * struct nvme_boot_partition - Boot Partition Log
  * @lid:			Boot Partition Identifier
  * @rsvd1:			Reserved
  * @bpinfo:			Boot Partition Information
@@ -3689,7 +3686,7 @@ struct nvme_boot_partition {
 };
 
 /**
- * struct nvme_media_unit_stat_desc -
+ * struct nvme_media_unit_stat_desc - Media Unit Status Descriptor
  * @muid:         Media Unit Identifier
  * @domainid:     Domain Identifier
  * @endgid:       Endurance Group Identifier
@@ -3713,7 +3710,7 @@ struct nvme_media_unit_stat_desc {
 };
 
 /**
- * struct nvme_media_unit_stat_log -
+ * struct nvme_media_unit_stat_log - Media Unit Status
  * @nmu:        Number unit status descriptor
  * @cchans:     Number of Channels
  * @sel_config: Selected Configuration
@@ -3729,12 +3726,10 @@ struct nvme_media_unit_stat_log {
 };
 
 /**
- * struct nvme_media_unit_config_desc -
- * @muid: Media Unit Identifier
- * @mudl: Media Unit Descriptor Length
- *
- * Media Unit Configuration Descriptor
- * Structure Definitions
+ * struct nvme_media_unit_config_desc - Media Unit Configuration Descriptor
+ * @muid:	Media Unit Identifier
+ * @rsvd2:	Reserved
+ * @mudl:	Media Unit Descriptor Length
  */
 struct nvme_media_unit_config_desc {
 	__le16	muid;
@@ -3743,12 +3738,11 @@ struct nvme_media_unit_config_desc {
 };
 
 /**
- * struct nvme_channel_config_desc -
- * @chanid:	Channel Identifier
- * @chmus:	Number Channel Media Units
- *
- * Channel Configuration Descriptor
- * Structure Definitions
+ * struct nvme_channel_config_desc - Channel Configuration Descriptor
+ * @chanid:		Channel Identifier
+ * @chmus:		Number Channel Media Units
+ * @mu_config_desc:	Channel Unit config descriptors.
+ *			See @struct nvme_media_unit_config_desc
  */
 struct nvme_channel_config_desc {
 	__le16	chanid;
@@ -3757,11 +3751,10 @@ struct nvme_channel_config_desc {
 };
 
 /**
- * struct nvme_end_grp_chan_desc -
- * @egchans:	Number of Channels
- *
- * Endurance group Channel Configuration Descriptor
- * Structure Definitions
+ * struct nvme_end_grp_chan_desc - Endurance Group Channel Configuration Descriptor
+ * @egchans:		Number of Channels
+ * @chan_config_desc:	Channel config descriptors.
+ *			See @struct nvme_channel_config_desc
  */
 struct nvme_end_grp_chan_desc {
 	__le16	egchans;
@@ -3769,17 +3762,16 @@ struct nvme_end_grp_chan_desc {
 };
 
 /**
- * struct nvme_end_grp_config_desc -
+ * struct nvme_end_grp_config_desc -  Endurance Group Configuration Descriptor
  * @endgid:		Endurance Group Identifier
  * @cap_adj_factor:	Capacity Adjustment Factor
+ * @rsvd4:		Reserved
  * @tegcap:		Total Endurance Group Capacity
  * @segcap:		Spare Endurance Group Capacity
  * @end_est:		Endurance Estimate
  * @egsets:		Number of NVM Sets
+ * @rsvd64:		Reserved
  * @nvmsetid:		NVM Set Identifier
- *
- * Endurance Group Configuration Descriptor
- * Structure Definitions
  */
 struct nvme_end_grp_config_desc {
 	__le16	endgid;
@@ -3794,13 +3786,14 @@ struct nvme_end_grp_config_desc {
 };
 
 /**
- * struct nvme_cap_config_desc -
+ * struct nvme_capacity_config_desc - Capacity Configuration structure definitions
  * @cap_config_id:	Capacity Configuration Identifier
  * @domainid:		Domain Identifier
  * @egcn:		Number Endurance Group Configuration
  *			Descriptors
- *
- * Capacity Configuration structure definitions
+ * @rsvd6:		Reserved
+ * @egcd:		Endurance Group Config descriptors.
+ *			See @struct nvme_end_grp_config_desc
  */
 struct nvme_capacity_config_desc {
 	__le16	cap_config_id;
@@ -3811,11 +3804,11 @@ struct nvme_capacity_config_desc {
 };
 
 /**
- * struct nvme_supported_cap_config_list_log -
- * @sccn: number of capacity configuration
- *
- * Supported Capacity Configuration list log page
- * structure definitions
+ * struct nvme_supported_cap_config_list_log - Supported Capacity Configuration list log page
+ * @sccn:		Number of capacity configuration
+ * @rsvd1:		Reserved
+ * @cap_config_desc:	Capacity configuration desriptor.
+ *			See @struct nvme_capacity_config_desc
  */
 struct nvme_supported_cap_config_list_log {
 	__u8	sccn;
@@ -3824,7 +3817,7 @@ struct nvme_supported_cap_config_list_log {
 };
 
 /**
- * struct nvme_resv_notification_log -
+ * struct nvme_resv_notification_log - Reservation Notification Log
  * @lpc:	Log Page Count
  * @rnlpt:	See &enum nvme_resv_notify_rnlpt.
  * @nalp:	Number of Available Log Pages
@@ -3842,11 +3835,11 @@ struct nvme_resv_notification_log {
 };
 
 /**
- * enum nvme_resv_notify_rnlpt -
- * @NVME_RESV_NOTIFY_RNLPT_EMPTY:
- * @NVME_RESV_NOTIFY_RNLPT_REGISTRATION_PREEMPTED:
- * @NVME_RESV_NOTIFY_RNLPT_RESERVATION_RELEASED:
- * @NVME_RESV_NOTIFY_RNLPT_RESERVATION_PREEMPTED:
+ * enum nvme_resv_notify_rnlpt -  Reservation Notification Log - Reservation Notification Log Page Type
+ * @NVME_RESV_NOTIFY_RNLPT_EMPTY:			Empty Log Page
+ * @NVME_RESV_NOTIFY_RNLPT_REGISTRATION_PREEMPTED:	Registration Preempted
+ * @NVME_RESV_NOTIFY_RNLPT_RESERVATION_RELEASED:	Reservation Released
+ * @NVME_RESV_NOTIFY_RNLPT_RESERVATION_PREEMPTED:	Reservation Preempted
  */
 enum nvme_resv_notify_rnlpt {
 	NVME_RESV_NOTIFY_RNLPT_EMPTY			= 0,
@@ -4006,15 +3999,15 @@ struct nvme_zns_changed_zone_log {
 };
 
 /**
- * enum nvme_zns_zt -
- * @NVME_ZONE_TYPE_SEQWRITE_REQ:
+ * enum nvme_zns_zt - Zone Descriptor Data Structure - Zone Type
+ * @NVME_ZONE_TYPE_SEQWRITE_REQ:	Sequential Write Required
  */
 enum nvme_zns_zt {
 	NVME_ZONE_TYPE_SEQWRITE_REQ	= 0x2,
 };
 
 /**
- * enum nvme_zns_za -
+ * enum nvme_zns_za - Zone Descriptor Data Structure
  * @NVME_ZNS_ZA_ZFC:	Zone Finished by Controller
  * @NVME_ZNS_ZA_FZR:	Finish Zone Recommended
  * @NVME_ZNS_ZA_RZR:	Reset Zone Recommended
@@ -4030,7 +4023,7 @@ enum nvme_zns_za {
 };
 
 /**
- * enum nvme_zns_zs -
+ * enum nvme_zns_zs - Zone Descriptor Data Structure - Zone State
  * @NVME_ZNS_ZS_EMPTY:		Empty state
  * @NVME_ZNS_ZS_IMPL_OPEN:	Implicitly open state
  * @NVME_ZNS_ZS_EXPL_OPEN:	Explicitly open state
@@ -4050,7 +4043,7 @@ enum nvme_zns_zs {
 };
 
 /**
- * struct nvme_zns_desc -
+ * struct nvme_zns_desc - Zone Descriptor Data Structure
  * @zt:		Zone Type
  * @zs:		Zone State
  * @za:		Zone Attributes
@@ -4074,7 +4067,7 @@ struct nvme_zns_desc {
 };
 
 /**
- * struct nvme_zone_report -
+ * struct nvme_zone_report - Report Zones Data Structure
  * @nr_zones: Number of descriptors in @entries
  * @rsvd8:    Reserved
  * @entries:  Zoned namespace descriptors
@@ -4086,7 +4079,7 @@ struct nvme_zone_report {
 };
 
 /**
- * struct nvme_lba_status_desc -
+ * struct nvme_lba_status_desc - LBA Status Descriptor Entry
  * @dslba:	Descriptor Starting LBA
  * @nlb:	Number of Logical Blocks
  * @rsvd12:	Reserved
@@ -4102,7 +4095,7 @@ struct nvme_lba_status_desc {
 };
 
 /**
- * struct nvme_lba_status -
+ * struct nvme_lba_status - LBA Status Descriptor List
  * @nlsd:	Number of LBA Status Descriptors
  * @cmpc:	Completion Condition
  * @rsvd5:	Reserved
@@ -4116,7 +4109,7 @@ struct nvme_lba_status {
 };
 
 /**
- * struct nvme_feat_auto_pst -
+ * struct nvme_feat_auto_pst - Autonomous Power State Transition
  * @apst_entry: See &enum nvme_apst_entry
  */
 struct nvme_feat_auto_pst {
@@ -4124,11 +4117,11 @@ struct nvme_feat_auto_pst {
 };
 
 /**
- * enum nvme_apst_entry -
- * @NVME_APST_ENTRY_ITPS_SHIFT:
- * @NVME_APST_ENTRY_ITPT_SHIFT:
- * @NVME_APST_ENTRY_ITPS_MASK:
- * @NVME_APST_ENTRY_ITPT_MASK:
+ * enum nvme_apst_entry - Autonomous Power State Transition
+ * @NVME_APST_ENTRY_ITPS_SHIFT:	Idle Transition Power State Shift
+ * @NVME_APST_ENTRY_ITPT_SHIFT:	Idle Time Prior to Transition Shift
+ * @NVME_APST_ENTRY_ITPS_MASK:	Idle Transition Power State Mask
+ * @NVME_APST_ENTRY_ITPT_MASK:	Idle Time Prior to Transition Mask
  */
 enum nvme_apst_entry {
 	NVME_APST_ENTRY_ITPS_SHIFT = 3,
@@ -4230,7 +4223,7 @@ enum nvme_ns_metadata_type {
 };
 
 /**
- * struct nvme_timestamp -
+ * struct nvme_timestamp - Timestamp - Data Structure for Get Features
  * @timestamp:	Timestamp value based on origin and synch field
  * @attr:	Attribute
  * @rsvd:	Reserved
@@ -4242,7 +4235,7 @@ struct nvme_timestamp {
 };
 
 /**
- * struct nvme_lba_range_type_entry -
+ * struct nvme_lba_range_type_entry - LBA Range Type - Data Structure Entry
  * @type:	Specifies the Type of the LBA range
  * @attributes: Specifies attributes of the LBA range
  * @rsvd2:	Reserved
@@ -4262,7 +4255,7 @@ struct nvme_lba_range_type_entry {
 };
 
 /**
- * enum nvme_lbart -
+ * enum nvme_lbart - LBA Range Type - Data Structure Entry
  * @NVME_LBART_TYPE_GP:		General Purpose
  * @NVME_LBART_TYPE_FS:		Filesystem
  * @NVME_LBART_TYPE_RAID:	RAID
@@ -4282,15 +4275,15 @@ enum nvme_lbart {
 };
 
 /**
- * struct nvme_lba_range_type -
- * @entry:	LBA range type entry
+ * struct nvme_lba_range_type - LBA Range Type
+ * @entry:	LBA range type entry. See @struct nvme_lba_range_type_entry
  */
 struct nvme_lba_range_type {
 	struct nvme_lba_range_type_entry entry[NVME_FEAT_LBA_RANGE_MAX];
 };
 
 /**
- * struct nvme_plm_config -
+ * struct nvme_plm_config - Predictable Latency Mode - Deterministic Threshold Configuration Data Structure
  * @ee:		Enable Event
  * @rsvd2:	Reserved
  * @dtwinrt:	DTWIN Reads Threshold
@@ -4308,7 +4301,7 @@ struct nvme_plm_config {
 };
 
 /**
- * struct nvme_feat_host_behavior -
+ * struct nvme_feat_host_behavior - Host Behavior Support - Data Structure
  * @acre:	Advanced Command Retry Enable
  * @rsvd1:	Reserved
  */
@@ -4318,7 +4311,7 @@ struct nvme_feat_host_behavior {
 };
 
 /**
- * enum nvme_host_behavior_support -
+ * enum nvme_host_behavior_support - Enable Advanced Command
  * @NVME_ENABLE_ACRE:	Enable Advanced Command Retry Enable
  */
 enum nvme_host_behavior_support {
@@ -4326,7 +4319,7 @@ enum nvme_host_behavior_support {
 };
 
 /**
- * struct nvme_dsm_range -
+ * struct nvme_dsm_range - Dataset Management - Range Definition
  * @cattr:	Context Attributes
  * @nlb:	Length in logical blocks
  * @slba:	Starting LBA
@@ -4338,7 +4331,7 @@ struct nvme_dsm_range {
 };
 
 /**
- * struct nvme_copy_range -
+ * struct nvme_copy_range - Copy - Source Range Entries Descriptor Format
  * @rsvd0:	Reserved
  * @slba:	Starting LBA
  * @nlb:	Number of Logical Blocks
@@ -4359,7 +4352,7 @@ struct nvme_copy_range {
 };
 
 /**
- * struct nvme_copy_range_f1 -
+ * struct nvme_copy_range_f1 - Copy - Source Range Entries Descriptor Format 1h
  * @rsvd0:	Reserved
  * @slba:	Starting LBA
  * @nlb:	Number of Logical Blocks
@@ -4380,7 +4373,7 @@ struct nvme_copy_range_f1 {
 };
 
 /**
- * struct nvme_registered_ctrl -
+ * struct nvme_registered_ctrl - Registered Controller Data Structure
  * @cntlid:	Controller ID
  * @rcsts:	Reservation Status
  * @rsvd3:	Reserved
@@ -4396,7 +4389,7 @@ struct nvme_registered_ctrl {
 };
 
 /**
- * struct nvme_registered_ctrl_ext -
+ * struct nvme_registered_ctrl_ext - Registered Controller Extended Data Structure
  * @cntlid:	Controller ID
  * @rcsts:	Reservation Status
  * @rsvd3:	Reserved
@@ -4414,7 +4407,7 @@ struct nvme_registered_ctrl_ext {
 };
 
 /**
- * struct nvme_resv_status -
+ * struct nvme_resv_status - Reservation Status Data Structure
  * @gen:	Generation
  * @rtype:	Reservation Type
  * @regctl:	Number of Registered Controllers
@@ -4442,7 +4435,7 @@ struct nvme_resv_status {
 };
 
 /**
- * struct nvme_streams_directive_params -
+ * struct nvme_streams_directive_params -  Streams Directive - Return Parameters Data Structure
  * @msl:	Max Streams Limit
  * @nssa:	NVM Subsystem Streams Available
  * @nsso:	NVM Subsystem Streams Open
@@ -4468,7 +4461,7 @@ struct nvme_streams_directive_params {
 };
 
 /**
- * struct nvme_streams_directive_status -
+ * struct nvme_streams_directive_status - Streams Directive - Get Status Data Structure
  * @osc: Open Stream Count
  * @sid: Stream Identifier
  */
@@ -4478,7 +4471,7 @@ struct nvme_streams_directive_status {
 };
 
 /**
- * struct nvme_id_directives -
+ * struct nvme_id_directives -  Identify Directive - Return Parameters Data Structure
  * @supported:	Identify directive is supported
  * @enabled:	Identify directive is Enabled
  * @rsvd64:	Reserved
@@ -4490,7 +4483,7 @@ struct nvme_id_directives {
 };
 
 /**
- * enum nvme_directive_types -
+ * enum nvme_directive_types - Directives Supported or Enabled
  * @NVME_ID_DIR_ID_BIT: Identify directive is supported
  * @NVME_ID_DIR_SD_BIT: Streams directive is supported
  */
@@ -4500,7 +4493,7 @@ enum nvme_directive_types {
 };
 
 /**
- * struct nvme_host_mem_buf_attrs -
+ * struct nvme_host_mem_buf_attrs - Host Memory Buffer - Attributes Data Structure
  * @hsize:	Host Memory Buffer Size
  * @hmdlal:	Host Memory Descriptor List Lower Address
  * @hmdlau:	Host Memory Descriptor List Upper Address
@@ -4517,7 +4510,7 @@ struct nvme_host_mem_buf_attrs {
 };
 
 /**
- * enum nvme_ae_type -
+ * enum nvme_ae_type - Asynchronous Event Type
  * @NVME_AER_ERROR:	Error event
  * @NVME_AER_SMART:	SMART / Health Status event
  * @NVME_AER_NOTICE:	Notice event
@@ -4533,7 +4526,7 @@ enum nvme_ae_type {
 };
 
 /**
- * enum nvme_ae_info_error -
+ * enum nvme_ae_info_error - Asynchronous Event Information - Error Status
  * @NVME_AER_ERROR_INVALID_DB_REG:		Write to Invalid Doorbell Register
  * @NVME_AER_ERROR_INVALID_DB_VAL:		Invalid Doorbell Write Value
  * @NVME_AER_ERROR_DIAG_FAILURE:		Diagnostic Failure
@@ -4551,7 +4544,7 @@ enum nvme_ae_info_error {
 };
 
 /**
- * enum nvme_ae_info_smart -
+ * enum nvme_ae_info_smart - Asynchronous Event Information - SMART / Health Status
  * @NVME_AER_SMART_SUBSYSTEM_RELIABILITY:	NVM subsystem Reliability
  * @NVME_AER_SMART_TEMPERATURE_THRESHOLD:	Temperature Threshold
  * @NVME_AER_SMART_SPARE_THRESHOLD:		Spare Below Threshold
@@ -4563,7 +4556,7 @@ enum nvme_ae_info_smart {
 };
 
 /**
- * enum nvme_ae_info_css_nvm -
+ * enum nvme_ae_info_css_nvm - Asynchronous Event Information - I/O Command Specific Status
  * @NVME_AER_CSS_NVM_RESERVATION:			Reservation Log Page Available
  * @NVME_AER_CSS_NVM_SANITIZE_COMPLETED:		Sanitize Operation Completed
  * @NVME_AER_CSS_NVM_UNEXPECTED_SANITIZE_DEALLOC:	Sanitize Operation Completed
@@ -4576,7 +4569,7 @@ enum nvme_ae_info_css_nvm {
 };
 
 /**
- * enum nvme_ae_info_notice -
+ * enum nvme_ae_info_notice - Asynchronous Event Information - Notice
  * @NVME_AER_NOTICE_NS_CHANGED:		Namespace Attribute Changed
  * @NVME_AER_NOTICE_FW_ACT_STARTING:	Firmware Activation Starting
  * @NVME_AER_NOTICE_TELEMETRY:		Telemetry Log Changed
@@ -5061,7 +5054,7 @@ struct nvmf_connect_data {
 };
 
 /**
- * struct nvme_mi_read_nvm_ss_info -
+ * struct nvme_mi_read_nvm_ss_info - NVM Subsystem Information Data Structure
  * @nump:	Number of Ports
  * @mjr:	NVMe-MI Major Version Number
  * @mnr:	NVMe-MI Minor Version Number
@@ -5075,7 +5068,7 @@ struct nvme_mi_read_nvm_ss_info {
 };
 
 /**
- * struct nvme_mi_port_pcie -
+ * struct nvme_mi_port_pcie - PCIe Port Specific Data
  * @mps:	PCIe Maximum Payload Size
  * @sls:	PCIe Supported Link Speeds Vector
  * @cls:	PCIe Current Link Speed
@@ -5095,7 +5088,7 @@ struct nvme_mi_port_pcie {
 };
 
 /**
- * struct nvme_mi_port_smb -
+ * struct nvme_mi_port_smb - SMBus Port Specific Data
  * @vpd_addr:	Current VPD SMBus/I2C Address
  * @mvpd_freq:	Maximum VPD Access SMBus/I2C Frequency
  * @mme_addr:	Current Management Endpoint SMBus/I2C Address
@@ -5113,7 +5106,7 @@ struct nvme_mi_port_smb {
 };
 
 /**
- * struct nvme_mi_read_port_info -
+ * struct nvme_mi_read_port_info - Port Information Data Structure
  * @portt:	Port Type
  * @rsvd1:	Reserved
  * @mmctptus:	Maximum MCTP Transmission Unit Size
@@ -5133,7 +5126,7 @@ struct nvme_mi_read_port_info {
 };
 
 /**
- * struct nvme_mi_read_ctrl_info -
+ * struct nvme_mi_read_ctrl_info - Controller Information Data Structure
  * @portid:	Port Identifier
  * @rsvd1:	Reserved
  * @prii:	PCIe Routing ID Information
@@ -5157,7 +5150,7 @@ struct nvme_mi_read_ctrl_info {
 };
 
 /**
- * struct nvme_mi_osc -
+ * struct nvme_mi_osc - Optionally Supported Command Data Structure
  * @type:	Command Type
  * @opc:	Opcode
  */
@@ -5167,9 +5160,10 @@ struct nvme_mi_osc {
 };
 
 /**
- * struct nvme_mi_read_sc_list -
+ * struct nvme_mi_read_sc_list -  Management Endpoint Buffer Supported Command List Data Structure
  * @numcmd:	Number of Commands
- * @cmds:	MEB supported Command Data Structure
+ * @cmds:	MEB supported Command Data Structure.
+ *		See @struct nvme_mi_osc
  */
 struct nvme_mi_read_sc_list {
 	__le16	numcmd;
@@ -5177,7 +5171,7 @@ struct nvme_mi_read_sc_list {
 };
 
 /**
- * struct nvme_mi_nvm_ss_health_status -
+ * struct nvme_mi_nvm_ss_health_status - Subsystem Management Data Structure
  * @nss:	NVM Subsystem Status
  * @sw:		Smart Warnings
  * @ctemp:	Composite Temperature
@@ -5195,7 +5189,7 @@ struct nvme_mi_nvm_ss_health_status {
 };
 
 /**
- * enum nvme_mi_css -
+ * enum nvme_mi_css - Get State Control Primitive Success Response Fields - Control Primitive Specific Response
  * @NVME_MI_CCS_RDY:	Ready
  * @NVME_MI_CSS_CFS:	Controller Fatal Status
  * @NVME_MI_CSS_SHST:	Shutdown Status
@@ -5225,7 +5219,7 @@ enum nvme_mi_css {
 };
 
 /**
- * struct nvme_mi_ctrl_health_status -
+ * struct nvme_mi_ctrl_health_status - Controller Health Data Structure (CHDS)
  * @ctlid:	Controller Identifier
  * @csts:	Controller Status
  * @ctemp:	Composite Temperature
@@ -5245,7 +5239,7 @@ struct nvme_mi_ctrl_health_status {
 };
 
 /**
- * enum nvme_mi_csts -
+ * enum nvme_mi_csts - Controller Health Data Structure (CHDS) - Controller Status (CSTS)
  * @NVME_MI_CSTS_RDY:	Ready
  * @NVME_MI_CSTS_CFS:	Controller Fatal Status
  * @NVME_MI_CSTS_SHST:	Shutdown Status
@@ -5265,7 +5259,7 @@ enum nvme_mi_csts {
 };
 
 /**
- * enum nvme_mi_cwarn -
+ * enum nvme_mi_cwarn - Controller Health Data Structure (CHDS) - Critical Warning (CWARN)
  * @NVME_MI_CWARN_ST:	Spare Threshold
  * @NVME_MI_CWARN_TAUT:	Temperature Above or Under Threshold
  * @NVME_MI_CWARN_RD:	Reliability Degraded
@@ -5281,7 +5275,7 @@ enum nvme_mi_cwarn {
 };
 
 /**
- * struct nvme_mi_vpd_mra -
+ * struct nvme_mi_vpd_mra - NVMe MultiRecord Area
  * @nmravn:	NVMe MultiRecord Area Version Number
  * @ff:		Form Factor
  * @rsvd7:	Reserved
@@ -5290,7 +5284,7 @@ enum nvme_mi_cwarn {
  * @i33vpwr:	Initial 3.3 V Power Supply Requirements
  * @m33vpwr:	Maximum 3.3 V Power Supply Requirements
  * @rsvd17:	Reserved
- * @m33vapsr:	Maximum 3.3 V aux Power Supply Requirements
+ * @m33vapsr:	Maximum 3.3 Vi aux Power Supply Requirements
  * @i5vapsr:	Initial 5 V Power Supply Requirements
  * @m5vapsr:	Maximum 5 V Power Supply Requirements
  * @i12vapsr:	Initial 12 V Power Supply Requirements
@@ -5319,7 +5313,7 @@ struct nvme_mi_vpd_mra {
 };
 
 /**
- * struct nvme_mi_vpd_ppmra -
+ * struct nvme_mi_vpd_ppmra -  NVMe PCIe Port MultiRecord Area
  * @nppmravn:	NVMe PCIe Port MultiRecord Area Version Number
  * @pn:		PCIe Port Number
  * @ppi:	Port Information
@@ -5343,7 +5337,7 @@ struct nvme_mi_vpd_ppmra {
 };
 
 /**
- * struct nvme_mi_vpd_telem -
+ * struct nvme_mi_vpd_telem - Vital Product Data Element Descriptor
  * @type:	Type of the Element Descriptor
  * @rev:	Revision of the Element Descriptor
  * @len:	Number of bytes in the Element Descriptor
@@ -5358,7 +5352,7 @@ struct nvme_mi_vpd_telem {
 };
 
 /**
- * enum nvme_mi_elem -
+ * enum nvme_mi_elem - Element Descriptor Types
  * @NVME_MI_ELEM_EED:		Extended Element Descriptor
  * @NVME_MI_ELEM_USCE:		Upstream Connector Element Descriptor
  * @NVME_MI_ELEM_ECED:		Expansion Connector Element Descriptor
@@ -5378,7 +5372,7 @@ enum nvme_mi_elem {
 };
 
 /**
- * struct nvme_mi_vpd_tra -
+ * struct nvme_mi_vpd_tra - Vital Product Data Topology MultiRecord
  * @vn:		Version Number
  * @rsvd6:	Reserved
  * @ec:		Element Count
@@ -5392,7 +5386,7 @@ struct nvme_mi_vpd_tra {
 };
 
 /**
- * struct nvme_mi_vpd_mr_common -
+ * struct nvme_mi_vpd_mr_common -  NVMe MultiRecord Area
  * @type:	NVMe Record Type ID
  * @rf:		Record Format
  * @rlen:	Record Length
@@ -5417,7 +5411,7 @@ struct nvme_mi_vpd_mr_common {
 };
 
 /**
- * struct nvme_mi_vpd_hdr -
+ * struct nvme_mi_vpd_hdr - Vital Product Data Common Header
  * @ipmiver:	IPMI Format Version Number
  * @iuaoff:	Internal Use Area Starting Offset
  * @ciaoff:	Chassis Info Area Starting Offset
@@ -5449,7 +5443,11 @@ struct nvme_mi_vpd_hdr {
  * @NVME_SCT_PATH:		      Errors associated with the paths connection
  * @NVME_SCT_VS:		      Vendor specific errors
  * @NVME_SCT_MASK:		      Mask to get the value of the Status Code Type
+ * @NVME_SCT_SHIFT:                   Shift value to get the value of the Status
+ *                                    Code Type
  * @NVME_SC_MASK:		      Mask to get the value of the status code.
+ * @NVME_SC_SHIFT:                    Shift value to get the value of the status
+ *                                    code.
  * @NVME_SC_SUCCESS:		      Successful Completion: The command
  * 				      completed without error.
  * @NVME_SC_INVALID_OPCODE:	      Invalid Command Opcode: A reserved coded
@@ -5764,7 +5762,7 @@ struct nvme_mi_vpd_hdr {
  *				      transient condition.
  * @NVME_SC_REQSTD_FUNCTION_DISABLED: Fabric Zoning is not enabled on the
  *				      CDC
- * @NVME_SC_ZONEGRP_ORIGINATOR_INVL:  The NQN contained in the ZoneGroup
+ * @NVME_SC_ZONEGRP_ORIGINATOR_INVLD:  The NQN contained in the ZoneGroup
  *				      Originator field does not match the
  *				      Host NQN used by the DDC to connect
  *				      to the CDC.
@@ -6076,9 +6074,10 @@ enum nvme_status_field {
 
 /**
  * nvme_status_code_type() - Returns the NVMe Status Code Type
- * @status_field: The NVMe Completion Queue Entry's Status Field
+ * @status_field:	The NVMe Completion Queue Entry's Status Field
+ *			See &enum nvme_status_field
  *
- * See &enum nvme_status_field
+ * Returns: status code type
  */
 static inline __u16 nvme_status_code_type(__u16 status_field)
 {
@@ -6087,9 +6086,10 @@ static inline __u16 nvme_status_code_type(__u16 status_field)
 
 /**
  * nvme_status_code() - Returns the NVMe Status Code
- * @status_field: The NVMe Completion Queue Entry's Status Field
+ * @status_field:	The NVMe Completion Queue Entry's Status Field
+ *			See &enum nvme_status_field
  *
- * See &enum nvme_status_field
+ * Returns: status code
  */
 static inline __u16 nvme_status_code(__u16 status_field)
 {
@@ -6173,7 +6173,7 @@ enum nvme_admin_opcode {
 };
 
 /**
- * enum nvme_identify_cns -
+ * enum nvme_identify_cns -			Identify - CNS Values
  * @NVME_IDENTIFY_CNS_NS:			Identify Namespace data structure
  * @NVME_IDENTIFY_CNS_CTRL:			Identify Controller data structur
  * @NVME_IDENTIFY_CNS_NS_ACTIVE_LIST:		Active Namespace ID list
@@ -6186,6 +6186,9 @@ enum nvme_admin_opcode {
  * @NVME_IDENTIFY_CNS_CSI_NS_ACTIVE_LIST:	Active Namespace ID list associated
  * 						with the specified I/O Command Set
  * @NVME_IDENTIFY_CNS_CSI_INDEPENDENT_ID_NS:	I/O Command Set Independent Identify
+ * @NVME_IDENTIFY_CNS_NS_USER_DATA_FORMAT:	Namespace user data format
+ * @NVME_IDENTIFY_CNS_CSI_NS_USER_DATA_FORMAT:	I/O Command Set specific user data
+ *						format
  * 						Namespace data structure
  * @NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST:	Allocated Namespace ID list
  * @NVME_IDENTIFY_CNS_ALLOCATED_NS:		Identify Namespace data structure for
@@ -6237,7 +6240,7 @@ enum nvme_identify_cns {
 };
 
 /**
- * enum nvme_cmd_get_log_lid -
+ * enum nvme_cmd_get_log_lid -			Get Log Page -Log Page Identifiers
  * @NVME_LOG_LID_SUPPORTED_LOG_PAGES:		Supported Log Pages
  * @NVME_LOG_LID_ERROR:				Error Information
  * @NVME_LOG_LID_SMART:				SMART / Health Information
@@ -6293,7 +6296,7 @@ enum nvme_cmd_get_log_lid {
 };
 
 /**
- * enum nvme_features_id -
+ * enum nvme_features_id -		Features - Feature Identifiers
  * @NVME_FEAT_FID_ARBITRATION:		Arbitration
  * @NVME_FEAT_FID_POWER_MGMT:		Power Management
  * @NVME_FEAT_FID_LBA_RANGE:		LBA Range Type
@@ -6367,7 +6370,7 @@ enum nvme_features_id {
 };
 
 /**
- * enum nvme_feat -
+ * enum nvme_feat - Features Access Shifts/Masks values
  * @NVME_FEAT_ARBITRATION_BURST_SHIFT:
  * @NVME_FEAT_ARBITRATION_BURST_MASK:
  * @NVME_FEAT_ARBITRATION_LPW_SHIFT:
@@ -6569,7 +6572,7 @@ enum nvme_feat {
 };
 
 /**
- * enum nvme_get_features_sel -
+ * enum nvme_get_features_sel - Get Features - Select
  * @NVME_GET_FEATURES_SEL_CURRENT:	Current value
  * @NVME_GET_FEATURES_SEL_DEFAULT:	Default value
  * @NVME_GET_FEATURES_SEL_SAVED:	Saved value
@@ -6642,7 +6645,7 @@ enum nvme_cmd_format_ses {
 };
 
 /**
- * enum nvme_ns_mgmt_sel -
+ * enum nvme_ns_mgmt_sel - Namespace Management - Select
  * @NVME_NS_MGMT_SEL_CREATE:	Namespace Create selection
  * @NVME_NS_MGMT_SEL_DELETE:	Namespace Delete selection
  */
@@ -6652,7 +6655,7 @@ enum nvme_ns_mgmt_sel {
 };
 
 /**
- * enum nvme_ns_attach_sel -
+ * enum nvme_ns_attach_sel - Namespace Attachment - Select
  * @NVME_NS_ATTACH_SEL_CTRL_ATTACH:	Namespace attach selection
  * @NVME_NS_ATTACH_SEL_CTRL_DEATTACH:	Namespace detach selection
  */
@@ -6662,7 +6665,7 @@ enum nvme_ns_attach_sel {
 };
 
 /**
- * enum nvme_fw_commit_ca -
+ * enum nvme_fw_commit_ca - Firmware Commit - Commit Action
  * @NVME_FW_COMMIT_CA_REPLACE:				Downloaded image replaces the existing
  * 							image, if any, in the specified Firmware
  * 							Slot. The newly placed image is not
@@ -6697,7 +6700,7 @@ enum nvme_fw_commit_ca {
 };
 
 /**
- * enum nvme_directive_dtype -
+ * enum nvme_directive_dtype - Directive Types
  * @NVME_DIRECTIVE_DTYPE_IDENTIFY:	Identify directive type
  * @NVME_DIRECTIVE_DTYPE_STREAMS:	Streams directive type
  */
@@ -6707,7 +6710,7 @@ enum nvme_directive_dtype {
 };
 
 /**
- * enum nvme_directive_receive_doper -
+ * enum nvme_directive_receive_doper - Directive Receive Directive Operation
  * @NVME_DIRECTIVE_RECEIVE_IDENTIFY_DOPER_PARAM:
  * @NVME_DIRECTIVE_RECEIVE_STREAMS_DOPER_PARAM:
  * @NVME_DIRECTIVE_RECEIVE_STREAMS_DOPER_STATUS:
@@ -6721,7 +6724,7 @@ enum nvme_directive_receive_doper {
 };
 
 /**
- * enum nvme_directive_send_doper -
+ * enum nvme_directive_send_doper - Directive Send Directive Operation
  * @NVME_DIRECTIVE_SEND_IDENTIFY_DOPER_ENDIR:
  * @NVME_DIRECTIVE_SEND_STREAMS_DOPER_RELEASE_IDENTIFIER:
  * @NVME_DIRECTIVE_SEND_STREAMS_DOPER_RELEASE_RESOURCE:
@@ -6733,7 +6736,7 @@ enum nvme_directive_send_doper {
 };
 
 /**
- * enum nvme_directive_send_identify_endir -
+ * enum nvme_directive_send_identify_endir - Enable Directive
  * @NVME_DIRECTIVE_SEND_IDENTIFY_ENDIR_DISABLE:
  * @NVME_DIRECTIVE_SEND_IDENTIFY_ENDIR_ENABLE:
  */
@@ -6771,7 +6774,7 @@ enum nvme_dst_stc {
 };
 
 /**
- * enum nvme_virt_mgmt_act -
+ * enum nvme_virt_mgmt_act - Virtualization Management - Action
  * @NVME_VIRT_MGMT_ACT_PRIM_CTRL_FLEX_ALLOC:	Primary Controller Flexible
  * 						Allocation
  * @NVME_VIRT_MGMT_ACT_OFFLINE_SEC_CTRL:	Secondary Controller Offline
@@ -6786,7 +6789,7 @@ enum nvme_virt_mgmt_act {
 };
 
 /**
- * enum nvme_virt_mgmt_rt -
+ * enum nvme_virt_mgmt_rt - Virtualization Management - Resource Type
  * @NVME_VIRT_MGMT_RT_VQ_RESOURCE:	VQ Resources
  * @NVME_VIRT_MGMT_RT_VI_RESOURCE:	VI Resources
  */
@@ -6796,7 +6799,7 @@ enum nvme_virt_mgmt_rt {
 };
 
 /**
- * enum nvme_ns_write_protect_cfg -
+ * enum nvme_ns_write_protect_cfg - Write Protection - Write Protection State
  * @NVME_NS_WP_CFG_NONE:		No Write Protect
  * @NVME_NS_WP_CFG_PROTECT:		Write Protect
  * @NVME_NS_WP_CFG_PROTECT_POWER_CYCLE:	Write Protect Until Power Cycle
@@ -6810,7 +6813,7 @@ enum nvme_ns_write_protect_cfg {
 };
 
 /**
- * enum nvme_log_ana_lsp -
+ * enum nvme_log_ana_lsp - Asymmetric Namespace Access - Return Groups Only
  * @NVME_LOG_ANA_LSP_RGO_NAMESPACES:
  * @NVME_LOG_ANA_LSP_RGO_GROUPS_ONLY:
  */
@@ -6820,7 +6823,7 @@ enum nvme_log_ana_lsp {
 };
 
 /**
- * enum nvme_pevent_log_action -
+ * enum nvme_pevent_log_action - Persistent Event Log - Action
  * @NVME_PEVENT_LOG_READ:		Read Log Data
  * @NVME_PEVENT_LOG_EST_CTX_AND_READ:	Establish Context and Read Log Data
  * @NVME_PEVENT_LOG_RELEASE_CTX:	Release Context
@@ -6832,7 +6835,7 @@ enum nvme_pevent_log_action {
 };
 
 /**
- * enum nvme_feat_tmpthresh_thsel -
+ * enum nvme_feat_tmpthresh_thsel - Temperature Threshold - Threshold Type Select
  * @NVME_FEATURE_TEMPTHRESH_THSEL_OVER:		Over temperature threshold select
  * @NVME_FEATURE_TEMPTHRESH_THSEL_UNDER:	Under temperature threshold select
  */
@@ -6842,7 +6845,7 @@ enum nvme_feat_tmpthresh_thsel {
 };
 
 /**
- * enum nvme_features_async_event_config_flags -
+ * enum nvme_features_async_event_config_flags - Asynchronous Event Configuration configuration flags
  * @NVME_FEATURE_AENCFG_SMART_CRIT_SPARE:
  * @NVME_FEATURE_AENCFG_SMART_CRIT_TEMPERATURE:
  * @NVME_FEATURE_AENCFG_SMART_CRIT_DEGRADED:
@@ -6876,7 +6879,7 @@ enum nvme_features_async_event_config_flags {
 };
 
 /**
- * enum nvme_feat_plm_window_select -
+ * enum nvme_feat_plm_window_select - Predictable Latency Per NVM Set Log
  * @NVME_FEATURE_PLM_DTWIN:	Deterministic Window select
  * @NVME_FEATURE_PLM_NDWIN:	Non-Deterministic Window select
  */
@@ -6886,7 +6889,7 @@ enum nvme_feat_plm_window_select {
 };
 
 /**
- * enum nvme_feat_resv_notify_flags -
+ * enum nvme_feat_resv_notify_flags - Reservation Notification Configuration
  * @NVME_FEAT_RESV_NOTIFY_REGPRE:	Mask Registration Preempted Notification
  * @NVME_FEAT_RESV_NOTIFY_RESREL:	Mask Reservation Released Notification
  * @NVME_FEAT_RESV_NOTIFY_RESPRE:	Mask Reservation Preempted Notification
@@ -6898,7 +6901,7 @@ enum nvme_feat_resv_notify_flags {
 };
 
 /**
- * enum nvme_feat_nswpcfg_state -
+ * enum nvme_feat_nswpcfg_state - Write Protection - Write Protection State
  * @NVME_FEAT_NS_NO_WRITE_PROTECT:		No Write Protect
  * @NVME_FEAT_NS_WRITE_PROTECT:			Write Protect
  * @NVME_FEAT_NS_WRITE_PROTECT_PWR_CYCLE:	Write Protect Until Power Cycle
@@ -6912,7 +6915,7 @@ enum nvme_feat_nswpcfg_state {
 };
 
 /**
- * enum nvme_fctype -
+ * enum nvme_fctype - Fabrics Command Types
  * @nvme_fabrics_type_property_set:	Property set
  * @nvme_fabrics_type_connect:		Connect
  * @nvme_fabrics_type_property_get:	Property Get
@@ -6930,7 +6933,7 @@ enum nvme_fctype {
 };
 
 /**
- * enum nvme_io_opcode -
+ * enum nvme_io_opcode - Opcodes for I/O Commands
  * @nvme_cmd_flush:		Flush
  * @nvme_cmd_write:		Write
  * @nvme_cmd_read:		Read
@@ -6968,7 +6971,7 @@ enum nvme_io_opcode {
 };
 
 /**
- * enum nvme_io_control_flags -
+ * enum nvme_io_control_flags - I/O control flags
  * @NVME_IO_DTYPE_STREAMS:	Directive Type Streams
  * @NVME_IO_STC:		Storage Tag Check
  * @NVME_IO_DEAC:		Deallocate
@@ -6994,7 +6997,7 @@ enum nvme_io_control_flags {
 };
 
 /**
- * enum nvme_io_dsm_flags -
+ * enum nvme_io_dsm_flags -  Dataset Management flags
  * @NVME_IO_DSM_FREQ_UNSPEC:	No frequency information provided
  * @NVME_IO_DSM_FREQ_TYPICAL:	Typical number of reads and writes
  * 				expected for this LBA range
@@ -7035,10 +7038,10 @@ enum nvme_io_dsm_flags {
 };
 
 /**
- * enum nvme_dsm_attributes -
- * @NVME_DSMGMT_IDR:	Attribute – Integral Dataset for Read
- * @NVME_DSMGMT_IDW:	Attribute – Integral Dataset for Write
- * @NVME_DSMGMT_AD:	Attribute – Deallocate
+ * enum nvme_dsm_attributes - Dataset Management attributes
+ * @NVME_DSMGMT_IDR:	Attribute -Integral Dataset for Read
+ * @NVME_DSMGMT_IDW:	Attribute - Integral Dataset for Write
+ * @NVME_DSMGMT_AD:	Attribute - Deallocate
  */
 enum nvme_dsm_attributes {
 	NVME_DSMGMT_IDR			= 1 << 0,
@@ -7047,7 +7050,7 @@ enum nvme_dsm_attributes {
 };
 
 /**
- * enum nvme_resv_rtype -
+ * enum nvme_resv_rtype - Reservation Type Encoding
  * @NVME_RESERVATION_RTYPE_WE:		Write Exclusive Reservation
  * @NVME_RESERVATION_RTYPE_EA:		Exclusive Access Reservation
  * @NVME_RESERVATION_RTYPE_WERO:	Write Exclusive - Registrants Only Reservation
@@ -7065,7 +7068,7 @@ enum nvme_resv_rtype {
 };
 
 /**
- * enum nvme_resv_racqa -
+ * enum nvme_resv_racqa - Reservation Acquire - Reservation Acquire Action
  * @NVME_RESERVATION_RACQA_ACQUIRE:		Acquire
  * @NVME_RESERVATION_RACQA_PREEMPT:		Preempt
  * @NVME_RESERVATION_RACQA_PREEMPT_AND_ABORT:	Preempt and Abort
@@ -7077,7 +7080,7 @@ enum nvme_resv_racqa {
 };
 
 /**
- * enum nvme_resv_rrega -
+ * enum nvme_resv_rrega - Reservation Register - Reservation Register Action
  * @NVME_RESERVATION_RREGA_REGISTER_KEY:	Register Reservation Key
  * @NVME_RESERVATION_RREGA_UNREGISTER_KEY:	Unregister Reservation Key
  * @NVME_RESERVATION_RREGA_REPLACE_KEY:		Replace Reservation Key
@@ -7089,7 +7092,7 @@ enum nvme_resv_rrega {
 };
 
 /**
- * enum nvme_resv_cptpl -
+ * enum nvme_resv_cptpl - Reservation Register - Change Persist Through Power Loss State
  * @NVME_RESERVATION_CPTPL_NO_CHANGE:	No change to PTPL state
  * @NVME_RESERVATION_CPTPL_CLEAR:	Reservations are released and
  * 					registrants are cleared on a power on
@@ -7103,7 +7106,7 @@ enum nvme_resv_cptpl {
 };
 
 /**
- * enum nvme_resv_rrela -
+ * enum nvme_resv_rrela - Reservation Release - Reservation Release Action
  * @NVME_RESERVATION_RRELA_RELEASE:	Release
  * @NVME_RESERVATION_RRELA_CLEAR:	Clear
  */
@@ -7113,7 +7116,7 @@ enum nvme_resv_rrela {
 };
 
 /**
- * enum nvme_zns_send_action -
+ * enum nvme_zns_send_action - Zone Management Send - Zone Send Action
  * @NVME_ZNS_ZSA_CLOSE:		Close Zone
  * @NVME_ZNS_ZSA_FINISH:	Finish Zone
  * @NVME_ZNS_ZSA_OPEN:		Open Zone
@@ -7133,7 +7136,7 @@ enum nvme_zns_send_action {
 };
 
 /**
- * enum nvme_zns_recv_action -
+ * enum nvme_zns_recv_action - Zone Management Receive - Zone Receive Action Specific Features
  * @NVME_ZNS_ZRA_REPORT_ZONES:		Report Zones
  * @NVME_ZNS_ZRA_EXTENDED_REPORT_ZONES:	Extended Report Zones
  */
@@ -7143,7 +7146,7 @@ enum nvme_zns_recv_action {
 };
 
 /**
- * enum nvme_zns_report_options -
+ * enum nvme_zns_report_options - Zone Management Receive - Zone Receive Action Specific Field
  * @NVME_ZNS_ZRAS_REPORT_ALL:		List all zones
  * @NVME_ZNS_ZRAS_REPORT_EMPTY:		List the zones in the ZSE:Empty state
  * @NVME_ZNS_ZRAS_REPORT_IMPL_OPENED:	List the zones in the ZSIO:Implicitly Opened state

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -156,7 +156,7 @@ void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
 int nvme_get_feature_length(int fid, __u32 cdw11, __u32 *len);
 
 /**
- * nvme_get_directive_receive_length() -
+ * nvme_get_directive_receive_length() - Get directive receive length
  * @dtype: Directive type, see &enum nvme_directive_dtype
  * @doper: Directive receive operation, see &enum nvme_directive_receive_doper
  * @len:   On success, set to this directives payload length in bytes.
@@ -559,8 +559,8 @@ struct nvmf_ext_attr *nvmf_exat_ptr_next(struct nvmf_ext_attr *p);
 /**
  * enum nvme_version - Selector for version to be returned by @nvme_get_version
  *
- * NVME_VERSION_PROJECT:	Project release version
- * NVME_VERSION_GIT:		Git reference
+ * @NVME_VERSION_PROJECT:	Project release version
+ * @NVME_VERSION_GIT:		Git reference
  */
 enum nvme_version {
 	NVME_VERSION_PROJECT	= 0,


### PR DESCRIPTION
Add missing documentation bits to all header files except types.h.
This a very rudimentary and surely needs a to be refined later. But
let's first try to get kernel-doc to report 0 warning/errors so we can
actually detect offenders added by new code.

Signed-off-by: Daniel Wagner <dwagner@suse.de>