### PR TITLE
json: fixup dhchap_ctrl_key definitions

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -25,6 +25,10 @@
 		    "description": "NVMe host ID",
 		    "type": "string"
 		},
+		"dhchap_key": {
+		    "description": "Host DH-HMAC-CHAP key",
+		    "type": "string"
+		},
 		"hostsymname": {
 		    "description": "NVMe host symbolic name",
 		    "type": "string"
@@ -76,10 +80,6 @@
 		},
 		"trsvcid": {
 		    "description": "Transport service identifier",
-		    "type": "string"
-		},
-		"dhchap_key": {
-		    "description": "Host DH-HMAC-CHAP key",
 		    "type": "string"
 		},
 		"dhchap_ctrl_key": {

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -95,7 +95,7 @@ static void json_parse_port(nvme_subsystem_t s, struct json_object *port_obj)
 	if (!c)
 		return;
 	json_update_attributes(c, port_obj);
-	attr_obj = json_object_object_get(port_obj, "dhchap_key");
+	attr_obj = json_object_object_get(port_obj, "dhchap_ctrl_key");
 	if (attr_obj)
 		nvme_ctrl_set_dhchap_key(c, json_object_get_string(attr_obj));
 }
@@ -224,7 +224,7 @@ static void json_update_port(struct json_object *ctrl_array, nvme_ctrl_t c)
 				       json_object_new_string(value));
 	value = nvme_ctrl_get_dhchap_key(c);
 	if (value)
-		json_object_object_add(port_obj, "dhchap_key",
+		json_object_object_add(port_obj, "dhchap_ctrl_key",
 				       json_object_new_string(value));
 	JSON_INT_OPTION(cfg, port_obj, nr_io_queues, 0);
 	JSON_INT_OPTION(cfg, port_obj, nr_write_queues, 0);
@@ -367,7 +367,7 @@ static void json_dump_ctrl(struct json_object *ctrl_array, nvme_ctrl_t c)
 				       json_object_new_string(value));
 	value = nvme_ctrl_get_dhchap_key(c);
 	if (value)
-		json_object_object_add(ctrl_obj, "dhchap_key",
+		json_object_object_add(ctrl_obj, "dhchap_ctrl_key",
 				       json_object_new_string(value));
 	JSON_INT_OPTION(cfg, ctrl_obj, nr_io_queues, 0);
 	JSON_INT_OPTION(cfg, ctrl_obj, nr_write_queues, 0);

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -897,6 +897,7 @@ void nvme_deconfigure_ctrl(nvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->queue_count);
 	FREE_CTRL_ATTR(c->serial);
 	FREE_CTRL_ATTR(c->sqsize);
+	FREE_CTRL_ATTR(c->dhchap_key);
 	FREE_CTRL_ATTR(c->address);
 	FREE_CTRL_ATTR(c->dctype);
 	FREE_CTRL_ATTR(c->cntrltype);


### PR DESCRIPTION
The config schema declared a 'dhchap_key' and a 'dhchap_ctrl_key'
value for the port structure, but the json parser implemented a
'dhchap_key' entry for the port (holding the controller key), and
a 'dhchap_key' entry for the host (holding the host key).
Fixup the config schema to declared the correct entries and the
json parser to check for 'dhchap_ctrl_key' instead of 'dhchap_key'.

Fixes: Issue #426

Signed-off-by: Hannes Reinecke <hare@suse.de>