### PR TITLE
libnvme: Change nlbs type to __u32 in copy command

### DIFF
--- a/doc/rst/util.rst
+++ b/doc/rst/util.rst
@@ -168,7 +168,7 @@ The nvme command status if a response was received or -errno
 otherwise.
 
 
-.. c:function:: void nvme_init_copy_range (struct nvme_copy_range *copy, __u16 *nlbs, __u64 *slbas, __u32 *eilbrts, __u32 *elbatms, __u32 *elbats, __u16 nr)
+.. c:function:: void nvme_init_copy_range (struct nvme_copy_range *copy, __u32 *nlbs, __u64 *slbas, __u32 *eilbrts, __u32 *elbatms, __u32 *elbats, __u16 nr)
 
    Constructs a copy range structure
 
@@ -177,7 +177,7 @@ otherwise.
 ``struct nvme_copy_range *copy``
   Copy range array
 
-``__u16 *nlbs``
+``__u32 *nlbs``
   Number of logical blocks
 
 ``__u64 *slbas``
@@ -196,7 +196,7 @@ otherwise.
   Number of descriptors to construct
 
 
-.. c:function:: void nvme_init_copy_range_f1 (struct nvme_copy_range_f1 *copy, __u16 *nlbs, __u64 *slbas, __u64 *eilbrts, __u32 *elbatms, __u32 *elbats, __u16 nr)
+.. c:function:: void nvme_init_copy_range_f1 (struct nvme_copy_range_f1 *copy, __u32 *nlbs, __u64 *slbas, __u64 *eilbrts, __u32 *elbatms, __u32 *elbats, __u16 nr)
 
    Constructs a copy range f1 structure
 
@@ -205,7 +205,7 @@ otherwise.
 ``struct nvme_copy_range_f1 *copy``
   Copy range array
 
-``__u16 *nlbs``
+``__u32 *nlbs``
   Number of logical blocks
 
 ``__u64 *slbas``

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -377,7 +377,7 @@ const char *nvme_status_to_string(int status, bool fabrics)
 	return s;
 }
 
-void nvme_init_copy_range(struct nvme_copy_range *copy, __u16 *nlbs,
+void nvme_init_copy_range(struct nvme_copy_range *copy, __u32 *nlbs,
 			  __u64 *slbas, __u32 *eilbrts, __u32 *elbatms,
 			  __u32 *elbats, __u16 nr)
 {
@@ -392,7 +392,7 @@ void nvme_init_copy_range(struct nvme_copy_range *copy, __u16 *nlbs,
 	}
 }
 
-void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
+void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u32 *nlbs,
 			  __u64 *slbas, __u64 *eilbrts, __u32 *elbatms,
 			  __u32 *elbats, __u16 nr)
 {

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -124,7 +124,7 @@ void nvme_init_dsm_range(struct nvme_dsm_range *dsm, __u32 *ctx_attrs,
  * @elbats:	Expected logical block application tag
  * @nr:		Number of descriptors to construct
  */
-void nvme_init_copy_range(struct nvme_copy_range *copy, __u16 *nlbs,
+void nvme_init_copy_range(struct nvme_copy_range *copy, __u32 *nlbs,
 			  __u64 *slbas, __u32 *eilbrts, __u32 *elbatms,
 			  __u32 *elbats, __u16 nr);
 
@@ -138,7 +138,7 @@ void nvme_init_copy_range(struct nvme_copy_range *copy, __u16 *nlbs,
  * @elbats:	Expected logical block application tag
  * @nr:		Number of descriptors to construct
  */
-void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
+void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u32 *nlbs,
 			     __u64 *slbas, __u64 *eilbrts, __u32 *elbatms,
 			     __u32 *elbats, __u16 nr);
 


### PR DESCRIPTION
In copy command, nlbs is declared as __u16. While parsing command line argument,
it is typecast to integer pointer. So nlbs[1], nlbs[3], nlbs[5], ... are stored
as zero after getting parsed. Therefore it is passing wrong value to controller.
Hence, changing the nlbs type to __u32.

Signed-off-by: Francis Pravin Antony Michael Raj <francis.michael@solidigm.com>
Signed-off-by: Jonathan Derrick <jonathan.derrick@solidigm.com>