### PR TITLE
build: Drop -nostdinc for LibreSSL header checks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -81,11 +81,9 @@ if openssl_dep.found()
     # Test for LibreSSL v3.x with incomplete OpenSSL v3 APIs
     is_libressl = cc.has_header_symbol('openssl/opensslv.h',
                                        'LIBRESSL_VERSION_NUMBER',
-                                       dependencies: openssl_dep,
-                                       args: '-nostdinc')
+                                       dependencies: openssl_dep)
     has_header = cc.has_header('openssl/core_names.h',
-                               dependencies: openssl_dep,
-                               args: '-nostdinc')
+                               dependencies: openssl_dep)
     if is_libressl and not has_header
       api_version = 1
     endif


### PR DESCRIPTION
-nostdinc is only necessary when the LibreSSL is not the default SSL
library on the system and OpenSSL header files are present in the
default include paths.

Though if LibreSSL found in standard paths 'pkg-config --cflags' will
include the standard include paths and hence the header files are not
found.

So -nostdinc is only useful for mixed installations which is very
unlikely a very common setup. So let's just drop the -nostdinc and if
the need is to support such setups, we can still try to figure out
how to support this.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See also discussions in #439 