### PR TITLE
Add support for uploading release candidates to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -46,13 +46,21 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Check if it is a release tag
+        id: check-tag
+        run: |
+           if [[ ${{ github.event.ref }} =~ ^refs/tags/v([0-9]+\.[0-9]+)(-rc[0-9]+)?$ ]]; then
+               echo ::set-output name=match::true
+           fi
+      - name: Download artifiact
+        uses: actions/download-artifact@v3
+        if: steps.check-tag.outputs.match == 'true'
         with:
           name: artifact
           path: dist
-
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1.5
+        if: steps.check-tag.outputs.match == 'true'
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,8 @@ project(
     ]
 )
 
-library_version = meson.project_version() + '.0'
+maj_min = meson.project_version().split('-rc')[0]
+library_version =  maj_min + '.0'
 
 ################################################################################
 cc = meson.get_compiler('c')

--- a/release.sh
+++ b/release.sh
@@ -54,16 +54,16 @@ else
     exit 1
 fi
 
-./$doc_dir/update-docs.sh
-git add $doc_dir
-git commit -s -m "Regenerate all documentation" \
-              -m "Regenerate documentation for $VERSION release"
-
 # update meson.build
 sed -i -e "0,/[ \t]version: /s/\([ \t]version: \).*/\1\'$ver\',/" meson.build
 git add meson.build
+git commit -s -m "build: Update version to $VERSION"
 
-git commit -s -m "Release $VERSION"
+# update documentation
+./$doc_dir/update-docs.sh
+git add $doc_dir
+git commit -s -m "doc: Regenerate all docs for $VERSION"
+
 git tag -s -m "Release $VERSION" "$VERSION"
 git push --dry-run origin "$VERSION"^{}:master tag "$VERSION"
 

--- a/release.sh
+++ b/release.sh
@@ -9,10 +9,8 @@ usage() {
     echo "      '^v[\d]+.[\d]+(-rc[0-9]+)?$'"
     echo ""
     echo "example:"
-    echo "  release.sh v2.1-rc0     # v2.1 release candidate 0 -> sets the project "
-    echo "                          # version to '1.1' and sets the tag"
-    echo "  release.sh v2.1-rc1     # v2.1 release canditate 1 -> only sets the tag"
-    echo "  release.sh v2.1         # v2.1 release -> sets the final tag"
+    echo "  release.sh v2.1-rc0     # v2.1 release candidate 0"
+    echo "  release.sh v2.1         # v2.1 release"
 }
 
 VERSION=$1
@@ -22,14 +20,12 @@ if [ -z "$VERSION" ] ; then
     exit 1
 fi
 
-new_ver=""
-rc=""
+ver=""
 
 re='^v([0-9]+\.[0-9]+)(-rc[0-9]+)?$'
 if [[ "$VERSION" =~ $re ]]; then
     echo "Valid version $VERSION string"
-    new_ver=${BASH_REMATCH[1]}
-    rc=${BASH_REMATCH[2]}
+    ver=${BASH_REMATCH[1]}${BASH_REMATCH[2]}
 else
     echo "Invalid version string $VERSION"
     echo ""
@@ -64,14 +60,8 @@ git commit -s -m "Regenerate all documentation" \
               -m "Regenerate documentation for $VERSION release"
 
 # update meson.build
-old_ver=$(sed -n "0,/[ \t]\+version: /s/[ \t]\+version: '\([0-9]\+.[0-9]\+\)',$/\1/p" meson.build)
-if [ "$old_ver" != "$new_ver" ]; then
-    # Only update project version once, that is either
-    # - for the first RC phase or
-    # - for the release when there was no RC
-    sed -i -e "0,/[ \t]version: /s/\([ \t]version: \).*/\1\'$new_ver\',/" meson.build
-    git add meson.build
-fi
+sed -i -e "0,/[ \t]version: /s/\([ \t]version: \).*/\1\'$ver\',/" meson.build
+git add meson.build
 
 git commit -s -m "Release $VERSION"
 git tag -s -m "Release $VERSION" "$VERSION"


### PR DESCRIPTION
This changes slightly how releases are done. It's possible now to have the `-rc[0-9]+` suffix added to the project version. 

Fixes #429