### PR TITLE
Allow to get and set DHCHAP host key on controller level

### DIFF
--- a/doc/config-schema.json.in
+++ b/doc/config-schema.json.in
@@ -25,6 +25,10 @@
 		    "description": "NVMe host ID",
 		    "type": "string"
 		},
+		"dhchap_key": {
+		    "description": "Host DH-HMAC-CHAP key",
+		    "type": "string"
+		},
 		"hostsymname": {
 		    "description": "NVMe host symbolic name",
 		    "type": "string"

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -287,7 +287,9 @@ struct nvme_host {
   char *hostnqn;
   char *hostid;
   char *hostsymname;
-  char *dhchap_key;
+  %extend {
+    char *dhchap_key;
+  }
 };
 
 struct nvme_subsystem {
@@ -332,7 +334,9 @@ struct nvme_ctrl {
   char *subsysnqn;
   char *traddr;
   char *trsvcid;
-  char *dhchap_key;
+  %extend {
+    char *dhchap_key;
+  }
   char *cntrltype;
   char *dctype;
   bool discovery_ctrl;
@@ -447,6 +451,15 @@ struct nvme_ns {
     return nvme_first_subsystem($self);
   }
 }
+
+%{
+  const char *nvme_host_dhchap_key_get(struct nvme_host *h) {
+    return nvme_host_get_dhchap_key(h);
+  }
+  void nvme_host_dhchap_key_set(struct nvme_host *h, char *key) {
+    nvme_host_set_dhchap_key(h, key);
+  }
+%};
 
 %extend subsystem_iter {
   struct subsystem_iter *__iter__() {
@@ -655,6 +668,9 @@ struct nvme_ns {
   }
   const char *nvme_ctrl_state_get(struct nvme_ctrl *c) {
     return nvme_ctrl_get_state(c);
+  }
+  const char *nvme_ctrl_dhchap_key_get(struct nvme_ctrl *c) {
+    return nvme_ctrl_get_dhchap_key(c);
   }
 %};
 

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -316,6 +316,7 @@ struct nvme_ctrl {
   %immutable subsysnqn;
   %immutable traddr;
   %immutable trsvcid;
+  %immutable dhchap_host_key;
   %immutable dhchap_key;
   %immutable cntrltype;
   %immutable dctype;
@@ -335,6 +336,7 @@ struct nvme_ctrl {
   char *traddr;
   char *trsvcid;
   %extend {
+    char *dhchap_host_key:
     char *dhchap_key;
   }
   char *cntrltype;
@@ -671,6 +673,9 @@ struct nvme_ns {
   }
   const char *nvme_ctrl_dhchap_key_get(struct nvme_ctrl *c) {
     return nvme_ctrl_get_dhchap_key(c);
+  }
+  const char *nvme_ctrl_dhchap_host_key_get(struct nvme_ctrl *c) {
+    return nvme_ctrl_get_dhchap_host_key(c);
   }
 %};
 

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+LIBNVME_1_2 {
+	global:
+		nvme_ctrl_get_dhchap_host_key;
+		nvme_ctrl_set_dhchap_host_key;
+};
+
 LIBNVME_1_1 {
 	global:
 		nvme_get_version;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -619,8 +619,8 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 			 * in @cfg, so ensure to update @c with the correct
 			 * controller key.
 			 */
-			if (fc->dhchap_key)
-				nvme_ctrl_set_dhchap_key(c, fc->dhchap_key);
+			if (fc->dhchap_ctrl_key)
+				nvme_ctrl_set_dhchap_key(c, fc->dhchap_ctrl_key);
 		}
 
 	}

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -465,6 +465,8 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 	hostnqn = nvme_host_get_hostnqn(h);
 	hostid = nvme_host_get_hostid(h);
 	hostkey = nvme_host_get_dhchap_key(h);
+	if (!hostkey)
+		hostkey = nvme_ctrl_get_dhchap_host_key(c);
 	ctrlkey = nvme_ctrl_get_dhchap_key(c);
 	if (add_argument(argstr, "transport", transport) ||
 	    add_argument(argstr, "traddr",
@@ -613,14 +615,20 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 					nvme_ctrl_get_trsvcid(c),
 					NULL);
 		if (fc) {
+			const char *key;
+
 			cfg = merge_config(c, nvme_ctrl_get_config(fc));
 			/*
 			 * An authentication key might already been set
 			 * in @cfg, so ensure to update @c with the correct
 			 * controller key.
 			 */
-			if (fc->dhchap_ctrl_key)
-				nvme_ctrl_set_dhchap_key(c, fc->dhchap_ctrl_key);
+			key = nvme_ctrl_get_dhchap_host_key(fc);
+			if (key)
+				nvme_ctrl_set_dhchap_host_key(c, key);
+			key = nvme_ctrl_get_dhchap_key(fc);
+			if (key)
+				nvme_ctrl_set_dhchap_key(c, key);
 		}
 
 	}

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -95,6 +95,9 @@ static void json_parse_port(nvme_subsystem_t s, struct json_object *port_obj)
 	if (!c)
 		return;
 	json_update_attributes(c, port_obj);
+	attr_obj = json_object_object_get(port_obj, "dhchap_key");
+	if (attr_obj)
+		nvme_ctrl_set_dhchap_host_key(c, json_object_get_string(attr_obj));
 	attr_obj = json_object_object_get(port_obj, "dhchap_ctrl_key");
 	if (attr_obj)
 		nvme_ctrl_set_dhchap_key(c, json_object_get_string(attr_obj));
@@ -221,6 +224,10 @@ static void json_update_port(struct json_object *ctrl_array, nvme_ctrl_t c)
 	value = nvme_ctrl_get_trsvcid(c);
 	if (value)
 		json_object_object_add(port_obj, "trsvcid",
+				       json_object_new_string(value));
+	value = nvme_ctrl_get_dhchap_host_key(c);
+	if (value)
+		json_object_object_add(port_obj, "dhchap_key",
 				       json_object_new_string(value));
 	value = nvme_ctrl_get_dhchap_key(c);
 	if (value)
@@ -364,6 +371,10 @@ static void json_dump_ctrl(struct json_object *ctrl_array, nvme_ctrl_t c)
 	value = nvme_ctrl_get_trsvcid(c);
 	if (value)
 		json_object_object_add(ctrl_obj, "trsvcid",
+				       json_object_new_string(value));
+	value = nvme_ctrl_get_dhchap_host_key(c);
+	if (value)
+		json_object_object_add(ctrl_obj, "dhchap_key",
 				       json_object_new_string(value));
 	value = nvme_ctrl_get_dhchap_key(c);
 	if (value)

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -82,7 +82,7 @@ struct nvme_ctrl {
 	char *subsysnqn;
 	char *traddr;
 	char *trsvcid;
-	char *dhchap_key;
+	char *dhchap_ctrl_key;
 	char *cntrltype;
 	char *dctype;
 	bool discovery_ctrl;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -82,6 +82,7 @@ struct nvme_ctrl {
 	char *subsysnqn;
 	char *traddr;
 	char *trsvcid;
+	char *dhchap_key;
 	char *dhchap_ctrl_key;
 	char *cntrltype;
 	char *dctype;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -812,17 +812,17 @@ struct nvme_fabrics_config *nvme_ctrl_get_config(nvme_ctrl_t c)
 
 const char *nvme_ctrl_get_dhchap_key(nvme_ctrl_t c)
 {
-	return c->dhchap_key;
+	return c->dhchap_ctrl_key;
 }
 
 void nvme_ctrl_set_dhchap_key(nvme_ctrl_t c, const char *key)
 {
-	if (c->dhchap_key) {
-		free(c->dhchap_key);
-		c->dhchap_key = NULL;
+	if (c->dhchap_ctrl_key) {
+		free(c->dhchap_ctrl_key);
+		c->dhchap_ctrl_key = NULL;
 	}
 	if (key)
-		c->dhchap_key = strdup(key);
+		c->dhchap_ctrl_key = strdup(key);
 }
 
 void nvme_ctrl_set_discovered(nvme_ctrl_t c, bool discovered)
@@ -897,7 +897,7 @@ void nvme_deconfigure_ctrl(nvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->queue_count);
 	FREE_CTRL_ATTR(c->serial);
 	FREE_CTRL_ATTR(c->sqsize);
-	FREE_CTRL_ATTR(c->dhchap_key);
+	FREE_CTRL_ATTR(c->dhchap_ctrl_key);
 	FREE_CTRL_ATTR(c->address);
 	FREE_CTRL_ATTR(c->dctype);
 	FREE_CTRL_ATTR(c->cntrltype);
@@ -1166,10 +1166,10 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	c->queue_count = nvme_get_ctrl_attr(c, "queue_count");
 	c->serial = nvme_get_ctrl_attr(c, "serial");
 	c->sqsize = nvme_get_ctrl_attr(c, "sqsize");
-	c->dhchap_key = nvme_get_ctrl_attr(c, "dhchap_ctrl_secret");
-	if (c->dhchap_key && !strcmp(c->dhchap_key, "none")) {
-		free(c->dhchap_key);
-		c->dhchap_key = NULL;
+	c->dhchap_ctrl_key = nvme_get_ctrl_attr(c, "dhchap_ctrl_secret");
+	if (c->dhchap_ctrl_key && !strcmp(c->dhchap_ctrl_key, "none")) {
+		free(c->dhchap_ctrl_key);
+		c->dhchap_ctrl_key = NULL;
 	}
 	c->cntrltype = nvme_get_ctrl_attr(c, "cntrltype");
 	c->dctype = nvme_get_ctrl_attr(c, "dctype");

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -810,6 +810,21 @@ struct nvme_fabrics_config *nvme_ctrl_get_config(nvme_ctrl_t c)
 	return &c->cfg;
 }
 
+const char *nvme_ctrl_get_dhchap_host_key(nvme_ctrl_t c)
+{
+	return c->dhchap_key;
+}
+
+void nvme_ctrl_set_dhchap_host_key(nvme_ctrl_t c, const char *key)
+{
+	if (c->dhchap_key) {
+		free(c->dhchap_key);
+		c->dhchap_key = NULL;
+	}
+	if (key)
+		c->dhchap_key = strdup(key);
+}
+
 const char *nvme_ctrl_get_dhchap_key(nvme_ctrl_t c)
 {
 	return c->dhchap_ctrl_key;
@@ -897,6 +912,7 @@ void nvme_deconfigure_ctrl(nvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->queue_count);
 	FREE_CTRL_ATTR(c->serial);
 	FREE_CTRL_ATTR(c->sqsize);
+	FREE_CTRL_ATTR(c->dhchap_key);
 	FREE_CTRL_ATTR(c->dhchap_ctrl_key);
 	FREE_CTRL_ATTR(c->address);
 	FREE_CTRL_ATTR(c->dctype);
@@ -1146,6 +1162,7 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 			       const char *name)
 {
 	DIR *d;
+	char *host_key;
 
 	d = opendir(path);
 	if (!d) {
@@ -1166,6 +1183,14 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	c->queue_count = nvme_get_ctrl_attr(c, "queue_count");
 	c->serial = nvme_get_ctrl_attr(c, "serial");
 	c->sqsize = nvme_get_ctrl_attr(c, "sqsize");
+	host_key = nvme_get_ctrl_attr(c, "dhchap_secret");
+	if (host_key && (!strcmp(c->s->h->dhchap_key, host_key) ||
+			 !strcmp("none", host_key))) {
+		free(host_key);
+		host_key = NULL;
+	}
+	if (host_key)
+		c->dhchap_key = host_key;
 	c->dhchap_ctrl_key = nvme_get_ctrl_attr(c, "dhchap_ctrl_secret");
 	if (c->dhchap_ctrl_key && !strcmp(c->dhchap_ctrl_key, "none")) {
 		free(c->dhchap_ctrl_key);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -876,6 +876,21 @@ const char *nvme_ctrl_get_host_traddr(nvme_ctrl_t c);
 const char *nvme_ctrl_get_host_iface(nvme_ctrl_t c);
 
 /**
+ * nvme_ctrl_get_dhchap_host_key() - Return host key
+ * @c:	Controller to be checked
+ *
+ * Return: DH-HMAC-CHAP host key or NULL if not set
+ */
+const char *nvme_ctrl_get_dhchap_host_key(nvme_ctrl_t c);
+
+/**
+ * nvme_ctrl_set_dhchap_host_key() - Set host key
+ * @c:		Host for which the key should be set
+ * @key:	DH-HMAC-CHAP Key to set or NULL to clear existing key
+ */
+void nvme_ctrl_set_dhchap_host_key(nvme_ctrl_t c, const char *key);
+
+/**
  * nvme_ctrl_get_dhchap_key() - Return controller key
  * @c:	Controller for which the key should be set
  *


### PR DESCRIPTION
The json config schema already defines a DHCHAP host key on the controller level, so add the infrastructure for parsing and setting it. And while we're at it fixup the json config schema to define the DHCHAP key on the host level.

Fixes: #426