### PR TITLE
nvme-tree: avoid segfault if auth keys are unavailable

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1184,7 +1184,8 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	c->serial = nvme_get_ctrl_attr(c, "serial");
 	c->sqsize = nvme_get_ctrl_attr(c, "sqsize");
 	host_key = nvme_get_ctrl_attr(c, "dhchap_secret");
-	if (host_key && (!strcmp(c->s->h->dhchap_key, host_key) ||
+	if (host_key && c->s && c->s->h && c->s->h->dhchap_key &&
+			(!strcmp(c->s->h->dhchap_key, host_key) ||
 			 !strcmp("none", host_key))) {
 		free(host_key);
 		host_key = NULL;


### PR DESCRIPTION
Seeing multiple segfaults in nvme_configure_ctrl() when the
respective controller attributes (including auth keys) are
unavailable. For e.g. attempting a nvme connect with bidirectional
auth hits the following segfault:

nvme connect -t tcp -w 192.168.1.16 -a 192.168.1.116 -n
nqn.1992-08.com.netapp:sn.48391d66c0a611ecaaa5d039ea165514:subsystem.subsys_CLIENT116
-S DHHC-1:01:k+fO3MFyRpOwrPTUQh0ewZI58uf8bwn5H9RnHle4Q8U37aJe:
-C DHHC-1:03:KEVxLQLJxugDXw/tWm9VmZuas38ath9HWzpq+cDprHafC4yuVg+McEQgEltOJAIIziNfWWKaw8mpPrnSQqqQuHKE5zQ=:
Segmentation fault (core dumped)

In another instance, a segfault is seen if no keys are specified
in the nvme connect:

nvme connect -t tcp -w 192.168.1.16 -a 192.168.1.116
-n nqn.1992-08.com.netapp:sn.48391d66c0a611ecaaa5d039ea165514:subsystem.subsys_CLIENT116
Segmentation fault (core dumped)

Avoid these segfaults by checking if the respective controller attributes
(including auth keys) are available before dereferencing them.

Fixes: 6614a55 ("Parse dhchap_host_key at controller level")

Signed-off-by: Martin George <marting@netapp.com>