### PR TITLE
libnvme: fix a memory leak in nvme_mi_open_mctp()

### DIFF
--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -515,6 +515,7 @@ nvme_mi_ep_t nvme_mi_open_mctp(nvme_root_t root, unsigned int netid, __u8 eid)
 err_free_ep:
 	errno_save = errno;
 	free(ep);
+	free(mctp);
 	errno = errno_save;
 	return NULL;
 }


### PR DESCRIPTION
If the call to ops.socket() fails, the mctp pointer will be leaked.