### PR TITLE
fabrics: Add nvmf_get_discovery_log2()

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -340,6 +340,7 @@ LIBNVME_1_0 {
 		nvmf_default_config;
 		nvmf_eflags_str;
 		nvmf_get_discovery_log;
+		nvmf_get_discovery_log2;
 		nvmf_hostid_from_file;
 		nvmf_hostnqn_from_file;
 		nvmf_hostnqn_generate;

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -197,12 +197,51 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
  * nvmf_get_discovery_log() - Return the discovery log page
  * @c:			Discover controller to use
  * @logp:		Pointer to the log page to be returned
- * @max_retries:	maximum number of log page entries to be returned
+ * @max_retries:	Number of retries in case of failure
+ *
+ * The memory allocated for the log page and returned in @logp
+ * must be freed by the caller.
  *
  * Return: 0 on success; on failure -1 is returned and errno is set
  */
 int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 			   int max_retries);
+
+/**
+ * nvmf_get_discovery_log2() - Return the discovery log page
+ * @c:			Discover controller to use
+ * @args:		Argument structure
+ * @logp:		Pointer to the log page to be returned
+ * @max_retries:	Number of retries in case of failure
+ *
+ * The @args parameter is typically set as follows:
+ *
+ * struct nvme_get_log_args args = {
+ * 	.args_size = sizeof(args),
+ * 	.fd = 0,			< Set internally
+ * 	.nsid = NVME_NSID_NONE,
+ * 	.lsp = NVMF_LOG_DISC_LSP_NONE,	< See enum nvmf_get_log_discovery_lsp
+ * 	.lsi = NVME_LOG_LSI_NONE,
+ * 	.uuidx = NVME_UUID_NONE,
+ * 	.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+ * 	.result = NULL,
+ * 	.lid = NVME_LOG_LID_DISCOVER,
+ * 	.log = NULL,			< Set internally
+ * 	.len = 0,			< Set internally
+ * 	.csi = NVME_CSI_NVM,
+ * 	.rae = false,			< Set internally
+ * 	.ot = false,
+ * };
+ *
+ * The memory allocated for the returned log page (@logp) must
+ * be freed by the caller.
+ *
+ * Return: 0 on success; on failure -1 is returned and errno is set
+ */
+int nvmf_get_discovery_log2(nvme_ctrl_t c,
+			    struct nvme_get_log_args *args,
+			    struct nvmf_discovery_log **logp,
+			    int max_retries);
 
 /**
  * nvmf_hostnqn_generate() - Generate a machine specific host nqn

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4857,6 +4857,34 @@ enum nvmf_tcp_sectype {
 };
 
 /**
+ * enum nvmf_get_log_discovery_lid_support - Discovery log specific support
+ * @NVMF_LOG_DISC_LID_NONE:	None
+ * @NVMF_LOG_DISC_LID_EXTDLPES:	Extended Discovery Log Page Entries Supported
+ * @NVMF_LOG_DISC_LID_PLEOS:	Port Local Entries Only Supported
+ * @NVMF_LOG_DISC_LID_ALLSUBES:	All NVM Subsystem Entries Supported
+ */
+enum nvmf_get_log_discovery_lid_support {
+	NVMF_LOG_DISC_LID_NONE		= 0,
+	NVMF_LOG_DISC_LID_EXTDLPES	= (1 << 0),
+	NVMF_LOG_DISC_LID_PLEOS		= (1 << 1),
+	NVMF_LOG_DISC_LID_ALLSUBES	= (1 << 2),
+};
+
+/**
+ * enum nvmf_get_log_discovery_lsp - Discovery log specific field
+ * @NVMF_LOG_DISC_LSP_NONE:	None
+ * @NVMF_LOG_DISC_LSP_EXTDLPE:	Extended Discovery Log Page Entries
+ * @NVMF_LOG_DISC_LSP_PLEO:	Port Local Entries Only
+ * @NVMF_LOG_DISC_LSP_ALLSUBE:	All NVM Subsystem Entries
+ */
+enum nvmf_get_log_discovery_lsp {
+	NVMF_LOG_DISC_LSP_NONE		= 0,
+	NVMF_LOG_DISC_LSP_EXTDLPE	= (1 << 0),
+	NVMF_LOG_DISC_LSP_PLEO		= (1 << 1),
+	NVMF_LOG_DISC_LSP_ALLSUBE	= (1 << 2),
+};
+
+/**
  * struct nvmf_discovery_log - Discovery Log Page (Log Identifier 70h)
  * @genctr:  Generation Counter (GENCTR): Indicates the version of the discovery
  *	     information, starting at a value of 0h. For each change in the


### PR DESCRIPTION
TP8010 introduces new values for the Log page Specific field (LSP) in the "Get Discovery Log Page" command. Previously, the LSP field was unused and set to 0. Now, the LSP can carry the following values, which can be OR'ed.
```
enum nvmf_get_log_discovery_lsp {
	NVMF_LOG_DISC_LSP_NONE		= 0,
	NVMF_LOG_DISC_LSP_EXTDLPE	= (1 << 0), // Extended Discovery Log Page Entries
	NVMF_LOG_DISC_LSP_PLEO		= (1 << 1), // Port Local Entries Only
	NVMF_LOG_DISC_LSP_ALLSUBE	= (1 << 2), // All NVM Subsystem Entries
};
```
The existing API used to issue the "Get Discovery Log Page" command, `nvmf_get_discovery_log()`, does not allow specifying the LSP and always sets it to 0. This pull request introduces `nvmf_get_discovery_log2()`, which takes an `args` parameter allowing users to specify every field of the "Get Discovery Log Page" command and providing a more generic API. 

To determine which of the above LSP features a Discovery Controller supports, TP8010 extends the "Get supported log pages" command for LID=70h (Discovery) by adding the following definitions (e.g. `PLEOS` -> `PLEO Supported`). 
```
enum nvmf_get_log_discovery_lid_support {
	NVMF_LOG_DISC_LID_NONE		= 0,
	NVMF_LOG_DISC_LID_EXTDLPES	= (1 << 0),
	NVMF_LOG_DISC_LID_PLEOS		= (1 << 1),
	NVMF_LOG_DISC_LID_ALLSUBES	= (1 << 2),
};
```
Signed-off-by: Martin Belanger <martin.belanger@dell.com>