### PR TITLE
examples/mi-mctp: fix warning for possibly uninitialised variable

### DIFF
--- a/examples/mi-mctp.c
+++ b/examples/mi-mctp.c
@@ -661,6 +661,12 @@ static int do_action_endpoint(enum action action, nvme_mi_ep_t ep, int argc, cha
 	case ACTION_CONFIG_SET:
 		rc = do_config_set(ep, argc, argv);
 		break;
+	default:
+		/* This shouldn't be possible, as we should be covering all
+		 * of the enum action options above. Hoever, keep the compilers
+		 * happy and fail gracefully. */
+		fprintf(stderr, "invalid action %d?\n", action);
+		rc = -1;
 	}
 	return rc;
 }


### PR DESCRIPTION
gcc-12 with `-Wuninitialized-var` reports a warning for `mi-mctp`:

    examples/mi-mctp.c: In function ‘do_action_endpoint’:
    examples/mi-mctp.c:665:16: warning: ‘rc’ may be used uninitialized [-Wmaybe-uninitialized]
      665 |         return rc;
          |                ^~
    examples/mi-mctp.c:637:13: note: ‘rc’ was declared here
      637 |         int rc;
          |             ^~

We shouldn't be able to hit this path, but explicitly set rc to an error if we miss an enum case.

Fixes: https://github.com/linux-nvme/libnvme/issues/467

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>