### PR TITLE
MI: install top-level libnvme-mi.h header

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -123,6 +123,7 @@ pkg.generate(libnvme_mi,
 
 mode = ['rw-r--r--', 0, 0]
 install_headers('libnvme.h', install_mode: mode)
+install_headers('libnvme-mi.h', install_mode: mode)
 install_headers([
         'nvme/api-types.h',
         'nvme/fabrics.h',


### PR DESCRIPTION
Now that we have a decent amount of the libnvme-mi definitions fairly
stable, add the top-level libnvme-mi.h header to the installed header
set.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>