### PR TITLE
mi: unify MI Get Log Page function with ioctl API

### DIFF
--- a/examples/mi-mctp.c
+++ b/examples/mi-mctp.c
@@ -311,7 +311,7 @@ int do_get_log_page(nvme_mi_ep_t ep, int argc, char **argv)
 		return -1;
 	}
 
-	rc = nvme_mi_admin_get_log_page(ctrl, &args);
+	rc = nvme_mi_admin_get_log(ctrl, &args);
 	if (rc) {
 		warn("can't perform Get Log page command");
 		return -1;

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -13,7 +13,7 @@ LIBNVME_MI_1_1 {
 		nvme_mi_mi_read_mi_data_ctrl;
 		nvme_mi_mi_subsystem_health_status_poll;
 		nvme_mi_admin_identify_partial;
-		nvme_mi_admin_get_log_page;
+		nvme_mi_admin_get_log;
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -432,9 +432,9 @@ int nvme_mi_admin_identify_partial(nvme_mi_ctrl_t ctrl,
 
 /* retrieves a MCTP-messsage-sized chunk of log page data. offset and len are
  * specified within the args->data area */
-static int __nvme_mi_admin_get_log_page(nvme_mi_ctrl_t ctrl,
-					const struct nvme_get_log_args *args,
-					off_t offset, size_t *lenp, bool final)
+static int __nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl,
+				   const struct nvme_get_log_args *args,
+				   off_t offset, size_t *lenp, bool final)
 {
 	struct nvme_mi_admin_resp_hdr resp_hdr;
 	struct nvme_mi_admin_req_hdr req_hdr;
@@ -497,8 +497,7 @@ static int __nvme_mi_admin_get_log_page(nvme_mi_ctrl_t ctrl,
 	return 0;
 }
 
-int nvme_mi_admin_get_log_page(nvme_mi_ctrl_t ctrl,
-			       struct nvme_get_log_args *args)
+int nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl, struct nvme_get_log_args *args)
 {
 	const size_t xfer_size = 4096;
 	off_t xfer_offset;
@@ -520,8 +519,8 @@ int nvme_mi_admin_get_log_page(nvme_mi_ctrl_t ctrl,
 
 		final = xfer_offset + cur_xfer_size >= args->len;
 
-		rc = __nvme_mi_admin_get_log_page(ctrl, args, xfer_offset,
-						  &tmp, final);
+		rc = __nvme_mi_admin_get_log(ctrl, args, xfer_offset,
+					     &tmp, final);
 		if (rc)
 			break;
 

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1079,7 +1079,7 @@ static inline int nvme_mi_admin_identify_ctrl_list(nvme_mi_ctrl_t ctrl,
 }
 
 /**
- * nvme_mi_admin_get_log_page() - Retrieve log page data from controller
+ * nvme_mi_admin_get_log() - Retrieve log page data from controller
  * @ctrl: Controller to query
  * @args: Get Log Page command arguments
  *
@@ -1095,8 +1095,7 @@ static inline int nvme_mi_admin_identify_ctrl_list(nvme_mi_ctrl_t ctrl,
  *
  * See: &struct nvme_get_log_args
  */
-int nvme_mi_admin_get_log_page(nvme_mi_ctrl_t ctrl,
-			       struct nvme_get_log_args *args);
+int nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl, struct nvme_get_log_args *args);
 
 /**
  * nvme_mi_admin_security_send() - Perform a Security Send command on a


### PR DESCRIPTION
In the MI interface, we currently have:
```c
  nvme_mi_admin_get_log_page(...)
```
However, the ioctl-backed API equivalent doesn't use the `_page`:
```c
  nvme_get_log(...)
```
This change makes the MI version consistent, where we have the
equivalent names, just with the `mi_<type>` prefix:
```c
   nvme_mi_admin_get_log(...)
```
Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>