### PR TITLE
fabrics: Add nvmf_get_discovery_wargs()

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -4,6 +4,7 @@ LIBNVME_1_2 {
 	global:
 		nvme_ctrl_get_dhchap_host_key;
 		nvme_ctrl_set_dhchap_host_key;
+		nvmf_get_discovery_wargs;
 };
 
 LIBNVME_1_1 {

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -195,14 +195,54 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 
 /**
  * nvmf_get_discovery_log() - Return the discovery log page
- * @c:			Discover controller to use
+ * @c:			Discovery controller to use
  * @logp:		Pointer to the log page to be returned
- * @max_retries:	maximum number of log page entries to be returned
+ * @max_retries:	Number of retries in case of failure
+ *
+ * The memory allocated for the log page and returned in @logp
+ * must be freed by the caller using free().
+ *
+ * Note: Consider using nvmf_get_discovery_wargs() instead.
  *
  * Return: 0 on success; on failure -1 is returned and errno is set
  */
 int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 			   int max_retries);
+
+/**
+ * struct nvme_get_discovery_args - Arguments for nvmf_get_discovery_wargs()
+ * @c:			Discovery controller
+ * @args_size:		Length of the structure
+ * @max_retries:	Number of retries in case of failure
+ * @result:		The command completion result from CQE dword0
+ * @timeout:		Timeout in ms (default: NVME_DEFAULT_IOCTL_TIMEOUT)
+ * @lsp:		Log specific field (See enum nvmf_log_discovery_lsp)
+ */
+struct nvme_get_discovery_args {
+	nvme_ctrl_t c;
+	int args_size;
+	int max_retries;
+	__u32 *result;
+	__u32 timeout;
+	__u8 lsp;
+};
+
+/**
+ * nvmf_get_discovery_wargs() - Get the discovery log page with args
+ * @args:	Argument structure
+ *
+ * This function is similar to nvmf_get_discovery_log(), but
+ * takes an extensible @args parameter. @args provides more
+ * options than nvmf_get_discovery_log().
+ *
+ * This function performs a get discovery log page (DLP) command
+ * and returns the DLP. The memory allocated for the returned
+ * DLP must be freed by the caller using free().
+ *
+ * Return: Pointer to the discovery log page (to be freed). NULL
+ * on failure and errno is set.
+ */
+struct nvmf_discovery_log *nvmf_get_discovery_wargs(struct nvme_get_discovery_args *args);
 
 /**
  * nvmf_hostnqn_generate() - Generate a machine specific host nqn


### PR DESCRIPTION
TP8010 introduces new values for the Log page Specific field (LSP) in the "Get Discovery Log Page" command. Previously, the LSP field was unused and set to 0. 

This pull request adds function `nvmf_get_discovery_wargs()`. This function is similar to `nvmf_get_discovery_log()`, but takes an extensible "`args`" parameter. `nvmf_get_discovery_wargs()` allows setting more options (including the LSP)  than `nvmf_get_discovery_log()`. 

Signed-off-by: Martin Belanger <martin.belanger@dell.com>