### PR TITLE
MI: reinstate nvme_mi_init_ep for endpoint initialisation in test

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -19,3 +19,11 @@ LIBNVME_MI_1_1 {
 	local:
 		*;
 };
+# API exported only for libnvme-mi internal test functions. These should
+# not be used other than through the in-tree tests, and cannot be considered
+# at all stable.
+LIBNVME_MI_TEST {
+	global:
+		nvme_mi_init_ep;
+		nvme_mi_crc32_update;
+};

--- a/test/mi.c
+++ b/test/mi.c
@@ -30,18 +30,6 @@ struct test_transport_data {
 
 static const int test_transport_magic = 0x74657374;
 
-static __u32 crc32_update(__u32 crc, void *data, size_t len)
-{
-	int i;
-
-	while (len--) {
-		crc ^= *(unsigned char *)(data++);
-		for (i = 0; i < 8; i++)
-			crc = (crc >> 1) ^ ((crc & 1) ? 0x82F63B78 : 0);
-	}
-	return crc;
-}
-
 static int test_transport_submit(struct nvme_mi_ep *ep,
 				 struct nvme_mi_req *req,
 				 struct nvme_mi_resp *resp)
@@ -70,11 +58,11 @@ static void test_transport_close(struct nvme_mi_ep *ep)
 /* internal test helper to generate correct response crc */
 static void test_transport_resp_calc_mic(struct nvme_mi_resp *resp)
 {
-	extern __u32 crc32_update(__u32 crc, void *data, size_t len);
+	extern __u32 nvme_mi_crc32_update(__u32 crc, void *data, size_t len);
 	__u32 crc = 0xffffffff;
 
-	crc = crc32_update(crc, resp->hdr, resp->hdr_len);
-	crc = crc32_update(crc, resp->data, resp->data_len);
+	crc = nvme_mi_crc32_update(crc, resp->hdr, resp->hdr_len);
+	crc = nvme_mi_crc32_update(crc, resp->data, resp->data_len);
 
 	resp->mic = ~crc;
 }
@@ -101,9 +89,8 @@ nvme_mi_ep_t nvme_mi_open_test(nvme_root_t root)
 	struct test_transport_data *tpd;
 	struct nvme_mi_ep *ep;
 
-	ep = malloc(sizeof(*ep));
+	ep = nvme_mi_init_ep(root);
 	assert(ep);
-	ep->root = root;
 
 	tpd = malloc(sizeof(*tpd));
 	assert(tpd);


### PR DESCRIPTION
Ideally, we would be using the actual implementation of
nvme_mi_init_ep() for our tests, rather than open-coding it in the test
init.

This change exports the nvme_mi_init_ep from libnvme-mi.so, but it
remains excluded from the headers, as it's only intended for use in the
transport API. This means we can call it from the tests, but keep is
somewhat-internal.

We put this into a specific _TEST section of the version script, to keep
separate from the public symbols.

This prevents us from diverging the endpoint init process in our
testcases.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>