### PR TITLE
test: Remove code dependency for mi test

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -39,17 +39,9 @@ zns = executable(
     include_directories: [incdir, internal_incdir]
 )
 
-# The management interface tests don't require hardware, we have a small
-# test-mi endpoint instead.
-mi_sources = [
-    '../src/nvme/mi.c',
-    '../src/nvme/log.c',
-    '../src/nvme/cleanup.c',
-]
-
 mi = executable(
     'test-mi',
-    ['mi.c'] + mi_sources,
+    ['mi.c'],
     dependencies: libnvme_mi_dep,
     include_directories: [incdir, internal_incdir]
 )


### PR DESCRIPTION
When generating th coverage report, lcov chokes on the '../src/nvme'
paths prefix:

  geninfo: WARNING: GCOV did not produce any data for /home/wagi/work/libnvme-upstream/obj/src/test-mi.p/.._test_mi.c.gcda

We could restructure the project layout, e.g. by moving the test/mi.c
file to the src/nvme direcotry. But that looks ugly and as it turns
out we only really need one function copied over
nvme_mi_crc32_update() to resolve the dependency. The other function
is nvme_mi_init_ep() which we can easily open code.

Obviously, it would be better to fix the path issue for lcov but for
the time being let's go with this.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #393 