### PR TITLE
MI: Add endpoint iterators, and allow scanning from MCTP endpoints on dbus

### DIFF
--- a/doc/mi.rst
+++ b/doc/mi.rst
@@ -27,3 +27,17 @@ each have a unique ``unsigned int`` as their ID.
 
 The default Network ID is 1; unless you have configured otherwise, MCTP
 endpoints will appear on this network.
+
+If compiled with D-Bus support, ``libnvme-mi`` can query the system MCTP daemon
+("``mctpd``") to find attached NVMe devices, via the ``nvme_mi_scan_mctp()``
+function. Calling this will establish a ``nvme_root_t`` object, populated
+with the results of that scan. Use the ``nvme_mi_for_each_endpoint`` macro
+to iterate through the scanned endpoints.
+
+Note that the MCTP daemon is provided separately, as part of the MCTP userspace
+tools, at https://github.com/CodeConstruct/mctp . ``mctpd`` is responsible for
+discovery and enumeration for MCTP endpoints on the system, and will query
+each for its protocol capabilities during enumeration. Consequently, NVMe-MI
+endpoints will need to report support for NVMe-MI-over-MCTP (protocol 0x4) in
+their supported protocols list (ie., as returned by the MCTP Get Message Type
+Support command) in order to be discovered.

--- a/doc/mi.rst.in
+++ b/doc/mi.rst.in
@@ -27,3 +27,17 @@ each have a unique ``unsigned int`` as their ID.
 
 The default Network ID is 1; unless you have configured otherwise, MCTP
 endpoints will appear on this network.
+
+If compiled with D-Bus support, ``libnvme-mi`` can query the system MCTP daemon
+("``mctpd``") to find attached NVMe devices, via the ``nvme_mi_scan_mctp()``
+function. Calling this will establish a ``nvme_root_t`` object, populated
+with the results of that scan. Use the ``nvme_mi_for_each_endpoint`` macro
+to iterate through the scanned endpoints.
+
+Note that the MCTP daemon is provided separately, as part of the MCTP userspace
+tools, at https://github.com/CodeConstruct/mctp . ``mctpd`` is responsible for
+discovery and enumeration for MCTP endpoints on the system, and will query
+each for its protocol capabilities during enumeration. Consequently, NVMe-MI
+endpoints will need to report support for NVMe-MI-over-MCTP (protocol 0x4) in
+their supported protocols list (ie., as returned by the MCTP Get Message Type
+Support command) in order to be discovered.

--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,10 @@ if openssl_dep.found()
            description: 'OpenSSL version 3.x')
 endif
 
