### PR TITLE
rpmbuild: Enable 'make rpm' to build rpm pkgs #408

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ a.out
 *.swp
 *.a
 *.so.*
-
+*.tar.gz
 cscope.*
 
 .build

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,8 @@ test: ${BUILD-DIR}
 	ninja -C ${BUILD-DIR} $@
 
 .PHONY: rpm
-rpm: dist
-	rpmbuild -ba ${BUILD-DIR}/libnvme.spec
+rpm: ${BUILD-DIR}
+	git archive --format=tar HEAD > libnvme.tar
+	tar rf libnvme.tar ${BUILD-DIR}/libnvme.spec
+	gzip -f -9 libnvme.tar
+	rpmbuild -ta libnvme.tar.gz -v

--- a/libnvme.spec.in
+++ b/libnvme.spec.in
@@ -4,13 +4,9 @@ Release: 0
 Summary: Linux-native nvme device management library
 
 License: @LICENSE@
-Source: %{name}-%{version}.tar.gz
+Source: libnvme.tar.gz
 BuildRoot: %{_tmppath}/%{name}-root
 URL: http://github.com/linux-nvme/libnvme
-
-BuildRequires: libuuid-devel
-BuildRequires: meson
-BuildRequires: gcc
 
 %description
 Provides library functions for accessing and managing nvme devices on a Linux
@@ -29,29 +25,29 @@ for Linux-native nvme device maangement.
 %autosetup -c
 
 %build
-%meson
-%meson_build
+meson .build -Ddocs=man -Ddocs-build=true -Ddefault_library=both
 
 %install
-%meson_install
-
-%check
-%meson_test
+cd .build
+meson install --destdir %{buildroot} --skip-subprojects
 
 %files
 %defattr(-,root,root)
-%attr(0755,root,root) %{_libdir}/libnvme.so.*
+%attr(0755,root,root) %{_libdir}/libnvme*
 %doc COPYING
 
 %files devel
 %defattr(-,root,root)
 %attr(-,root,root) %{_includedir}/nvme/
-%attr(0644,root,root) %{_includedir}/libnvme.h
-%attr(0755,root,root) %{_libdir}/libnvme.so
-%attr(0644,root,root) %{_libdir}/libnvme.a
+%attr(0644,root,root) %{_includedir}/libnvme*
+%attr(0755,root,root) %{_libdir}/libnvme*
 %attr(0644,root,root) %{_libdir}/pkgconfig/*
 %attr(0644,root,root) %{_mandir}/man2/*
 
 %changelog
+* Wed Jul 13 2022 Steven Seungcheol Lee <sc108.lee@samsung.com>
+- Enable building rpm
+- meson is needed higher version then what rpm repo offering (use pip install)
+
 * Thu Dec 12 2019 Keith Busch <kbusch@kernel.org> - 0.1
 - Initial version


### PR DESCRIPTION
- Build will be happen in Makefile using meson
- Using meson build directory instead of Source(tar.gz)
- meson is needed higher version then what rpm repo offering (use pip install)
- Enable building static library (default: shared)

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>