### PR TITLE
ioctl: Fix numd calculation for corner case

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -395,7 +395,7 @@ int nvme_identify(struct nvme_identify_args *args)
 
 int nvme_get_log(struct nvme_get_log_args *args)
 {
-	__u32 numd = (args->len >> 2) - 1;
+	__u32 numd = ((args->len + 4) >> 2) - 1;
 	__u16 numdu = numd >> 16, numdl = numd & 0xffff;
 
 	__u32 cdw10 = NVME_SET(args->lid, LOG_CDW10_LID) |


### PR DESCRIPTION
numd is a 0's based dword value. Thus after dividing the lenght (in
bytes) through 4 we subtract 1. This works for all values in the range
of [3..].

By adding 4 before the division we make sure we always floor on the
next integer. With this, numd get calculated correctly for all len
values in the range [0..].

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #412