### PR TITLE
MI: add command timeouts

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -61,6 +61,7 @@ struct nvme_mi_ep *nvme_mi_init_ep(nvme_root_t root)
 	ep->root = root;
 	ep->controllers_scanned = false;
 	ep->timeout = default_timeout;
+	ep->mprt_max = 0;
 	list_head_init(&ep->controllers);
 
 	list_add(&root->endpoints, &ep->root_entry);
@@ -79,6 +80,11 @@ int nvme_mi_ep_set_timeout(nvme_mi_ep_t ep, unsigned int timeout_ms)
 
 	ep->timeout = timeout_ms;
 	return 0;
+}
+
+void nvme_mi_ep_set_mprt_max(nvme_mi_ep_t ep, unsigned int mprt_max_ms)
+{
+	ep->mprt_max = mprt_max_ms;
 }
 
 unsigned int nvme_mi_ep_get_timeout(nvme_mi_ep_t ep)

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -17,6 +17,9 @@
 #include "mi.h"
 #include "private.h"
 
+static const int default_timeout = 1000; /* milliseconds; endpoints may
+					    override */
+
 /* MI-equivalent of nvme_create_root, but avoids clashing symbol names
  * when linking against both libnvme and libnvme-mi.
  */
@@ -57,11 +60,30 @@ struct nvme_mi_ep *nvme_mi_init_ep(nvme_root_t root)
 	list_node_init(&ep->root_entry);
 	ep->root = root;
 	ep->controllers_scanned = false;
+	ep->timeout = default_timeout;
 	list_head_init(&ep->controllers);
 
 	list_add(&root->endpoints, &ep->root_entry);
 
 	return ep;
