### PR TITLE
libnvme: Fix the Reference Tag in copy command

### DIFF
--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -666,8 +666,6 @@ struct nvme_dsm_args {
  * @prinfow:	Protection information field for write
  * @dtype:	Directive type
  * @format:	Descriptor format
- * @ilbrt_u64:	Initial logical block reference tag - 8 byte
- *              version required for enhanced protection info
  */
 struct nvme_copy_args {
 	__u64 sdlba;
@@ -677,7 +675,7 @@ struct nvme_copy_args {
 	int fd;
 	__u32 timeout;
 	__u32 nsid;
-	__u32 ilbrt;
+	__u64 ilbrt;
 	int lr;
 	int fua;
 	__u16 nr;
@@ -688,7 +686,6 @@ struct nvme_copy_args {
 	__u8 prinfow;
 	__u8 dtype;
 	__u8 format;
-	__u64 ilbrt_u64;
 };
 
 /**

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -401,14 +401,16 @@ void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
 			  __u64 *slbas, __u64 *eilbrts, __u32 *elbatms,
 			  __u32 *elbats, __u16 nr)
 {
-	int i;
+	int i, j;
 
 	for (i = 0; i < nr; i++) {
 		copy[i].nlb = cpu_to_le16(nlbs[i]);
 		copy[i].slba = cpu_to_le64(slbas[i]);
-		copy[i].elbt[2] = cpu_to_le64(eilbrts[i]);
 		copy[i].elbatm = cpu_to_le16(elbatms[i]);
 		copy[i].elbat = cpu_to_le16(elbats[i]);
+
+		for (j = 0; j < 8; j++)
+			copy[i].elbt[9 - j] = (eilbrts[i] >> (8 * j)) & 0xff;
 	}  
 }
 


### PR DESCRIPTION
The elbt is declared as elbt[10] to store 80-bit refernce tag value. For now,
the Kernel supports 32-bit and 48-bit refernce tag only. Therefore the value is
received in the 64-bit variable. So elbt[2] to elbt[9] is used to store that 64-bit value.

Identify the type of copy format using args->format instead of structure size.
Also, use a single 64-bit ilbrt instead of using two ilbrt with different datatypes.

Signed-off-by: Francis Pravin Antony Michael Raj <francis.michael@solidigm.com>
Signed-off-by: Jonathan Derrick <jonathan.derrick@solidigm.com>