### PR TITLE
doc: Install pre-compiled man pages to the correct path

### DIFF
--- a/doc/list-pre-compiled.sh
+++ b/doc/list-pre-compiled.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for i in man/*.2; do
+  echo $i
+done

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -85,7 +85,10 @@ if want_docs != 'false'
       endforeach
     else
       if want_docs == 'all' or want_docs == 'man'
-        install_subdir('man', install_dir: mandir)
+        list_pre_compiled = find_program('list-pre-compiled.sh')
+        m = run_command(list_pre_compiled, check: true)
+        man_pages = m.stdout().strip().split('\n')
+        install_data(man_pages, install_dir: mandir)
       endif
     endif
   endif


### PR DESCRIPTION
The install_subdir('man', ...) command installs the man pages under
$mandir/man/ instead of $mandir. Use and external script to get the
list of man pages to avoid having to list all the man pages
explicitly.

Signed-off-by: Daniel Wagner <dwagner@suse.de>