### PR TITLE
python: add eflags to discovery log page

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -269,6 +269,8 @@ static void PyDict_SetItemStringDecRef(PyObject *p, const char *key, PyObject *v
     PyDict_SetItemStringDecRef(entry, "cntlid", val);
     val = PyLong_FromLong(e->asqsz);
     PyDict_SetItemStringDecRef(entry, "asqsz", val);
+    val = PyLong_FromLong(e->eflags);
+    PyDict_SetItemStringDecRef(entry, "eflags", val);
     PyList_SetItem(obj, i, entry); /* steals ref. to entry */
   }
   $result = obj;


### PR DESCRIPTION
Python bindings are extended to report the EFLAGS when a discovery
command is issued. This was previously missing.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>