+# Check for libsystemd availability. Optional, only required for MCTP dbus scan
+libsystemd_dep = dependency('libsystemd', required: false)
+conf.set('CONFIG_LIBSYSTEMD', libsystemd_dep.found(), description: 'Is libsystemd available?')
+
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(
     'HAVE_BUILTIN_TYPES_COMPATIBLE_P',

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -20,6 +20,7 @@ LIBNVME_MI_1_1 {
 		nvme_mi_first_endpoint;
 		nvme_mi_next_endpoint;
 		nvme_mi_open_mctp;
+		nvme_mi_scan_mctp;
 	local:
 		*;
 };

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -15,6 +15,7 @@ LIBNVME_MI_1_1 {
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;
+		nvme_mi_endpoint_desc;
 		nvme_mi_open_mctp;
 	local:
 		*;

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -16,6 +16,9 @@ LIBNVME_MI_1_1 {
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;
 		nvme_mi_endpoint_desc;
+		nvme_mi_root_close;
+		nvme_mi_first_endpoint;
+		nvme_mi_next_endpoint;
 		nvme_mi_open_mctp;
 	local:
 		*;

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,6 +35,7 @@ deps = [
 
 mi_deps = [
     libuuid_dep,
+    libsystemd_dep,
 ]
 
 source_dir = meson.current_source_dir()

--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -194,11 +194,26 @@ static void nvme_mi_mctp_close(struct nvme_mi_ep *ep)
 	free(ep->transport_data);
 }
 
+static int nvme_mi_mctp_desc_ep(struct nvme_mi_ep *ep, char *buf, size_t len)
+{
+	struct nvme_mi_transport_mctp *mctp;
+
+	if (ep->transport != &nvme_mi_transport_mctp)
+		return -1;
+
+	mctp = ep->transport_data;
+
+	snprintf(buf, len, "net %d eid %d", mctp->net, mctp->eid);
+
+	return 0;
+}
+
 static const struct nvme_mi_transport nvme_mi_transport_mctp = {
 	.name = "mctp",
 	.mic_enabled = true,
 	.submit = nvme_mi_mctp_submit,
 	.close = nvme_mi_mctp_close,
+	.desc_ep = nvme_mi_mctp_desc_ep,
 };
 
 nvme_mi_ep_t nvme_mi_open_mctp(nvme_root_t root, unsigned int netid, __u8 eid)

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -39,6 +39,11 @@ nvme_root_t nvme_mi_create_root(FILE *fp, int log_level)
 
 void nvme_mi_free_root(nvme_root_t root)
 {
+	nvme_mi_ep_t ep, tmp;
+
+	nvme_mi_for_each_endpoint_safe(root, ep, tmp)
+		nvme_mi_close(ep);
+
 	free(root);
 }
 
@@ -49,6 +54,8 @@ struct nvme_mi_ep *nvme_mi_init_ep(nvme_root_t root)
 	ep = calloc(1, sizeof(*ep));
 	list_node_init(&ep->root_entry);
 	ep->root = root;
+
+	list_add(&root->endpoints, &ep->root_entry);
 
 	return ep;
 }

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -285,6 +285,38 @@ struct nvme_mi_ep;
  */
 typedef struct nvme_mi_ep * nvme_mi_ep_t;
 
+/**
+ * nvme_mi_first_endpoint - Start endpoint iterator
+ * @m: &nvme_root_t object
+ *
+ * Return: first MI endpoint object under this root, or NULL if no endpoints
+ *         are present.
+ *
+ * See: &nvme_mi_next_endpoint, &nvme_mi_for_each_endpoint
+ */
+nvme_mi_ep_t nvme_mi_first_endpoint(nvme_root_t m);
+
+/**
+ * nvme_mi_next_endpoint - Continue endpoint iterator
+ * @m: &nvme_root_t object
+ * @e: &nvme_mi_ep_t current position of iterator
+ *
+ * Return: next endpoint MI endpoint object after @e under this root, or NULL
+ *         if no further endpoints are present.
+ *
+ * See: &nvme_mi_first_endpoint, &nvme_mi_for_each_endpoint
+ */
+nvme_mi_ep_t nvme_mi_next_endpoint(nvme_root_t m, nvme_mi_ep_t e);
+
+/**
+ * nvme_mi_for_each_endpoint - Iterator for NVMe-MI endpoints.
+ * @m: &nvme_root_t containing endpoints
+ * @e: &nvme_mi_ep_t object, set on each iteration
+ */
+#define nvme_mi_for_each_endpoint(m, e)			\
+	for (e = nvme_mi_first_endpoint(m); e != NULL;	\
+	     e = nvme_mi_next_endpoint(m, e))
+
 struct nvme_mi_ctrl;
 
 /**

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -337,6 +337,19 @@ nvme_mi_ctrl_t nvme_mi_init_ctrl(nvme_mi_ep_t ep, __u16 ctrl_id);
  */
 void nvme_mi_close_ctrl(nvme_mi_ctrl_t ctrl);
 
+/**
+ * nvme_mi_endpoint_desc - Get a string describing a MI endpoint.
+ * @ep: endpoint to describe
+ *
+ * Generates a human-readable string describing the endpoint, with possibly
+ * transport-specific data. The string is allocated during the call, and the
+ * caller is responsible for free()-ing the string.
+ *
+ * Return: a newly-allocated string containing the endpoint description, or
+ *         NULL on failure.
+ */
+char *nvme_mi_endpoint_desc(nvme_mi_ep_t ep);
+
 /* MI Command API: nvme_mi_mi_ prefix */
 
 /**

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -317,6 +317,18 @@ nvme_mi_ep_t nvme_mi_next_endpoint(nvme_root_t m, nvme_mi_ep_t e);
 	for (e = nvme_mi_first_endpoint(m); e != NULL;	\
 	     e = nvme_mi_next_endpoint(m, e))
 
+/**
+ * nvme_mi_for_each_endpoint_safe - Iterator for NVMe-MI endpoints, allowing
+ * deletion during traversal
+ * @m: &nvme_root_t containing endpoints
+ * @e: &nvme_mi_ep_t object, set on each iteration
+ * @_e: &nvme_mi_ep_t object used as temporary storage
+ */
+#define nvme_mi_for_each_endpoint_safe(m, e, _e)			      \
+	for (e = nvme_mi_first_endpoint(m), _e = nvme_mi_next_endpoint(m, e); \
+	     e != NULL;							      \
+	     e = _e, _e = nvme_mi_next_endpoint(m, e))
+
 struct nvme_mi_ctrl;
 
 /**

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -361,6 +361,20 @@ nvme_mi_ep_t nvme_mi_open_mctp(nvme_root_t root, unsigned int netid, uint8_t eid
 void nvme_mi_close(nvme_mi_ep_t ep);
 
 /**
+ * nvme_mi_scan_mctp - look for MCTP-connected NVMe-MI endpoints.
+ *
+ * This function queries the system mctp daemon ("mctpd") over dbus, to find
+ * MCTP endpoints that report support for NVMe-MI over MCTP.
+ *
+ * This requires libvnme-mi to be compiled with D-Bus support; if not, this
+ * will return NULL.
+ *
+ * Return: A @nvme_root_t populated with a set of MCTP-connected endpoints,
+ *         or NULL on failure
+ */
+nvme_root_t nvme_mi_scan_mctp(void);
+
+/**
  * nvme_mi_init_ctrl() - initialise a NVMe controller.
  * @ep: Endpoint to create under
  * @ctrl_id: ID of controller to initialise.

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -118,6 +118,7 @@ struct nvme_host {
 struct nvme_root {
 	char *config_file;
 	struct list_head hosts;
+	struct list_head endpoints; /* MI endpoints */
 	FILE *fp;
 	int log_level;
 	bool log_pid;
@@ -187,6 +188,7 @@ struct nvme_mi_ep {
 	struct nvme_root *root;
 	const struct nvme_mi_transport *transport;
 	void *transport_data;
+	struct list_node root_entry;
 };
 
 struct nvme_mi_ctrl {

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -180,6 +180,7 @@ struct nvme_mi_transport {
 		      struct nvme_mi_req *req,
 		      struct nvme_mi_resp *resp);
 	void (*close)(struct nvme_mi_ep *ep);
+	int (*desc_ep)(struct nvme_mi_ep *ep, char *buf, size_t len);
 };
 
 struct nvme_mi_ep {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -141,6 +141,7 @@ nvme_root_t nvme_create_root(FILE *fp, int log_level)
 	if (fp)
 		r->fp = fp;
 	list_head_init(&r->hosts);
+	list_head_init(&r->endpoints);
 	return r;
 }
 


### PR DESCRIPTION
The MCTP userspace infrastructure provides the set of discovered endpoints over dbus. This series adds a facility to query that list for endpoints that report support for the NVMe-MI protocol, and add them to the `nvme_root_t`.

With that information, we can add iterators to traverse the results of the scan.

This dbus mechanism is conditional on the low-level sdbus interface library, provided by libsystemd, and is enabled/disabled at `meson setup`.

As always, comments, queries, etc. are most welcome.