### PR TITLE
fabrics: Add No CDC Connectivity to EFLAGS

### DIFF
--- a/libnvme/__init__.py
+++ b/libnvme/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is part of libnvme.
+# Copyright (c) 2022 Dell Inc.
+#
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+
+__version__ = @PROJECT_VERSION@
+__git_version__ = @GIT_VERSION@

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -46,7 +46,7 @@ if have_python_support
     configure_file(
         input:  '__init__.py', 
         output: '__init__.py',
-        copy: true,
+        configuration: conf,
         install_dir: python3.get_install_dir(pure: false, subdir: 'libnvme'),
     )
 

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -269,6 +269,8 @@ static void PyDict_SetItemStringDecRef(PyObject *p, const char *key, PyObject *v
     PyDict_SetItemStringDecRef(entry, "cntlid", val);
     val = PyLong_FromLong(e->asqsz);
     PyDict_SetItemStringDecRef(entry, "asqsz", val);
+    val = PyLong_FromLong(e->eflags);
+    PyDict_SetItemStringDecRef(entry, "eflags", val);
     PyList_SetItem(obj, i, entry); /* steals ref. to entry */
   }
   $result = obj;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -118,8 +118,21 @@ static const char * const eflags_strings[] = {
 	[NVMF_DISC_EFLAGS_NONE]		= "not specified",
 	[NVMF_DISC_EFLAGS_EPCSD]	= "explicit discovery connections",
 	[NVMF_DISC_EFLAGS_DUPRETINFO]	= "duplicate discovery information",
-	[NVMF_DISC_EFLAGS_BOTH]		= "explicit discovery connections, "
+	[NVMF_DISC_EFLAGS_EPCSD |
+	 NVMF_DISC_EFLAGS_DUPRETINFO]	= "explicit discovery connections, "
 					  "duplicate discovery information",
+	[NVMF_DISC_EFLAGS_NCC]		= "no cdc connectivity",
+	[NVMF_DISC_EFLAGS_EPCSD |
+	 NVMF_DISC_EFLAGS_NCC]		= "explicit discovery connections, "
+					  "no cdc connectivity",
+	[NVMF_DISC_EFLAGS_DUPRETINFO |
+	 NVMF_DISC_EFLAGS_NCC]		= "duplicate discovery information, "
+					  "no cdc connectivity",
+	[NVMF_DISC_EFLAGS_EPCSD |
+	 NVMF_DISC_EFLAGS_DUPRETINFO |
+	 NVMF_DISC_EFLAGS_NCC]		= "explicit discovery connections, "
+					  "duplicate discovery information, "
+					  "no cdc connectivity",
 };
 
 const char *nvmf_eflags_str(__u16 eflags)

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4635,15 +4635,24 @@ enum nvme_subsys_type {
  *				 this flag set.
  * @NVMF_DISC_EFLAGS_EPCSD:	 Explicit Persistent Connection Support for Discovery (EPCSD):
  *				 Indicates that Explicit Persistent Connections are
- *				 supported for the Discovery controller.
+ *      			 supported for the Discovery controller.
+ * @NVMF_DISC_EFLAGS_NCC:	 No CDC Connectivity (NCC): If set to
+ *      			 '1', then no DDC that describes this entry
+ *      			 is currently connected to the CDC. If
+ *      			 cleared to '0', then at least one DDC that
+ *      			 describes this entry is currently
+ *      			 connected to the CDC. If the Discovery
+ *      			 controller returning this log page is not
+ *      			 a CDC, then this bit shall be cleared to
+ *      			 '0' and should be ignored by the host.
  * @NVMF_DISC_EFLAGS_BOTH:	 Indicates that both the DUPRETINFO and EPCSD
  *				 features are supported.
  */
 enum nvmf_disc_eflags {
 	NVMF_DISC_EFLAGS_NONE		= 0,
-	NVMF_DISC_EFLAGS_DUPRETINFO	= 1,
-	NVMF_DISC_EFLAGS_EPCSD		= 2,
-	NVMF_DISC_EFLAGS_BOTH		= 3,
+	NVMF_DISC_EFLAGS_DUPRETINFO	= 1 << 0,
+	NVMF_DISC_EFLAGS_EPCSD		= 1 << 1,
+	NVMF_DISC_EFLAGS_NCC		= 1 << 2,
 };
 
 /**


### PR DESCRIPTION
TP8010 adds a new "No Connectivity to CDC (NCC)" field to the Discovery Log Page entry flags (EFLAGS). This pull request adds this new definition to `types.h`. We also add the corresponding strings to `nvmf_eflags_str()`.

At the same time, the Python bindings are extended to report the EFLAGS when a discovery command is invoked. This was previously missing. Also, the libnvme python package has gained two new attributes:
1. \_\_version__
2. \_\_git_version__

Note: It is customary for Python packages to provide a \_\_version__ attribute. The \_\_git_version__ is just a bonus!