### PR TITLE
Fix build against LibreSSL

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -68,14 +68,16 @@ openssl_dep = dependency('openssl',
                          required: get_option('openssl'),
                          fallback : ['openssl', 'libssl_dep'])
 if openssl_dep.found()
+  api_v3 = openssl_dep.version().version_compare('>=3.0.0') and not (
+    # LibreSSL v3.x with incomplete OpenSSL v3 APIs
+    cc.has_header_symbol('openssl/opensslv.h',
+                         'LIBRESSL_VERSION_NUMBER',
+                         dependencies: openssl_dep) and
+    not cc.has_header('openssl/core_names.h', dependencies: openssl_dep))
+  api_v1 = not api_v3 and openssl_dep.version().version_compare('>=1.1.0')
   conf.set('CONFIG_OPENSSL', true, description: 'Is OpenSSL available?')
-  conf.set('CONFIG_OPENSSL_1',
-           openssl_dep.version().version_compare('<2.0.0') and
-           openssl_dep.version().version_compare('>=1.1.0'),
-           description: 'OpenSSL version 1.x')
-  conf.set('CONFIG_OPENSSL_3',
-           openssl_dep.version().version_compare('>=3.0.0'),
-           description: 'OpenSSL version 3.x')
+  conf.set('CONFIG_OPENSSL_1', api_v1, description: 'OpenSSL version 1.x')
+  conf.set('CONFIG_OPENSSL_3', api_v3, description: 'OpenSSL version 3.x')
 endif
 
 # Check for libsystemd availability. Optional, only required for MCTP dbus scan


### PR DESCRIPTION
Check the 3.x API for completeness, in case LibreSSL > 3.5.3 implements
the missing bits.

Signed-off-by: Ismael Luceno <ismael@iodev.co.uk>