### PR TITLE
ioctl: Honor rae in nvme_get_nsid_log

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1244,7 +1244,7 @@ static inline int nvme_get_nsid_log(int fd, bool rae,
 		.lsi = NVME_LOG_LSI_NONE,
 		.lsp = NVME_LOG_LSP_NONE,
 		.uuidx = NVME_UUID_NONE,
-		.rae = false,
+		.rae = rae,
 		.ot = false,
 	};
 


### PR DESCRIPTION
The nvme_get_nsid_log() helper has a rae (Retain Asynchronous Events)
parameter, but we currently ignore this when constructing the Get Log
Page command arguments.

This is a behavior change and not an API change. But the good thing is
only for newly build binaries because all helpers are static inline
fuctions.

Reported-by: Reported-by: Jeremy Kerr <jk@codeconstruct.com.au>
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #437 

BTW, I've decided against updating `test/test.c`, as I am not sure if this
was intended setting or just set without a lot of thinking.