### PR TITLE
util: Add LINE_MAX define

### DIFF
--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -23,6 +23,11 @@
 #include "util.h"
 #include "log.h"
 
+/* The bionic libc implementation doesn't define LINE_MAX */
+#ifndef LINE_MAX
+#define LINE_MAX 2048
+#endif
+
 /* Source Code Control System, query version of binary with 'what' */
 const char sccsid[] = "@(#)libnvme " GIT_VERSION;
 


### PR DESCRIPTION
The bionic libc implementation doesn't implement the complete
POSIX API. Apperantly we just need this define to be able
to compile for Android OS. Thus, keep it as simple as possible
and just define it here.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #452