### PR TITLE
Init ctrl_id within xfer of libnvme-mi

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -165,6 +165,7 @@ int nvme_mi_admin_xfer(nvme_mi_ctrl_t ctrl,
 	admin_req->hdr.type = NVME_MI_MSGTYPE_NVME;
 	admin_req->hdr.nmp = (NVME_MI_ROR_REQ << 7) |
 				(NVME_MI_MT_ADMIN << 3);
+	admin_req->ctrl_id = cpu_to_le16(ctrl->id);
 	memset(&req, 0, sizeof(req));
 	req.hdr = &admin_req->hdr;
 	req.hdr_len = sizeof(*admin_req);


### PR DESCRIPTION
The xfer() requires a `nvme_mi_ctrl_t ctrl` as input so the ctrl_id should be included in `ctrl` instead of from
`nvme_mi_admin_req_hdr.ctrl_id`.

Signed-off-by: Hao Jiang <jianghao@google.com>