### PR TITLE
github workflows: Add armhf & powerpc64le cross builds

### DIFF
--- a/.github/cross/ubuntu-armhf.txt
+++ b/.github/cross/ubuntu-armhf.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = '/usr/bin/arm-linux-gnueabihf-gcc'
+ar = '/usr/arm-linux-gnueabihf/bin/ar'
+strip = '/usr/arm-linux-gnueabihf/bin/strip'
+pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
+ld = '/usr/bin/arm-linux/gnueabihf-ld'
+
+[properties]
+root = '/usr/arm-linux-gnueabihf'
+has_function_printf = true
+skip_sanity_check = true
+
+[host_machine]
+system = 'linux'
+cpu_family = 'arm'
+cpu = 'armv7'
+endian = 'little'

--- a/.github/cross/ubuntu-ppc64le.txt
+++ b/.github/cross/ubuntu-ppc64le.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = '/usr/bin/powerpc64le-linux-gnu-gcc'
+ar = '/usr/powerpc64le-linux-gnu/bin/ar'
+strip = '/usr/powerpc64le-linux-gnu/bin/strip'
+pkgconfig = '/usr/bin/powerpc64le-linux-gnu-pkg-config'
+ld = '/usr/bin/powerpc64le-linux-gnu-ld'
+
+[properties]
+root = '/usr/powerpc64le-linux-gnu'
+has_function_printf = true
+skip_sanity_check = true
+
+[host_machine]
+system = 'linux'
+cpu_family = 'ppc64'
+cpu = ''
+endian = 'little'

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -30,6 +30,36 @@ jobs:
           name: Linux_Meson_Testlog
           path: build/meson-logs/testlog.txt
 
+  build-cross-armhf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up arm architecture
+        run: |
+          export release=$(lsb_release -c -s)
+          sudo dpkg --add-architecture armhf
+          sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
+          sudo dd of=/etc/apt/sources.list.d/armhf.list <<EOF
+          deb [arch=armhf] http://ports.ubuntu.com/ $release main universe restricted"
+          deb [arch=armhf] http://ports.ubuntu.com/ $release-updates main universe restricted"
+          EOF
+          sudo apt update
+      - name: install armhf compiler
+        run: sudo apt install gcc-arm-linux-gnueabihf pkg-config
+      - name: install libraries
+        run: sudo apt install uuid-dev:armhf libjson-c-dev:armhf
+      - uses: actions/checkout@v3
+      - uses: BSFishy/meson-build@v1.0.3
+        with:
+          # suppress python for now; the python headers currently assume native
+          setup-options: --werror --cross-file=.github/cross/ubuntu-armhf.txt --wrap-mode=nofallback -Dpython=false
+          options: --verbose
+          action: build
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Linux_Meson_Testlog
+          path: build/meson-logs/testlog.txt
+
   build-fallback:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -60,6 +60,36 @@ jobs:
           name: Linux_Meson_Testlog
           path: build/meson-logs/testlog.txt
 
+  build-cross-ppc64le:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up ppc64le architecture
+        run: |
+          export release=$(lsb_release -c -s)
+          sudo dpkg --add-architecture ppc64el
+          sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
+          sudo dd of=/etc/apt/sources.list.d/ppc64el.list <<EOF
+          deb [arch=ppc64el] http://ports.ubuntu.com/ $release main universe restricted"
+          deb [arch=ppc64el] http://ports.ubuntu.com/ $release-updates main universe restricted"
+          EOF
+          sudo apt update
+      - name: install powerpc64le compiler
+        run: sudo apt install gcc-powerpc64le-linux-gnu pkg-config
+      - name: install libraries
+        run: sudo apt install uuid-dev:ppc64el libjson-c-dev:ppc64el
+      - uses: actions/checkout@v3
+      - uses: BSFishy/meson-build@v1.0.3
+        with:
+          # suppress python for now; the python headers currently assume native
+          setup-options: --werror --cross-file=.github/cross/ubuntu-ppc64le.txt --wrap-mode=nofallback -Dpython=false
+          options: --verbose
+          action: build
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Linux_Meson_Testlog
+          path: build/meson-logs/testlog.txt
+
   build-fallback:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This RFC change adds a github workflow for a cross-compile of libnvme on armhf & powerpc64le We use a similar setup to the build-distro job, but install a suitable cross compiler and provide a cross config to meson.

We currently setup with -Dpython=false, as the setup-python@v4 seems to assume a native python build. We may be able to remove this later.

The suitability of this will depend on the resources available for actions; doing some test runs on a private repo shows an execution time of about 1 min 15 sec per cross build - a little less than the build-static job.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>