### PR TITLE
test: define separate library for MI unit tests

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -19,11 +19,3 @@ LIBNVME_MI_1_1 {
 	local:
 		*;
 };
-# API exported only for libnvme-mi internal test functions. These should
-# not be used other than through the in-tree tests, and cannot be considered
-# at all stable.
-LIBNVME_MI_TEST {
-	global:
-		nvme_mi_init_ep;
-		nvme_mi_crc32_update;
-};

--- a/src/meson.build
+++ b/src/meson.build
@@ -93,6 +93,25 @@ libnvme_mi_dep = declare_dependency(
     link_with: libnvme_mi,
 )
 
+# test library with all symbols visible, to use for MI unit tests. Should
+# match libnvme_mi above, but with no version script, and install: false.
+libnvme_mi_test = library(
+    'nvme-mi-test', # produces libnvme-mi-test.so
+    mi_sources,
+    dependencies: mi_deps,
+    include_directories: [incdir, internal_incdir],
+    install: false,
+    link_with: libccan,
+)
+
+libnvme_mi_test_dep = declare_dependency(
+    include_directories: ['.'],
+    dependencies: [
+      libuuid_dep.partial_dependency(compile_args: true, includes: true),
+    ],
+    link_with: libnvme_mi_test,
+)
+
 pkg.generate(libnvme_mi,
     filebase: 'libnvme-mi',
     name: 'libnvme-mi',

--- a/test/meson.build
+++ b/test/meson.build
@@ -42,7 +42,7 @@ zns = executable(
 mi = executable(
     'test-mi',
     ['mi.c'],
-    dependencies: libnvme_mi_dep,
+    dependencies: libnvme_mi_test_dep,
     include_directories: [incdir, internal_incdir]
 )
 


### PR DESCRIPTION
We previously exposed a couple of internal functions for libnvme-mi.so
in ce4a044720. However, Daniel Wagner has suggest instead using a
separate shared library with all symbols visible, just for the unit
test.

This change reverts the symbol visibility changes for the installed
libnvme-mi.so, and defines a separate, non-installed library for the MI
unit tests. This is the same as libnvme-mi.so, but has no linker script
or versioning information.

This means we're not exposing the init_ep and crc32 functions in the
actual .so, but can still allow unit tests to access non-public symbols.
The coverage reports can handle the separate library just fine, as the
coverage data is correlated on the underlying source files.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>