### PR TITLE
MI: expand admin command implementation

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -18,6 +18,7 @@ LIBNVME_MI_1_1 {
 		nvme_mi_admin_set_features;
 		nvme_mi_admin_ns_mgmt;
 		nvme_mi_admin_ns_attach;
+		nvme_mi_admin_format_nvm;
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -17,6 +17,7 @@ LIBNVME_MI_1_1 {
 		nvme_mi_admin_get_features;
 		nvme_mi_admin_set_features;
 		nvme_mi_admin_ns_mgmt;
+		nvme_mi_admin_ns_attach;
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -14,6 +14,8 @@ LIBNVME_MI_1_1 {
 		nvme_mi_mi_subsystem_health_status_poll;
 		nvme_mi_admin_identify_partial;
 		nvme_mi_admin_get_log;
+		nvme_mi_admin_get_features;
+		nvme_mi_admin_set_features;
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -19,6 +19,7 @@ LIBNVME_MI_1_1 {
 		nvme_mi_admin_ns_mgmt;
 		nvme_mi_admin_ns_attach;
 		nvme_mi_admin_format_nvm;
+		nvme_mi_admin_sanitize_nvm;
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -16,6 +16,7 @@ LIBNVME_MI_1_1 {
 		nvme_mi_admin_get_log;
 		nvme_mi_admin_get_features;
 		nvme_mi_admin_set_features;
+		nvme_mi_admin_ns_mgmt;
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -729,6 +729,48 @@ int nvme_mi_admin_set_features(nvme_mi_ctrl_t ctrl,
 	return 0;
 }
 
+int nvme_mi_admin_ns_mgmt(nvme_mi_ctrl_t ctrl,
+			  struct nvme_ns_mgmt_args *args)
+{
+	struct nvme_mi_admin_resp_hdr resp_hdr;
+	struct nvme_mi_admin_req_hdr req_hdr;
+	struct nvme_mi_resp resp;
+	struct nvme_mi_req req;
+	int rc;
+
+	if (args->args_size < sizeof(*args))
+		return -EINVAL;
+
+	nvme_mi_admin_init_req(&req, &req_hdr, ctrl->id,
+			       nvme_admin_ns_mgmt);
+
+	req_hdr.cdw1 = cpu_to_le32(args->nsid);
+	req_hdr.cdw10 = cpu_to_le32(args->sel & 0xf);
+	req_hdr.cdw11 = cpu_to_le32(args->csi << 24);
+	if (args->ns) {
+		req.data = args->ns;
+		req.data_len = sizeof(*args->ns);
+		req_hdr.dlen = cpu_to_le32(sizeof(*args->ns));
+		req_hdr.flags = 0x1;
+	}
+
+	nvme_mi_calc_req_mic(&req);
+
+	nvme_mi_admin_init_resp(&resp, &resp_hdr);
+
+	rc = nvme_mi_submit(ctrl->ep, &req, &resp);
+	if (rc)
+		return rc;
+
+	if (resp_hdr.status)
+		return resp_hdr.status;
+
+	if (args->result)
+		*args->result = le32_to_cpu(resp_hdr.cdw0);
+
+	return 0;
+}
+
 static int nvme_mi_read_data(nvme_mi_ep_t ep, __u32 cdw0,
 			     void *data, size_t *data_len)
 {

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -643,6 +643,92 @@ int nvme_mi_admin_security_recv(nvme_mi_ctrl_t ctrl,
 	return 0;
 }
 
+int nvme_mi_admin_get_features(nvme_mi_ctrl_t ctrl,
+			       struct nvme_get_features_args *args)
+{
+	struct nvme_mi_admin_resp_hdr resp_hdr;
+	struct nvme_mi_admin_req_hdr req_hdr;
+	struct nvme_mi_resp resp;
+	struct nvme_mi_req req;
+	int rc;
+
+	if (args->args_size < sizeof(*args))
+		return -EINVAL;
+
+	nvme_mi_admin_init_req(&req, &req_hdr, ctrl->id,
+			       nvme_admin_get_features);
+
+	req_hdr.cdw1 = cpu_to_le32(args->nsid);
+	req_hdr.cdw10 = cpu_to_le32((args->sel & 0x7) << 8 | args->fid);
+	req_hdr.cdw14 = cpu_to_le32(args->uuidx & 0x7f);
+	req_hdr.cdw11 = cpu_to_le32(args->cdw11);
+
+	nvme_mi_calc_req_mic(&req);
+
+	nvme_mi_admin_init_resp(&resp, &resp_hdr);
+	resp.data = args->data;
+	resp.data_len = args->data_len;
+
+	rc = nvme_mi_submit(ctrl->ep, &req, &resp);
+	if (rc)
+		return rc;
+
+	if (resp_hdr.status)
+		return resp_hdr.status;
+
+	if (args->result)
+		*args->result = le32_to_cpu(resp_hdr.cdw0);
+
+	args->data_len = resp.data_len;
+
+	return 0;
+}
+
+int nvme_mi_admin_set_features(nvme_mi_ctrl_t ctrl,
+			       struct nvme_set_features_args *args)
+{
+	struct nvme_mi_admin_resp_hdr resp_hdr;
+	struct nvme_mi_admin_req_hdr req_hdr;
+	struct nvme_mi_resp resp;
+	struct nvme_mi_req req;
+	int rc;
+
+	if (args->args_size < sizeof(*args))
+		return -EINVAL;
+
+	nvme_mi_admin_init_req(&req, &req_hdr, ctrl->id,
+			       nvme_admin_set_features);
+
+	req_hdr.cdw1 = cpu_to_le32(args->nsid);
+	req_hdr.cdw10 = cpu_to_le32((args->save ? 1 : 0) << 31 |
+				    (args->fid & 0xff));
+	req_hdr.cdw14 = cpu_to_le32(args->uuidx & 0x7f);
+	req_hdr.cdw11 = cpu_to_le32(args->cdw11);
+	req_hdr.cdw12 = cpu_to_le32(args->cdw12);
+	req_hdr.cdw13 = cpu_to_le32(args->cdw13);
+	req_hdr.cdw15 = cpu_to_le32(args->cdw15);
+
+	req.data_len = args->data_len;
+	req.data = args->data;
+
+	nvme_mi_calc_req_mic(&req);
+
+	nvme_mi_admin_init_resp(&resp, &resp_hdr);
+
+	rc = nvme_mi_submit(ctrl->ep, &req, &resp);
+	if (rc)
+		return rc;
+
+	if (resp_hdr.status)
+		return resp_hdr.status;
+
+	if (args->result)
+		*args->result = le32_to_cpu(resp_hdr.cdw0);
+	args->data_len = resp.data_len;
+
+	return 0;
+}
+
 static int nvme_mi_read_data(nvme_mi_ep_t ep, __u32 cdw0,
 			     void *data, size_t *data_len)
 {

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -810,6 +810,46 @@ int nvme_mi_admin_ns_attach(nvme_mi_ctrl_t ctrl,
 	return 0;
 }
 
+int nvme_mi_admin_format_nvm(nvme_mi_ctrl_t ctrl,
+			     struct nvme_format_nvm_args *args)
+{
+	struct nvme_mi_admin_resp_hdr resp_hdr;
+	struct nvme_mi_admin_req_hdr req_hdr;
+	struct nvme_mi_resp resp;
+	struct nvme_mi_req req;
+	int rc;
+
+	if (args->args_size < sizeof(*args))
+		return -EINVAL;
+
+	nvme_mi_admin_init_req(&req, &req_hdr, ctrl->id,
+			       nvme_admin_format_nvm);
+
+	req_hdr.cdw1 = cpu_to_le32(args->nsid);
+	req_hdr.cdw10 = cpu_to_le32(((args->lbafu & 0x3) << 12)
+				    | ((args->ses & 0x7) << 9)
+				    | ((args->pil & 0x1) << 8)
+				    | ((args->pi & 0x7) << 5)
+				    | ((args->mset & 0x1) << 4)
+				    | ((args->lbaf & 0xf) << 0));
+
+	nvme_mi_calc_req_mic(&req);
+
+	nvme_mi_admin_init_resp(&resp, &resp_hdr);
+
+	rc = nvme_mi_submit(ctrl->ep, &req, &resp);
+	if (rc)
+		return rc;
+
+	if (resp_hdr.status)
+		return resp_hdr.status;
+
+	if (args->result)
+		*args->result = le32_to_cpu(resp_hdr.cdw0);
+
+	return 0;
+}
+
 static int nvme_mi_read_data(nvme_mi_ep_t ep, __u32 cdw0,
 			     void *data, size_t *data_len)
 {

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1079,6 +1079,80 @@ static inline int nvme_mi_admin_identify_ctrl_list(nvme_mi_ctrl_t ctrl,
 }
 
 /**
+ * nvme_mi_admin_identify_allocated_ns_list() - Perform an Admin identify for
+ * an allocated namespace list
+ * @ctrl: Controller to process identify command
+ * @nsid: Namespace ID to specify list start
+ * @list: List data to populate
+ *
+ * Perform an Identify command, for the allocated namespace list starting with
+ * IDs greater than or equal to @nsid. Specify &NVME_NSID_NONE for the start
+ * of the list.
+ *
+ * Will return an error if the length of the response data (from the
+ * controller) is not a full &NVME_IDENTIFY_DATA_SIZE, so @list will be
+ * be fully populated on success.
+ *
+ * Return: 0 on success, non-zero on failure
+ *
+ * See: &struct nvme_ns_list
+ */
+static inline int nvme_mi_admin_identify_allocated_ns_list(nvme_mi_ctrl_t ctrl,
+							   __u32 nsid,
+							   struct nvme_ns_list *list)
+{
+	struct nvme_identify_args args = {
+		.result = NULL,
+		.data = list,
+		.args_size = sizeof(args),
+		.cns = NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST,
+		.csi = NVME_CSI_NVM,
+		.nsid = nsid,
+		.cns_specific_id = NVME_CNSSPECID_NONE,
+		.uuidx = NVME_UUID_NONE,
+	};
+
+	return nvme_mi_admin_identify(ctrl, &args);
+}
+
+/**
+ * nvme_mi_admin_identify_active_ns_list() - Perform an Admin identify for an
+ * active namespace list
+ * @ctrl: Controller to process identify command
+ * @nsid: Namespace ID to specify list start
+ * @list: List data to populate
+ *
+ * Perform an Identify command, for the active namespace list starting with
+ * IDs greater than or equal to @nsid. Specify &NVME_NSID_NONE for the start
+ * of the list.
+ *
+ * Will return an error if the length of the response data (from the
+ * controller) is not a full &NVME_IDENTIFY_DATA_SIZE, so @list will be
+ * be fully populated on success.
+ *
+ * Return: 0 on success, non-zero on failure
+ *
+ * See: &struct nvme_ns_list
+ */
+static inline int nvme_mi_admin_identify_active_ns_list(nvme_mi_ctrl_t ctrl,
+							__u32 nsid,
+							struct nvme_ns_list *list)
+{
+	struct nvme_identify_args args = {
+		.result = NULL,
+		.data = list,
+		.args_size = sizeof(args),
+		.cns = NVME_IDENTIFY_CNS_NS_ACTIVE_LIST,
+		.csi = NVME_CSI_NVM,
+		.nsid = nsid,
+		.cns_specific_id = NVME_CNSSPECID_NONE,
+		.uuidx = NVME_UUID_NONE,
+	};
+
+	return nvme_mi_admin_identify(ctrl, &args);
+}
+
+/**
  * nvme_mi_admin_get_log() - Retrieve log page data from controller
  * @ctrl: Controller to query
  * @args: Get Log Page command arguments

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1496,4 +1496,17 @@ static inline int nvme_mi_admin_ns_detach_ctrls(nvme_mi_ctrl_t ctrl, __u32 nsid,
 	return nvme_mi_admin_ns_attach(ctrl, &args);
 }
 
+/**
+ * nvme_mi_admin_format_nvm() - Format NVMe namespace
+ * @ctrl: Controller to send command to
+ * @args: Format NVM command arguments
+ *
+ * Perform a low-level format to set the LBA data & metadata size. May destroy
+ * data & metadata on the specified namespaces
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+int nvme_mi_admin_format_nvm(nvme_mi_ctrl_t ctrl,
+			     struct nvme_format_nvm_args *args);
+
 #endif /* _LIBNVME_MI_MI_H */

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1442,4 +1442,58 @@ static inline int nvme_mi_admin_ns_mgmt_delete(nvme_mi_ctrl_t ctrl, __u32 nsid)
 	return nvme_mi_admin_ns_mgmt(ctrl, &args);
 }
 
+/**
+ * nvme_mi_admin_ns_attach() - Attach or detach namespace to controller(s)
+ * @ctrl: Controller to send command to
+ * @args: Namespace Attach command arguments
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+int nvme_mi_admin_ns_attach(nvme_mi_ctrl_t ctrl,
+			    struct nvme_ns_attach_args *args);
+
+/**
+ * nvme_mi_admin_ns_attach_ctrls() - Attach namespace to controllers
+ * @ctrl: Controller to send command to
+ * @nsid: Namespace ID to attach
+ * @ctrlist: Controller list to modify attachment state of nsid
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+static inline int nvme_mi_admin_ns_attach_ctrls(nvme_mi_ctrl_t ctrl, __u32 nsid,
+						struct nvme_ctrl_list *ctrlist)
+{
+	struct nvme_ns_attach_args args = {
+		.result = NULL,
+		.ctrlist = ctrlist,
+		.args_size = sizeof(args),
+		.nsid = nsid,
+		.sel = NVME_NS_ATTACH_SEL_CTRL_ATTACH,
+	};
+
+	return nvme_mi_admin_ns_attach(ctrl, &args);
+}
+
+/**
+ * nvme_mi_admin_ns_detach_ctrls() - Detach namespace from controllers
+ * @ctrl: Controller to send command to
+ * @nsid: Namespace ID to detach
+ * @ctrlist: Controller list to modify attachment state of nsid
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+static inline int nvme_mi_admin_ns_detach_ctrls(nvme_mi_ctrl_t ctrl, __u32 nsid,
+						struct nvme_ctrl_list *ctrlist)
+{
+	struct nvme_ns_attach_args args = {
+		.result = NULL,
+		.ctrlist = ctrlist,
+		.args_size = sizeof(args),
+		.nsid = nsid,
+		.sel = NVME_NS_ATTACH_SEL_CTRL_DEATTACH,
+	};
+
+	return nvme_mi_admin_ns_attach(ctrl, &args);
+}
+
 #endif /* _LIBNVME_MI_MI_H */

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1019,6 +1019,46 @@ static inline int nvme_mi_admin_identify_cns_nsid(nvme_mi_ctrl_t ctrl,
 }
 
 /**
+ * nvme_mi_admin_identify_ns() - Perform an Admin identify command for a
+ * namespace
+ * @ctrl: Controller to process identify command
+ * @nsid: namespace ID
+ * @ns: Namespace identification to populate
+ *
+ * Perform an Identify (namespace) command, setting the namespace id data
+ * in @ns. The namespace is expected to active and allocated.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+static inline int nvme_mi_admin_identify_ns(nvme_mi_ctrl_t ctrl, __u32 nsid,
+					    struct nvme_id_ns *ns)
+{
+	return nvme_mi_admin_identify_cns_nsid(ctrl, NVME_IDENTIFY_CNS_NS,
+					       nsid, ns);
+}
+
+/**
+ * nvme_mi_admin_identify_allocated_ns() - Perform an Admin identify command
+ * for an allocated namespace
+ * @ctrl: Controller to process identify command
+ * @nsid: namespace ID
+ * @ns: Namespace identification to populate
+ *
+ * Perform an Identify (namespace) command, setting the namespace id data
+ * in @ns.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+static inline int nvme_mi_admin_identify_allocated_ns(nvme_mi_ctrl_t ctrl,
+						      __u32 nsid,
+						      struct nvme_id_ns *ns)
+{
+	return nvme_mi_admin_identify_cns_nsid(ctrl,
+					       NVME_IDENTIFY_CNS_ALLOCATED_NS,
+					       nsid, ns);
+}
+
+/**
  * nvme_mi_admin_identify_ctrl() - Perform an Admin identify for a controller
  * @ctrl: Controller to process identify command
  * @id: Controller identify data to populate

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1509,4 +1509,24 @@ static inline int nvme_mi_admin_ns_detach_ctrls(nvme_mi_ctrl_t ctrl, __u32 nsid,
 int nvme_mi_admin_format_nvm(nvme_mi_ctrl_t ctrl,
 			     struct nvme_format_nvm_args *args);
 
+/**
+ * nvme_mi_admin_sanitize_nvm() - Start a subsystem Sanitize operation
+ * @ctrl: Controller to send command to
+ * @args: Sanitize command arguments
+ *
+ * A sanitize operation alters all user data in the NVM subsystem such that
+ * recovery of any previous user data from any cache, the non-volatile media,
+ * or any Controller Memory Buffer is not possible.
+ *
+ * The Sanitize command starts a sanitize operation or to recover from a
+ * previously failed sanitize operation. The sanitize operation types that may
+ * be supported are Block Erase, Crypto Erase, and Overwrite. All sanitize
+ * operations are processed in the background, i.e., completion of the sanitize
+ * command does not indicate completion of the sanitize operation.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+int nvme_mi_admin_sanitize_nvm(nvme_mi_ctrl_t ctrl,
+			       struct nvme_sanitize_nvm_args *args);
+
 #endif /* _LIBNVME_MI_MI_H */

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1379,4 +1379,67 @@ static inline int nvme_mi_admin_get_features_simple(nvme_mi_ctrl_t ctrl,
 int nvme_mi_admin_set_features(nvme_mi_ctrl_t ctrl,
 			       struct nvme_set_features_args *args);
 
+/**
+ * nvme_mi_admin_ns_mgmt - Issue a Namespace Management command
+ * @ctrl: Controller to send command to
+ * @args: Namespace management command arguments
+ *
+ * Issues a Namespace Management command to @ctrl, with arguments specified
+ * from @args.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+int nvme_mi_admin_ns_mgmt(nvme_mi_ctrl_t ctrl,
+			  struct nvme_ns_mgmt_args *args);
+
+/**
+ * nvme_mi_admin_ns_mgmt_create - Helper for Namespace Management Create command
+ * @ctrl: Controller to send command to
+ * @ns: New namespace parameters
+ * @csi: Command Set Identifier for new NS
+ * @nsid: Set to new namespace ID on create
+ *
+ * Issues a Namespace Management (Create) command to @ctrl, to create a
+ * new namespace specified by @ns, using command set @csi. On success,
+ * the new namespace ID will be written to @nsid.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+static inline int nvme_mi_admin_ns_mgmt_create(nvme_mi_ctrl_t ctrl,
+					       struct nvme_id_ns *ns,
+					       __u8 csi, __u32 *nsid)
+{
+	struct nvme_ns_mgmt_args args = {
+		.args_size = sizeof(args),
+		.csi = csi,
+		.nsid = NVME_NSID_NONE,
+		.sel = NVME_NS_MGMT_SEL_CREATE,
+		.ns = ns,
+		.result = nsid,
+	};
+
+	return nvme_mi_admin_ns_mgmt(ctrl, &args);
+}
+
+/**
+ * nvme_mi_admin_ns_mgmt_delete - Helper for Namespace Management Delete command
+ * @ctrl: Controller to send command to
+ * @nsid: Namespace ID to delete
+ *
+ * Issues a Namespace Management (Delete) command to @ctrl, to delete the
+ * namespace with id @nsid.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+static inline int nvme_mi_admin_ns_mgmt_delete(nvme_mi_ctrl_t ctrl, __u32 nsid)
+{
+	struct nvme_ns_mgmt_args args = {
+		.args_size = sizeof(args),
+		.nsid = nsid,
+		.sel = NVME_NS_MGMT_SEL_DELETE,
+	};
+
+	return nvme_mi_admin_ns_mgmt(ctrl, &args);
+}
+
 #endif /* _LIBNVME_MI_MI_H */

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1119,6 +1119,44 @@ static inline int nvme_mi_admin_identify_ctrl_list(nvme_mi_ctrl_t ctrl,
 }
 
 /**
+ * nvme_mi_admin_identify_nsid_ctrl_list() - Perform an Admin identify for a
+ * controller list with specific namespace ID
+ * @ctrl: Controller to process identify command
+ * @nsid: Namespace identifier
+ * @cntid: Controller ID to specify list start
+ * @list: List data to populate
+ *
+ * Perform an Identify command, for the controller list for @nsid, starting
+ * with IDs greater than or equal to @cntid.
+ *
+ * Will return an error if the length of the response data (from the
+ * controller) is not a full &NVME_IDENTIFY_DATA_SIZE, so @id will be
+ * fully populated on success.
+ *
+ * Return: 0 on success, non-zero on failure
+ *
+ * See: &struct nvme_ctrl_list
+ */
+static inline int nvme_mi_admin_identify_nsid_ctrl_list(nvme_mi_ctrl_t ctrl,
+							__u32 nsid, __u16 cntid,
+							struct nvme_ctrl_list *list)
+{
+	struct nvme_identify_args args = {
+		.result = NULL,
+		.data = list,
+		.args_size = sizeof(args),
+		.cns = NVME_IDENTIFY_CNS_CTRL_LIST,
+		.csi = NVME_CSI_NVM,
+		.nsid = nsid,
+		.cntid = cntid,
+		.cns_specific_id = NVME_CNSSPECID_NONE,
+		.uuidx = NVME_UUID_NONE,
+	};
+
+	return nvme_mi_admin_identify(ctrl, &args);
+}
+
+/**
  * nvme_mi_admin_identify_allocated_ns_list() - Perform an Admin identify for
  * an allocated namespace list
  * @ctrl: Controller to process identify command


### PR DESCRIPTION
This series adds MI implementations for more Admin commands:

 * Get Features
 * Set Features
 * Namespace Management
 * Namespace Attach
 * Format NVM
 * Sanitize NVM

plus a few inline helpers for these and the existing Get Log Page and Identify commands (which `nvme-cli` needs to support the above)

As always, comments/queries/etc most welcome.