### PR TITLE
util: Add simple UUID type

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,10 +52,6 @@ conf.set('PROJECT_VERSION', '"@0@"'.format(meson.project_version()))
 
 conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 
-# Check for libuuid availability
-libuuid_dep = dependency('uuid', required: true, fallback : ['uuid', 'uuid_dep'])
-conf.set('CONFIG_LIBUUID', libuuid_dep.found(), description: 'Is libuuid required?')
-
 # Check for json-c availability
 json_c_dep = dependency('json-c',
 			version: '>=0.13',

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -7,6 +7,9 @@ LIBNVME_1_2 {
 		nvmf_get_discovery_wargs;
 		nvme_get_feature_length2;
 		nvme_ctrl_is_persistent;
+		nvme_uuid_from_string;
+		nvme_uuid_to_string;
+		nvme_uuid_random;
 };
 
 LIBNVME_1_1 {

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,13 +28,11 @@ if conf.get('CONFIG_JSONC')
 endif
 
 deps = [
-    libuuid_dep,
     json_c_dep,
     openssl_dep,
 ]
 
 mi_deps = [
-    libuuid_dep,
     libsystemd_dep,
 ]
 
@@ -68,7 +66,6 @@ pkg.generate(libnvme,
 libnvme_dep = declare_dependency(
     include_directories: ['.'],
     dependencies: [
-      libuuid_dep.partial_dependency(compile_args: true, includes: true),
       json_c_dep.partial_dependency(compile_args: true, includes: true),
     ],
     link_with: libnvme,
@@ -88,9 +85,6 @@ libnvme_mi = library(
 
 libnvme_mi_dep = declare_dependency(
     include_directories: ['.'],
-    dependencies: [
-      libuuid_dep.partial_dependency(compile_args: true, includes: true),
-    ],
     link_with: libnvme_mi,
 )
 
@@ -107,9 +101,6 @@ libnvme_mi_test = library(
 
 libnvme_mi_test_dep = declare_dependency(
     include_directories: ['.'],
-    dependencies: [
-      libuuid_dep.partial_dependency(compile_args: true, includes: true),
-    ],
     link_with: libnvme_mi_test,
 )
 

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -16,8 +16,6 @@
 #include "fabrics.h"
 #include "mi.h"
 
-#include <uuid.h>
-
 
 extern const char *nvme_ctrl_sysfs_dir;
 extern const char *nvme_subsys_sysfs_dir;
@@ -57,7 +55,7 @@ struct nvme_ns {
 
 	uint8_t eui64[8];
 	uint8_t nguid[16];
-	uuid_t  uuid;
+	unsigned char uuid[NVME_UUID_LEN];
 	enum nvme_csi csi;
 };
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1551,9 +1551,9 @@ const uint8_t *nvme_ns_get_nguid(nvme_ns_t n)
 	return n->nguid;
 }
 
-void nvme_ns_get_uuid(nvme_ns_t n, uuid_t out)
+void nvme_ns_get_uuid(nvme_ns_t n, unsigned char out[NVME_UUID_LEN])
 {
-	uuid_copy(out, n->uuid);
+	memcpy(out, n->uuid, NVME_UUID_LEN);
 }
 
 int nvme_ns_identify(nvme_ns_t n, struct nvme_id_ns *ns)

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -15,7 +15,6 @@
 #include <stddef.h>
 
 #include <sys/types.h>
-#include <uuid.h>
 
 #include "ioctl.h"
 #include "util.h"
@@ -521,7 +520,7 @@ const uint8_t *nvme_ns_get_nguid(nvme_ns_t n);
  *
  * Copies the namespace's uuid into @out
  */
-void nvme_ns_get_uuid(nvme_ns_t n, uuid_t out);
+void nvme_ns_get_uuid(nvme_ns_t n, unsigned char out[NVME_UUID_LEN]);
 
 /**
  * nvme_ns_get_sysfs_dir() - sysfs directory of a namespace

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -606,4 +606,36 @@ enum nvme_version {
  */
 const char *nvme_get_version(enum nvme_version type);
 
+#define NVME_UUID_LEN_STRING	37  /* 1b4e28ba-2fa1-11d2-883f-0016d3cca427 + \0 */
+#define NVME_UUID_LEN		16
+
+/**
+ * nvme_uuid_to_string - Return string represenation of encoded UUID
+ * @uuid:	Binary encoded input UUID
+ * @str:	Output string represenation of UUID
+ *
+ * Return: Returns error code if type conversion fails.
+ */
+int nvme_uuid_to_string(unsigned char uuid[NVME_UUID_LEN], char *str);
+
+/**
+ * nvme_uuid_from_string - Return encoded UUID represenation of string UUID
+ * @uuid:	Binary encoded input UUID
+ * @str:	Output string represenation of UUID
+ *
+ * Return: Returns error code if type conversion fails.
+ */
+int nvme_uuid_from_string(const char *str, unsigned char uuid[NVME_UUID_LEN]);
+
+/**
+ * nvme_uuid_random - Generate random UUID
+ * @uuid:       Generated random UUID
+ *
+ * Generate random number according
+ * https://www.rfc-editor.org/rfc/rfc4122#section-4.4
+ *
+ * Return: Returns error code if generating of random number fails.
+ */
+int nvme_uuid_random(unsigned char uuid[NVME_UUID_LEN]);
+
 #endif /* _LIBNVME_UTIL_H */

--- a/test/meson.build
+++ b/test/meson.build
@@ -12,7 +12,7 @@
 main = executable(
     'main-test',
     ['test.c'],
-    dependencies: [libnvme_dep, libuuid_dep],
+    dependencies: [libnvme_dep],
     include_directories: [incdir, internal_incdir]
 )
 
@@ -56,3 +56,12 @@ mi_mctp = executable(
 )
 
 test('mi-mctp', mi_mctp)
+
+uuid = executable(
+    'test-uuid',
+    ['uuid.c'],
+    dependencies: libnvme_dep,
+    include_directories: [incdir, internal_incdir]
+)
+
+test('uuid', uuid)

--- a/test/test.c
+++ b/test/test.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <stdbool.h>
 #include <inttypes.h>
-#include <uuid.h>
 #include <libnvme.h>
 
 #include <ccan/endian/endian.h>
@@ -377,8 +376,8 @@ int main(int argc, char **argv)
 				       nvme_ctrl_get_state(c));
 
 				nvme_ctrl_for_each_ns(c, n) {
-					char uuid_str[40];
-					uuid_t uuid;
+					char uuid_str[NVME_UUID_LEN_STRING];
+					unsigned char uuid[NVME_UUID_LEN];
 					printf("   `- %s lba size:%d lba max:%" PRIu64 "\n",
 					       nvme_ns_get_name(n),
 					       nvme_ns_get_lba_size(n),
@@ -388,7 +387,7 @@ int main(int argc, char **argv)
 					printf(" nguid:");
 					print_hex(nvme_ns_get_nguid(n), 16);
 					nvme_ns_get_uuid(n, uuid);
-					uuid_unparse_lower(uuid, uuid_str);
+					nvme_uuid_to_string(uuid, uuid_str);
 					printf(" uuid:%s csi:%d\n", uuid_str,
 					       nvme_ns_get_csi(n));
 				}

--- a/test/uuid.c
+++ b/test/uuid.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/**
+ * This file is part of libnvme.
+ * Copyright (c) 2022 Daniel Wagner, SUSE Software Solutions
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include <ccan/array_size/array_size.h>
+
+#include <libnvme.h>
+
+static int test_rc;
+
+struct test_data {
+	unsigned char uuid[NVME_UUID_LEN];
+	const char *str;
+};
+
+static struct test_data test_data[] = {
+	{ { 0 },	         "00000000-0000-0000-0000-000000000000" },
+	{ { [0 ... 15] = 0xff }, "ffffffff-ffff-ffff-ffff-ffffffffffff" },
+	{ { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0f, 0x10 },
+				 "00010203-0405-0607-0809-0a0b0c0d0f10" },
+};
+
+static void check_str(const char *exp, const char *res)
+{
+	if (!strcmp(res, exp))
+		return;
+
+	printf("ERROR: got '%s', expected '%s'\n", res, exp);
+
+	test_rc = 1;
+}
+
+static void print_uuid_hex(const unsigned char uuid[NVME_UUID_LEN])
+{
+	for (int i = 0; i < NVME_UUID_LEN; i++)
+		printf("%02x", uuid[i]);
+}
+
+static void check_uuid(unsigned char exp[NVME_UUID_LEN],
+		       unsigned char res[NVME_UUID_LEN])
+{
+	if (!memcmp(exp, res, NVME_UUID_LEN))
+		return;
+
+	printf("ERROR: got '");
+	print_uuid_hex(exp);
+	printf("', expected '");
+	print_uuid_hex(res);
+	printf("'\n");
+}
+
+static void tostr_test(struct test_data *test)
+{
+	char str[NVME_UUID_LEN_STRING];
+
+	if (nvme_uuid_to_string(test->uuid, str)) {
+		test_rc = 1;
+		printf("ERROR: nvme_uuid_to_string() failed\n");
+		return;
+	}
+	check_str(test->str, str);
+}
+
+static void fromstr_test(struct test_data *test)
+{
+
+	unsigned char uuid[NVME_UUID_LEN];
+
+	if (nvme_uuid_from_string(test->str, uuid)) {
+		test_rc = 1;
+		printf("ERROR: nvme_uuid_from_string() failed\n");
+		return;
+	}
+	check_uuid(test->uuid, uuid);
+}
+
+static void random_uuid_test(void)
+{
+	unsigned char uuid1[NVME_UUID_LEN], uuid2[NVME_UUID_LEN];
+	char str1[NVME_UUID_LEN_STRING], str2[NVME_UUID_LEN_STRING];
+
+	if (nvme_uuid_random(uuid1) || nvme_uuid_random(uuid2)) {
+		test_rc = 1;
+		printf("ERROR: nvme_uuid_random() failed\n");
+		return;
+	}
+
+	if (!memcmp(uuid1, uuid2, NVME_UUID_LEN)) {
+		test_rc = 1;
+		printf("ERROR: generated random numbers are equal\n");
+		return;
+	}
+
+	if (nvme_uuid_to_string(uuid1, str1) ||
+	    nvme_uuid_to_string(uuid2, str2)) {
+		test_rc = 1;
+		printf("ERROR: could not stringify randomly generated UUID\n");
+		return;
+	}
+	printf("PASS: generated UUIDs %s %s\n", str1, str2);
+}
+
+int main(void)
+{
+	for (int i = 0; i < ARRAY_SIZE(test_data); i++)
+		tostr_test(&test_data[i]);
+
+	for (int i = 0; i < ARRAY_SIZE(test_data); i++)
+		fromstr_test(&test_data[i]);
+
+	random_uuid_test();
+
+	return test_rc ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
Provide our own UUID type as there is no point to have a dependency on libuuid just for a couple function we use.

Signed-off-by: Daniel Wagner <dwagner@suse.de>