+}
+
+int nvme_mi_ep_set_timeout(nvme_mi_ep_t ep, unsigned int timeout_ms)
+{
+	if (ep->transport->check_timeout) {
+		int rc;
+		rc = ep->transport->check_timeout(ep, timeout_ms);
+		if (rc)
+			return rc;
+	}
+
+	ep->timeout = timeout_ms;
+	return 0;
+}
+
+unsigned int nvme_mi_ep_get_timeout(nvme_mi_ep_t ep)
+{
+	return ep->timeout;
 }
 
 struct nvme_mi_ctrl *nvme_mi_init_ctrl(nvme_mi_ep_t ep, __u16 ctrl_id)

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -459,6 +459,24 @@ nvme_mi_ep_t nvme_mi_next_endpoint(nvme_root_t m, nvme_mi_ep_t e);
 int nvme_mi_ep_set_timeout(nvme_mi_ep_t ep, unsigned int timeout_ms);
 
 /**
+ * nvme_mi_ep_set_mprt_max - set the maximum wait time for a More Processing
+ * Required response
+ * @ep: MI endpoint object
+ * @mprt_max_ms: Maximum more processing required wait time
+ *
+ * NVMe-MI endpoints may respond to a request with a "More Processing Required"
+ * response; this also includes a hint on the worst-case processing time for
+ * the eventual response data, with a specification-defined maximum of 65.535
+ * seconds.
+ *
+ * This function provides a way to limit the maximum time we're prepared to
+ * wait for the final response. Specify zero in @mprt_max_ms for no limit.
+ * This should be larger than the command/response timeout set in
+ * &nvme_mi_ep_set_timeout().
+ */
+void nvme_mi_ep_set_mprt_max(nvme_mi_ep_t ep, unsigned int mprt_max_ms);
+
+/**
  * nvme_mi_ep_get_timeout - get the current timeout value for NVMe-MI responses
  * @ep: MI endpoint object
  *

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -451,6 +451,21 @@ nvme_mi_ep_t nvme_mi_next_endpoint(nvme_root_t m, nvme_mi_ep_t e);
 	     e != NULL;							      \
 	     e = _e, _e = nvme_mi_next_endpoint(m, e))
 
+/**
+ * nvme_mi_ep_set_timeout - set a timeout for NVMe-MI responses
+ * @ep: MI endpoint object
+ * @timeout_ms: Timeout for MI responses, given in milliseconds
+ */
+int nvme_mi_ep_set_timeout(nvme_mi_ep_t ep, unsigned int timeout_ms);
+
+/**
+ * nvme_mi_ep_get_timeout - get the current timeout value for NVMe-MI responses
+ * @ep: MI endpoint object
+ *
+ * Returns the current timeout value, in milliseconds, for this endpoint.
+ */
+unsigned int nvme_mi_ep_get_timeout(nvme_mi_ep_t ep);
+
 struct nvme_mi_ctrl;
 
 /**

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -183,6 +183,7 @@ struct nvme_mi_transport {
 		      struct nvme_mi_resp *resp);
 	void (*close)(struct nvme_mi_ep *ep);
 	int (*desc_ep)(struct nvme_mi_ep *ep, char *buf, size_t len);
+	int (*check_timeout)(struct nvme_mi_ep *ep, unsigned int timeout);
 };
 
 struct nvme_mi_ep {
@@ -192,6 +193,7 @@ struct nvme_mi_ep {
 	struct list_node root_entry;
 	struct list_head controllers;
 	bool controllers_scanned;
+	unsigned int timeout;
 };
 
 struct nvme_mi_ctrl {

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -194,6 +194,7 @@ struct nvme_mi_ep {
 	struct list_head controllers;
 	bool controllers_scanned;
 	unsigned int timeout;
+	unsigned int mprt_max;
 };
 
 struct nvme_mi_ctrl {

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -10,6 +10,7 @@
 #define _LIBNVME_PRIVATE_H
 
 #include <ccan/list/list.h>
+#include <sys/poll.h>
 #include <sys/socket.h>
 
 #include "fabrics.h"
@@ -216,6 +217,7 @@ struct __mi_mctp_socket_ops {
 	int (*socket)(int, int, int);
 	ssize_t (*sendmsg)(int, const struct msghdr *, int);
 	ssize_t (*recvmsg)(int, struct msghdr *, int);
+	int (*poll)(struct pollfd *, nfds_t, int);
 	int (*ioctl_tag)(int, unsigned long, struct mctp_ioc_tag_ctl *);
 };
 void __nvme_mi_mctp_set_ops(const struct __mi_mctp_socket_ops *newops);


### PR DESCRIPTION
This series implements a facility for endpoint-specific timeouts for the NVMe-MI transports. We add a simple API to get/set timeout values:

```c
/**
 * nvme_mi_ep_set_timeout - set a timeout for NVMe-MI responses
 * @ep: MI endpoint object
 * @timeout_ms: Timeout for MI responses, given in milliseconds
 */
int nvme_mi_ep_set_timeout(nvme_mi_ep_t ep, unsigned int timeout_ms);

/**
 * nvme_mi_ep_set_mprt_max - set the maximum wait time for a More Processing
 * Required response
 * @ep: MI endpoint object
 * @mprt_max_ms: Maximum more processing required wait time
 *
 * NVMe-MI endpoints may respond to a request with a "More Processing Required"
 * response; this also includes a hint on the worst-case processing time for
 * the eventual response data, with a specification-defined maximum of 65.535
 * seconds.
 *
 * This function provides a way to limit the maximum time we're prepared to
 * wait for the final response. Specify zero in @mprt_max_ms for no limit.
 * This should be larger than the command/response timeout set in
 * &nvme_mi_ep_set_timeout().
 */
void nvme_mi_ep_set_mprt_max(nvme_mi_ep_t ep, unsigned int mprt_max_ms);

/**
 * nvme_mi_ep_get_timeout - get the current timeout value for NVMe-MI responses
 * @ep: MI endpoint object
 *
 * Returns the current timeout value, in milliseconds, for this endpoint.
 */
unsigned int nvme_mi_ep_get_timeout(nvme_mi_ep_t ep);
```

\- and implement this for the MCTP transport layer, plus a bunch of tests.

This means that we can recover from device/transport/address errors, instead of potentially blocking forever waiting for a response.