### PR TITLE
Implement DH-HMAC-CHAP key templating

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -55,6 +55,10 @@
 		    "type": "array",
 		    "items": { "$ref": "#/$defs/port" }
 		},
+		"dhchap_key": {
+		    "description": "Host DH-HMAC-CHAP key",
+		    "type": "string"
+		},
 		"required": [ "nqn" ]
 	    }
 	},
@@ -80,6 +84,10 @@
 		},
 		"trsvcid": {
 		    "description": "Transport service identifier",
+		    "type": "string"
+		},
+		"dhchap_key": {
+		    "description": "Host DH-HMAC-CHAP key",
 		    "type": "string"
 		},
 		"dhchap_ctrl_key": {

--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -25,6 +25,10 @@
 		    "description": "NVMe host ID",
 		    "type": "string"
 		},
+		"dhchap_key": {
+		    "description": "Host DH-HMAC-CHAP key",
+		    "type": "string"
+		},
 		"hostsymname": {
 		    "description": "NVMe host symbolic name",
 		    "type": "string"
@@ -76,10 +80,6 @@
 		},
 		"trsvcid": {
 		    "description": "Transport service identifier",
-		    "type": "string"
-		},
-		"dhchap_key": {
-		    "description": "Host DH-HMAC-CHAP key",
 		    "type": "string"
 		},
 		"dhchap_ctrl_key": {

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -287,7 +287,9 @@ struct nvme_host {
   char *hostnqn;
   char *hostid;
   char *hostsymname;
-  char *dhchap_key;
+  %extend {
+    char *dhchap_key;
+  }
 };
 
 struct nvme_subsystem {
@@ -332,7 +334,9 @@ struct nvme_ctrl {
   char *subsysnqn;
   char *traddr;
   char *trsvcid;
-  char *dhchap_key;
+  %extend {
+    char *dhchap_key;
+  }
   char *cntrltype;
   char *dctype;
   bool discovery_ctrl;
@@ -447,6 +451,15 @@ struct nvme_ns {
     return nvme_first_subsystem($self);
   }
 }
+
+%{
+  const char *nvme_host_dhchap_key_get(struct nvme_host *h) {
+    return nvme_host_get_dhchap_key(h);
+  }
+  void nvme_host_dhchap_key_set(struct nvme_host *h, char *key) {
+    nvme_host_set_dhchap_key(h, key);
+  }
+%};
 
 %extend subsystem_iter {
   struct subsystem_iter *__iter__() {
@@ -655,6 +668,9 @@ struct nvme_ns {
   }
   const char *nvme_ctrl_state_get(struct nvme_ctrl *c) {
     return nvme_ctrl_get_state(c);
+  }
+  const char *nvme_ctrl_dhchap_key_get(struct nvme_ctrl *c) {
+    return nvme_ctrl_get_dhchap_key(c);
   }
 %};
 

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -301,6 +301,9 @@ struct nvme_subsystem {
   char *model;
   char *serial;
   char *firmware;
+  %extend {
+    char *dhchap_host_key;
+  }
 };
 
 struct nvme_ctrl {
@@ -317,6 +320,7 @@ struct nvme_ctrl {
   %immutable traddr;
   %immutable trsvcid;
   %immutable dhchap_key;
+  %immutable dhchap_host_key;
   %immutable cntrltype;
   %immutable dctype;
   %immutable discovery_ctrl;
@@ -336,6 +340,7 @@ struct nvme_ctrl {
   char *trsvcid;
   %extend {
     char *dhchap_key;
+    char *dhchap_host_key;
   }
   char *cntrltype;
   char *dctype;
@@ -534,6 +539,12 @@ struct nvme_ns {
   struct nvme_host *nvme_subsystem_host_get(struct nvme_subsystem *s) {
     return nvme_subsystem_get_host(s);
   }
+  const char *nvme_subsystem_dhchap_host_key_get(struct nvme_subsystem *s) {
+    return nvme_subsystem_get_dhchap_host_key(s, false);
+  }
+  void nvme_subsystem_dhchap_host_key_set(struct nvme_subsystem *s, char *key) {
+    nvme_subsystem_set_dhchap_host_key(s, key);
+  }
 %};
 
 %extend ctrl_iter {
@@ -671,6 +682,9 @@ struct nvme_ns {
   }
   const char *nvme_ctrl_dhchap_key_get(struct nvme_ctrl *c) {
     return nvme_ctrl_get_dhchap_key(c);
+  }
+  const char *nvme_ctrl_dhchap_host_key_get(struct nvme_ctrl *c) {
+    return nvme_ctrl_get_dhchap_host_key(c, false);
   }
 %};
 

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+LIBNVME_1_2 {
+	global:
+		nvme_ctrl_get_dhchap_host_key;
+		nvme_ctrl_set_dhchap_host_key;
+		nvme_subsystem_get_dhchap_host_key;
+		nvme_subsystem_set_dhchap_host_key;
+
 LIBNVME_1_1 {
 	global:
 		nvme_get_version;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -616,8 +616,8 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 			 * in @cfg, so ensure to update @c with the correct
 			 * controller key.
 			 */
-			if (fc->dhchap_key)
-				nvme_ctrl_set_dhchap_key(c, fc->dhchap_key);
+			if (fc->dhchap_ctrl_key)
+				nvme_ctrl_set_dhchap_key(c, fc->dhchap_ctrl_key);
 		}
 
 	}

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -461,7 +461,7 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 		discover = true;
 	hostnqn = nvme_host_get_hostnqn(h);
 	hostid = nvme_host_get_hostid(h);
-	hostkey = nvme_host_get_dhchap_key(h);
+	hostkey = nvme_ctrl_get_dhchap_host_key(c, true);
 	ctrlkey = nvme_ctrl_get_dhchap_key(c);
 	if (add_argument(argstr, "transport", transport) ||
 	    add_argument(argstr, "traddr",

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -95,7 +95,7 @@ static void json_parse_port(nvme_subsystem_t s, struct json_object *port_obj)
 	if (!c)
 		return;
 	json_update_attributes(c, port_obj);
-	attr_obj = json_object_object_get(port_obj, "dhchap_key");
+	attr_obj = json_object_object_get(port_obj, "dhchap_ctrl_key");
 	if (attr_obj)
 		nvme_ctrl_set_dhchap_key(c, json_object_get_string(attr_obj));
 }
@@ -224,7 +224,7 @@ static void json_update_port(struct json_object *ctrl_array, nvme_ctrl_t c)
 				       json_object_new_string(value));
 	value = nvme_ctrl_get_dhchap_key(c);
 	if (value)
-		json_object_object_add(port_obj, "dhchap_key",
+		json_object_object_add(port_obj, "dhchap_ctrl_key",
 				       json_object_new_string(value));
 	JSON_INT_OPTION(cfg, port_obj, nr_io_queues, 0);
 	JSON_INT_OPTION(cfg, port_obj, nr_write_queues, 0);
@@ -367,7 +367,7 @@ static void json_dump_ctrl(struct json_object *ctrl_array, nvme_ctrl_t c)
 				       json_object_new_string(value));
 	value = nvme_ctrl_get_dhchap_key(c);
 	if (value)
-		json_object_object_add(ctrl_obj, "dhchap_key",
+		json_object_object_add(ctrl_obj, "dhchap_ctrl_key",
 				       json_object_new_string(value));
 	JSON_INT_OPTION(cfg, ctrl_obj, nr_io_queues, 0);
 	JSON_INT_OPTION(cfg, ctrl_obj, nr_write_queues, 0);

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -82,6 +82,7 @@ struct nvme_ctrl {
 	char *subsysnqn;
 	char *traddr;
 	char *trsvcid;
+	char *dhchap_host_key;
 	char *dhchap_ctrl_key;
 	char *cntrltype;
 	char *dctype;
@@ -104,6 +105,7 @@ struct nvme_subsystem {
 	char *serial;
 	char *firmware;
 	char *subsystype;
+	char *dhchap_host_key;
 };
 
 struct nvme_host {

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -82,7 +82,7 @@ struct nvme_ctrl {
 	char *subsysnqn;
 	char *traddr;
 	char *trsvcid;
-	char *dhchap_key;
+	char *dhchap_ctrl_key;
 	char *cntrltype;
 	char *dctype;
 	bool discovery_ctrl;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -812,17 +812,17 @@ struct nvme_fabrics_config *nvme_ctrl_get_config(nvme_ctrl_t c)
 
 const char *nvme_ctrl_get_dhchap_key(nvme_ctrl_t c)
 {
-	return c->dhchap_key;
+	return c->dhchap_ctrl_key;
 }
 
 void nvme_ctrl_set_dhchap_key(nvme_ctrl_t c, const char *key)
 {
-	if (c->dhchap_key) {
-		free(c->dhchap_key);
-		c->dhchap_key = NULL;
+	if (c->dhchap_ctrl_key) {
+		free(c->dhchap_ctrl_key);
+		c->dhchap_ctrl_key = NULL;
 	}
 	if (key)
-		c->dhchap_key = strdup(key);
+		c->dhchap_ctrl_key = strdup(key);
 }
 
 void nvme_ctrl_set_discovered(nvme_ctrl_t c, bool discovered)
@@ -897,7 +897,7 @@ void nvme_deconfigure_ctrl(nvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->queue_count);
 	FREE_CTRL_ATTR(c->serial);
 	FREE_CTRL_ATTR(c->sqsize);
-	FREE_CTRL_ATTR(c->dhchap_key);
+	FREE_CTRL_ATTR(c->dhchap_ctrl_key);
 	FREE_CTRL_ATTR(c->address);
 	FREE_CTRL_ATTR(c->dctype);
 	FREE_CTRL_ATTR(c->cntrltype);
@@ -1166,10 +1166,10 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	c->queue_count = nvme_get_ctrl_attr(c, "queue_count");
 	c->serial = nvme_get_ctrl_attr(c, "serial");
 	c->sqsize = nvme_get_ctrl_attr(c, "sqsize");
-	c->dhchap_key = nvme_get_ctrl_attr(c, "dhchap_ctrl_secret");
-	if (c->dhchap_key && !strcmp(c->dhchap_key, "none")) {
-		free(c->dhchap_key);
-		c->dhchap_key = NULL;
+	c->dhchap_ctrl_key = nvme_get_ctrl_attr(c, "dhchap_ctrl_secret");
+	if (c->dhchap_ctrl_key && !strcmp(c->dhchap_ctrl_key, "none")) {
+		free(c->dhchap_ctrl_key);
+		c->dhchap_ctrl_key = NULL;
 	}
 	c->cntrltype = nvme_get_ctrl_attr(c, "cntrltype");
 	c->dctype = nvme_get_ctrl_attr(c, "dctype");

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -897,6 +897,7 @@ void nvme_deconfigure_ctrl(nvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->queue_count);
 	FREE_CTRL_ATTR(c->serial);
 	FREE_CTRL_ATTR(c->sqsize);
+	FREE_CTRL_ATTR(c->dhchap_key);
 	FREE_CTRL_ATTR(c->address);
 	FREE_CTRL_ATTR(c->dctype);
 	FREE_CTRL_ATTR(c->cntrltype);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -877,7 +877,7 @@ const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c);
 
 /**
  * nvme_ctrl_get_dhchap_key() - Return controller key
- * @c:	Controller for which the key should be set
+ * @c:	Controller for which the key should be returned
  *
  * Return: DH-HMAC-CHAP controller key or NULL if not set
  */
@@ -889,6 +889,28 @@ const char *nvme_ctrl_get_dhchap_key(nvme_ctrl_t c);
  * @key:	DH-HMAC-CHAP Key to set or NULL to clear existing key
  */
 void nvme_ctrl_set_dhchap_key(nvme_ctrl_t c, const char *key);
+
+/**
+ * nvme_ctrl_get_dhchap_host_key() - Return host key
+ * @c:	Controller for which the host key should be returned
+ * @traverse: true if parent structures should be checked, too
+ *
+ * Checks for any DH-HMAC-CHAP host key in either the controller,
+ * subsystem, or host structure and returns the first found one.
+ *
+ * Return: DH-HMAC-CHAP host key or NULL if not set
+ */
+const char *nvme_ctrl_get_dhchap_host_key(nvme_ctrl_t c, bool traverse);
+
+/**
+ * nvme_ctrl_set_dhchap_host_key() - Set host key
+ * @c:		Controller for which the host key should be set
+ * @key:	DH-HMAC-CHAP Key to set or NULL to clear existing key
+ *
+ * Sets the DH-HMAC-CHAP host key for only the controller structure;
+ * other keys in either subsystem or host structures are not checked.
+ */
+void nvme_ctrl_set_dhchap_host_key(nvme_ctrl_t c, const char *key);
 
 /**
  * nvme_ctrl_get_config() - Fabrics configuration of a controller
@@ -1048,6 +1070,28 @@ const char *nvme_subsystem_get_name(nvme_subsystem_t s);
  * Return: 'nvm' or 'discovery'
  */
 const char *nvme_subsystem_get_type(nvme_subsystem_t s);
+
+/**
+ * nvme_subsystem_get_dhchap_host_key() - Return host key
+ * @s:	Subsystem for which the host key should be returned
+ * @traverse: True if host structure should be checked
+ *
+ * Checks for any DH-HMAC-CHAP host key in either the subsystem
+ * or host structure and returns the first found one.
+ *
+ * Return: DH-HMAC-CHAP host key or NULL if not set
+ */
+const char *nvme_subsystem_get_dhchap_host_key(nvme_subsystem_t s, bool traverse);
+
+/**
+ * nvme_subsystem_set_dhchap_host_key() - Set host key
+ * @s:		Subsystem for which the host key should be set
+ * @key:	DH-HMAC-CHAP Key to set or NULL to clear existing key
+ *
+ * Sets the DH-HMAC-CHAP host key for only the subsystem structure;
+ * key in the host structure is not checked.
+ */
+void nvme_subsystem_set_dhchap_host_key(nvme_subsystem_t c, const char *key);
 
 /**
  * nvme_scan_topology() - Scan NVMe topology and apply filter


### PR DESCRIPTION
Implement templating for dhchap host keys, where the host key can be stored at either the host, subsystem, or controller level. The function nvme_ctrl_get_dhchap_host_key() will retrieve the key, with the setting from the controller taking precedence over both the subsystem and controller settings.