### PR TITLE
python: add __version__ to libnvme python package

### DIFF
--- a/libnvme/__init__.py
+++ b/libnvme/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is part of libnvme.
+# Copyright (c) 2022 Dell Inc.
+#
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+
+__version__ = @PROJECT_VERSION@
+__git_version__ = @GIT_VERSION@

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -46,7 +46,7 @@ if have_python_support
     configure_file(
         input:  '__init__.py', 
         output: '__init__.py',
-        copy: true,
+        configuration: conf,
         install_dir: python3.get_install_dir(pure: false, subdir: 'libnvme'),
     )
 


### PR DESCRIPTION
It is customary for Python packages to provide a __version__ attribute

Signed-off-by: Martin Belanger <martin.belanger@dell.com>