### PR TITLE
doc: Use correct variable in configure_file input

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -62,7 +62,7 @@ if want_docs != 'false'
     if want_docs_build
       foreach apif : api_paths
         subst = configure_file(
-            input: file,
+            input: apif,
             output: '@BASENAME@.subst',
             configuration: conf)
         c = run_command(list_man_pages, subst)


### PR DESCRIPTION
In e33cc17 we removed an inner loop on the result of files(), but didn't
update the local variable to suit.

This change uses the correct iterator variable for the configure_file()
invocation.

Reported-by: Daniel Wagner <dwagner@suse.de>
Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>