### PR TITLE
fabrics: Add nvmf_connect_disc_entry2

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -4,6 +4,7 @@ LIBNVME_1_1 {
 	global:
 		nvme_get_version;
 		nvme_init_copy_range_f1;
+		nvmf_connect_disc_entry2;
 };
 
 LIBNVME_1_0 {

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -237,8 +237,36 @@ char *nvmf_hostid_from_file();
  * Return: Pointer to the new controller
  */
 nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
-	struct nvmf_disc_log_entry *e,
-	const struct nvme_fabrics_config *defcfg, bool *discover);
+				    struct nvmf_disc_log_entry *e,
+			            const struct nvme_fabrics_config *defcfg,
+				    bool *discover);
+
+/**
+ * struct nvmf_connect_disc_entry2_args - Arguments for the nvmf_connect_disc_entry2 command
+ * @defcfg:	Default configuration to be used for the new controller
+ * @discover:	Set to 'true' if the new controller is a discovery controller
+ * @dhchap_ctrl_key: DH-HMAC-CHAP ctrl key
+ * @args_size:	Size of &struct nvmf_connect_disc_entry2_args
+ */
+struct nvmf_connect_disc_entry2_args
+{
+	const struct nvme_fabrics_config *defcfg;
+	bool		*discover;
+	const char	*dhchap_ctrl_key;
+	int		args_size;
+};
+
+/**
+ * nvmf_connect_disc_entry2() - Connect controller based on the discovery log page entry
+ * @h:		Host to which the controller should be connected
+ * @e:		Discovery log page entry
+ * @args:	&struct nvmf_connect_disc_entry2_args argument structure
+ *
+ * Return: Pointer to the  controller
+ */
+nvme_ctrl_t nvmf_connect_disc_entry2(nvme_host_t h,
+				     struct nvmf_disc_log_entry *e,
+				     struct nvmf_connect_disc_entry2_args *args);
 
 /**
  * nvmf_is_registration_supported - check whether registration can be performed.


### PR DESCRIPTION
The current nvmf_connect_disc_entry function does not set the DHCHAP
ctrl key. The problem is that we can't really pass a new argument into
the function without breaking the existing API.

The first idea (and probably the technical correct one) was to extend
struct nvme_fabrics_config. Unfortunately, we forgot to add the
args_size member to this data structure which makes it really hard to
extend. Introducing a wrapper struct and adding new function for all
users of struct nvme_fabrics_config (nvmf_default_config,
nvmf_update_config, nvmf_add_ctrl, ...) is a bit excessive.

The main problem we want to solve here is the ability to call setters
on a newly created controller before we do a connect call. The only
place where we have this sequence is nvmf_connect_disc_entry.

Hence, this approach introduces a new nvmf_connect_disc_entry2
function which sets the key between the ctrl creation and the connect
call. We use the struct args approach so that we can extend if
needed.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See https://github.com/linux-nvme/nvme-cli/issues/1618