### PR TITLE
mi: Add firmware download and commit commands

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -6,6 +6,8 @@ LIBNVME_MI_1_2 {
 		nvme_mi_admin_ns_attach;
 		nvme_mi_admin_format_nvm;
 		nvme_mi_admin_sanitize_nvm;
+		nvme_mi_admin_fw_download;
+		nvme_mi_admin_fw_commit;
 };
 
 LIBNVME_MI_1_1 {

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,3 +1,13 @@
+LIBNVME_MI_1_2 {
+	global:
+		nvme_mi_admin_get_features;
+		nvme_mi_admin_set_features;
+		nvme_mi_admin_ns_mgmt;
+		nvme_mi_admin_ns_attach;
+		nvme_mi_admin_format_nvm;
+		nvme_mi_admin_sanitize_nvm;
+};
+
 LIBNVME_MI_1_1 {
 	global:
 		nvme_mi_create_root;
@@ -14,12 +24,6 @@ LIBNVME_MI_1_1 {
 		nvme_mi_mi_subsystem_health_status_poll;
 		nvme_mi_admin_identify_partial;
 		nvme_mi_admin_get_log;
-		nvme_mi_admin_get_features;
-		nvme_mi_admin_set_features;
-		nvme_mi_admin_ns_mgmt;
-		nvme_mi_admin_ns_attach;
-		nvme_mi_admin_format_nvm;
-		nvme_mi_admin_sanitize_nvm;
 		nvme_mi_admin_xfer;
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -2345,6 +2345,42 @@ static inline int nvme_mi_admin_ns_detach_ctrls(nvme_mi_ctrl_t ctrl, __u32 nsid,
 }
 
 /**
+ * nvme_mi_admin_fw_download() - Download part or all of a firmware image to
+ * the controller
+ * @ctrl: Controller to send firmware data to
+ * @args: &struct nvme_fw_download_args argument structure
+ *
+ * The Firmware Image Download command downloads all or a portion of an image
+ * for a future update to the controller. The Firmware Image Download command
+ * downloads a new image (in whole or in part) to the controller.
+ *
+ * The image may be constructed of multiple pieces that are individually
+ * downloaded with separate Firmware Image Download commands. Each Firmware
+ * Image Download command includes a Dword Offset and Number of Dwords that
+ * specify a dword range.
+ *
+ * The new firmware image is not activated as part of the Firmware Image
+ * Download command. Use the nvme_mi_admin_fw_commit() to activate a newly
+ * downloaded image.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+int nvme_mi_admin_fw_download(nvme_mi_ctrl_t ctrl,
+			      struct nvme_fw_download_args *args);
+
+/**
+ * nvme_mi_admin_fw_commit() - Commit firmware using the specified action
+ * @ctrl: Controller to send firmware data to
+ * @args: &struct nvme_fw_download_args argument structure
+ *
+ * The Firmware Commit command modifies the firmware image or Boot Partitions.
+ *
+ * Return: 0 on success, non-zero on failure
+ */
+int nvme_mi_admin_fw_commit(nvme_mi_ctrl_t ctrl,
+			    struct nvme_fw_commit_args *args);
+
+/**
  * nvme_mi_admin_format_nvm() - Format NVMe namespace
  * @ctrl: Controller to send command to
  * @args: Format NVM command arguments


### PR DESCRIPTION
This change adds MI implementations for the Firmware Download and Firmware Commit admin commands, as well as a couple of tests.

As usual, these are designed to match the ioctl API.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>