### PR TITLE
meson: libsystemd <= 219 does not support sd-bus, sd-event

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -79,8 +79,8 @@ if openssl_dep.found()
 endif
 
 # Check for libsystemd availability. Optional, only required for MCTP dbus scan
-libsystemd_dep = dependency('libsystemd', required: false)
-conf.set('CONFIG_LIBSYSTEMD', libsystemd_dep.found(), description: 'Is libsystemd available?')
+libsystemd_dep = dependency('libsystemd', version: '>219', required: false)
+conf.set('CONFIG_LIBSYSTEMD', libsystemd_dep.found(), description: 'Is libsystemd(>219) available?')
 
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(

--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -25,6 +25,10 @@
 #include <systemd/sd-event.h>
 #include <systemd/sd-bus.h>
 #include <systemd/sd-id128.h>
+
+#define MCTP_DBUS_PATH "/xyz/openbmc_project/mctp"
+#define MCTP_DBUS_IFACE "xyz.openbmc_project.MCTP"
+#define MCTP_DBUS_IFACE_ENDPOINT "xyz.openbmc_project.MCTP.Endpoint"
 #endif
 
 #include "private.h"
@@ -80,9 +84,6 @@ struct nvme_mi_transport_mctp {
 	int	sd;
 };
 
-#define MCTP_DBUS_PATH "/xyz/openbmc_project/mctp"
-#define MCTP_DBUS_IFACE "xyz.openbmc_project.MCTP"
-#define MCTP_DBUS_IFACE_ENDPOINT "xyz.openbmc_project.MCTP.Endpoint"
 
 static const struct nvme_mi_transport nvme_mi_transport_mctp;
 


### PR DESCRIPTION
build error below
./dist-unpack/libnvme-1.0/src/nvme/mi-mctp.c
../dist-unpack/libnvme-1.0/src/nvme/mi-mctp.c:25:10: fatal error: systemd/sd-event.h: No such file or directory
   25 | #include <systemd/sd-event.h>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
[740/769] Compiling C object src/libnvme.so.1.0.0.p/nvme_tree.c.o

MCTP defined values are used when CONFIG_LIBSYSTEMD is defined