### PR TITLE
json-schema: add dhchap_key details to host section

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -29,6 +29,10 @@
 		    "description": "NVMe host symbolic name",
 		    "type": "string"
 		},
+		"dhchap_key": {
+		    "description": "Host DH-HMAC-CHAP key",
+		    "type": "string"
+		},
 		"required": [ "hostnqn" ],
 		"subsystems": {
 		    "description": "Array of NVMe subsystem properties",


### PR DESCRIPTION
One can set the dhchap_key in the host section as well of the config JSON file. So update the JSON schema to reflect the same.

Signed-off-by: Martin George <marting@netapp.com>