### PR TITLE
MI: tests and fixes

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -194,20 +194,6 @@ int nvme_mi_admin_identify_partial(nvme_mi_ctrl_t ctrl,
 	return 0;
 }
 
-int nvme_mi_admin_identify_ctrl(nvme_mi_ctrl_t ctrl,
-				struct nvme_id_ctrl *id)
-{
-	struct nvme_identify_args id_args = {
-		.args_size = sizeof(id_args),
-		.data = id,
-		.cns = NVME_IDENTIFY_CNS_CTRL,
-		.nsid = NVME_NSID_NONE,
-		.cntid = ctrl->id,
-	};
-
-	return nvme_mi_admin_identify(ctrl, &id_args);
-}
-
 static int nvme_mi_read_data(nvme_mi_ep_t ep, __u32 cdw0,
 			     void *data, size_t *data_len)
 {

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -163,14 +163,16 @@ int nvme_mi_admin_identify_partial(nvme_mi_ctrl_t ctrl,
 		return -EINVAL;
 
 	nvme_mi_admin_init_req(&req, &req_hdr, ctrl->id, nvme_admin_identify);
-	req_hdr.cdw10 = cpu_to_le16(args->cntid) << 16 | cpu_to_le16(args->cns);
-	req_hdr.cdw11 = cpu_to_le16(args->nsid);
-	req_hdr.cdw14 = args->uuidx & 0xff;
+	req_hdr.cdw1 = cpu_to_le32(args->nsid);
+	req_hdr.cdw10 = cpu_to_le32(args->cntid << 16 | args->cns);
+	req_hdr.cdw11 = cpu_to_le32((args->csi & 0xff) << 24 |
+				    args->cns_specific_id);
+	req_hdr.cdw14 = cpu_to_le32(args->uuidx);
 	req_hdr.dlen = cpu_to_le32(size & 0xffffffff);
 	req_hdr.flags = 0x1;
 	if (offset) {
 		req_hdr.flags |= 0x2;
-		req_hdr.doff = offset;
+		req_hdr.doff = cpu_to_le32(offset);
 	}
 
 	nvme_mi_calc_req_mic(&req);

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -155,15 +155,16 @@ static inline int nvme_mi_admin_identify_cns_nsid(nvme_mi_ctrl_t ctrl,
 	return nvme_mi_admin_identify(ctrl, &args);
 }
 
-static inline int nvme_mi_identify_ctrl(nvme_mi_ctrl_t ctrl,
-					struct nvme_id_ctrl *id)
+static inline int nvme_mi_admin_identify_ctrl(nvme_mi_ctrl_t ctrl,
+					      struct nvme_id_ctrl *id)
 {
 	return nvme_mi_admin_identify_cns_nsid(ctrl, NVME_IDENTIFY_CNS_CTRL,
 					       NVME_NSID_NONE, id);
 }
 
-static inline int nvme_mi_identify_ctrl_list(nvme_mi_ctrl_t ctrl, __u16 cntid,
-					     struct nvme_ctrl_list *list)
+static inline int nvme_mi_admin_identify_ctrl_list(nvme_mi_ctrl_t ctrl,
+						   __u16 cntid,
+						   struct nvme_ctrl_list *list)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,

--- a/test/mi.c
+++ b/test/mi.c
@@ -193,6 +193,73 @@ static void test_invalid_crc(nvme_mi_ep_t ep)
 	assert(rc != 0);
 }
 
+/* test: simple NVMe admin request/response */
+static int test_admin_id_cb(struct nvme_mi_ep *ep,
+				  struct nvme_mi_req *req,
+				  struct nvme_mi_resp *resp,
+				  void *data)
+{
+	__u8 ror, mt, *hdr;
+	__u32 dlen, cdw10;
+	__u16 ctrl_id;
+	__u8 flags;
+
+	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+
+	ror = req->hdr->nmp >> 7;
+	mt = req->hdr->nmp >> 3 & 0x7;
+	assert(ror == NVME_MI_ROR_REQ);
+	assert(mt == NVME_MI_MT_ADMIN);
+
+	/* do we have enough for a mi header? */
+	assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
+
+	/* inspect response as raw bytes */
+	hdr = (__u8 *)req->hdr;
+	assert(hdr[4] == nvme_admin_identify);
+	flags = hdr[5];
+
+	ctrl_id = hdr[7] << 8 | hdr[6];
+	assert(ctrl_id == 0x5); /* controller id */
+
+	/* we requested a full id; if we've set the length flag,
+	 * ensure the length matches */
+	dlen = hdr[35] << 24 | hdr[34] << 16 | hdr[33] << 8 | hdr[32];
+	if (flags & 0x1) {
+		assert(dlen == sizeof(struct nvme_id_ctrl));
+	}
+	assert(!(flags & 0x2));
+
+	/* CNS value of 1 in cdw10 field */
+	cdw10 = hdr[47] << 24 | hdr[46] << 16 | hdr[45] << 8 | hdr[44];
+	assert(cdw10 == 0x1);
+
+	/* create valid (but somewhat empty) response */
+	hdr = (__u8 *)resp->hdr;
+	memset(resp->hdr, 0, resp->hdr_len);
+	memset(resp->data, 0, resp->data_len);
+	hdr[4] = 0x00; /* status: success */
+
+	test_transport_resp_calc_mic(resp);
+
+	return 0;
+}
+
+static void test_admin_id(nvme_mi_ep_t ep)
+{
+	struct nvme_id_ctrl id;
+	nvme_mi_ctrl_t ctrl;
+	int rc;
+
+	test_set_transport_callback(ep, test_admin_id_cb, NULL);
+
+	ctrl = nvme_mi_init_ctrl(ep, 5);
+	assert(ctrl);
+
+	rc = nvme_mi_admin_identify_ctrl(ctrl, &id);
+	assert(rc == 0);
+}
+
 #define DEFINE_TEST(name) { #name, test_ ## name }
 struct test {
 	const char *name;
@@ -201,6 +268,7 @@ struct test {
 	DEFINE_TEST(read_mi_data),
 	DEFINE_TEST(transport_fail),
 	DEFINE_TEST(invalid_crc),
+	DEFINE_TEST(admin_id),
 };
 
 static void print_log_buf(FILE *logfd)


### PR DESCRIPTION
This series adds a couple of tests for the initial Admin command infrastructure, and a fix for how we serialise some of the lesser-used identify fields, particularly on big-endian platforms. We also have a cleanup to unify the admin function naming scheme.

As always, please let me know if you have any comments/queries.