### PR TITLE
mi: fix get_log_page chunked offset check

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -498,7 +498,7 @@ static int __nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl,
 		return -1;
 	}
 
-	if (offset < 0 || offset >= len) {
+	if (offset < 0 || offset >= args->len || offset + len > args->len) {
 		errno = EINVAL;
 		return -1;
 	}


### PR DESCRIPTION
In our get_log_page helper, we're incorrectly checking the requested chunk offset against the chunk len, rather than the overall length - this means we can't query anything but the first chunk.

This change fixes this to check against the overall length instead, and adds an additional check to ensure we're not requesting more than the full data size.

We also add a testcase for the chunking code.

Reported-by: Hao Jiang <jianghao@google.com>
Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>