### PR TITLE
python: Use nvmf_get_discovery_wargs()

### DIFF
--- a/libnvme/README.md
+++ b/libnvme/README.md
@@ -10,16 +10,24 @@ import sys
 import pprint
 from libnvme import nvme
 
+def disc_supp_str(disc_log_page_support):
+    d = {
+        nvme.NVMF_LOG_DISC_LID_EXTDLPES: "Extended Discovery Log Page Entry Supported (EXTDLPES)",
+        nvme.NVMF_LOG_DISC_LID_PLEOS:    "Port Local Entries Only Supported (PLEOS)",
+        nvme.NVMF_LOG_DISC_LID_ALLSUBES: "All NVM Subsystem Entries Supported (ALLSUBES)",
+    }
+    return [txt for msk, txt in d.items() if disc_log_page_support & msk]
+
 root = nvme.root()      # This is a singleton
 root.log_level('debug') # Optional: extra debug info
 
 host = nvme.host(root)      # This "may be" a singleton. 
-sybsysnqn  = [string]       # e.g. 'nqn.2014-08.org.nvmexpress.discovery', nvme.NVME_DISC_SUBSYS_NAME, ...
-transport  = [string]       # One of: 'tcp, 'rdma', 'fc', 'loop'.
+subsysnqn  = [string]       # e.g. nvme.NVME_DISC_SUBSYS_NAME, ...
+transport  = [string]       # One of: 'tcp', 'rdma', 'fc', 'loop'.
 traddr     = [IPv4 or IPv6] # e.g. '192.168.10.10', 'fd2e:853b:3cad:e135:506a:65ee:29f2:1b18', ...
 trsvcid    = [string]		# e.g. '8009', '4420', ...
 host_iface = [interface]    # e.g. 'eth1', ens256', ...
-ctrl = nvme.ctrl(subsysnqn=subsysnqn, transport=transport, traddr=traddr, trsvcid=trsvcid, host_iface=host_iface)
+ctrl = nvme.ctrl(root, subsysnqn=subsysnqn, transport=transport, traddr=traddr, trsvcid=trsvcid, host_iface=host_iface)
 
 try:
     cfg = {
@@ -31,8 +39,17 @@ try:
 except Exception as e:
     sys.exit(f'Failed to connect: {e}')
 
+supported_log_pages = ctrl.supported_log_pages()
+if supported_log_pages is not None:
+    disc_log_page_support = supported_log_pages[nvme.NVME_LOG_LID_DISCOVER]
+    print(f"LID {nvme.NVME_LOG_LID_DISCOVER:02x}h (Discovery), supports: {disc_supp_str(disc_log_page_support)}")
+
 try:
-    log_pages = ctrl.discover()
+    if disc_log_page_support and (disc_log_page_support & nvme.NVMF_LOG_DISC_LID_PLEOS):
+        lsp = nvme.NVMF_LOG_DISC_LSP_PLEO
+    else:
+        lsp = 0
+    log_pages = ctrl.discover(lsp=lsp)
     print(pprint.pformat(log_pages))
 except Exception as e:
     sys.exit(f'Failed to retrieve log pages: {e}')
@@ -42,5 +59,8 @@ try:
 except Exception as e:
     sys.exit(f'Failed to disconnect: {e}')
 
+ctrl = None
+host = None
+root = None
 ```
 


### PR DESCRIPTION
Refactor code to use `nvmf_get_discovery_wargs()` which allows setting the LSP field. Needed for TP8010 support (i.e. setting PLEO bit).

Also, added `supported_log_pages()` which is used to determine whether the PLEO bit is supported (PLEOS).

Finally, updated the Python example code that was a bit outdated.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>