### PR TITLE
mi: track controller lifetime under endpoint and provide endpoint scan

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -19,8 +19,11 @@ LIBNVME_MI_1_1 {
 		nvme_mi_root_close;
 		nvme_mi_first_endpoint;
 		nvme_mi_next_endpoint;
+		nvme_mi_first_ctrl;
+		nvme_mi_next_ctrl;
 		nvme_mi_open_mctp;
 		nvme_mi_scan_mctp;
+		nvme_mi_scan_ep;
 	local:
 		*;
 };

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -189,11 +189,14 @@ struct nvme_mi_ep {
 	const struct nvme_mi_transport *transport;
 	void *transport_data;
 	struct list_node root_entry;
+	struct list_head controllers;
+	bool controllers_scanned;
 };
 
 struct nvme_mi_ctrl {
 	struct nvme_mi_ep	*ep;
 	__u16			id;
+	struct list_node	ep_entry;
 };
 
 struct nvme_mi_ep *nvme_mi_init_ep(struct nvme_root *root);


### PR DESCRIPTION
This change introduces a list of controllers under each MI endpoint, and
ties the controller's lifetime to the endpoints - when an endpoint is
free()ed, so are its controllers.

We also provide a new function to populate the controllers list:

    nvme_mi_scan_ep()

\- which scans the endpoint for its owned controllers. For retrieving the
scan results, we now have a new macro:

    nvme_mi_for_each_ctrl(ep, ctrl) {
      ...
    }

Add a couple of new tests: one to check the lifetime semantics, and
another to test the scan using a fake Read MI Data (Controller List)
response.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>