### PR TITLE
Makefile: add 'make uninstall'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ endif
 install dist: ${BUILD-DIR}
 	cd ${BUILD-DIR} && meson $@
 
+.PHONY: uninstall
+uninstall:
+	cd ${BUILD-DIR} && meson --internal uninstall
+
 .PHONY: test
 test: ${BUILD-DIR}
 	ninja -C ${BUILD-DIR} $@


### PR DESCRIPTION
This PR adds ``make uninstall``.

Example output is provided below, showing how ``make uninstall`` behaves after ``make install``.
Equivalent PR provided for **nvme-cli**: https://github.com/linux-nvme/nvme-cli/pull/1704

**Install**

```
safl@debtop:~/git/libnvme$ make && sudo make install
meson .build
The Meson build system
Version: 0.60.0
Source dir: /home/safl/git/libnvme
Build dir: /home/safl/git/libnvme/.build
Build type: native build
Project name: libnvme
Project version: 1.1
C compiler for the host machine: cc (gcc 10.2.1 "cc (Debian 10.2.1-6) 10.2.1 20210110")
C linker for the host machine: cc ld.bfd 2.35.2
Host machine cpu family: x86_64
Host machine cpu: x86_64
C++ compiler for the host machine: c++ (gcc 10.2.1 "c++ (Debian 10.2.1-6) 10.2.1 20210110")
C++ linker for the host machine: c++ ld.bfd 2.35.2
Found pkg-config: /usr/bin/pkg-config (0.29.2)
Run-time dependency uuid found: YES 2.36.1
Run-time dependency json-c found: YES 0.15
Run-time dependency openssl found: YES 1.1.1k
Found CMake: /usr/bin/cmake (3.18.4)
Run-time dependency libsystemd found: NO (tried pkgconfig and cmake)
Checking if "__builtin_type_compatible_p" : compiles: YES 
Checking if "typeof" : compiles: YES 
Checking if "byteswap.h" : compiles: YES 
Checking if "bswap64" : links: YES 
Checking if "statement-expr" : compiles: YES 
Checking if "isblank" : links: YES 
Checking if "linux/mctp.h" : compiles: NO 
Configuring libnvme.spec using configuration
Configuring config.h using configuration
Program python3 found: YES (/usr/bin/python3)
WARNING: Broken python installation detected. Python files installed by Meson might not be found by python interpreter.
 This warning can be avoided by setting "python.platlibdir" option.
WARNING: Broken python installation detected. Python files installed by Meson might not be found by python interpreter.
 This warning can be avoided by setting "python.purelibdir" option.
Program swig found: NO
Has header "Python.h" with dependency python: YES 
Configuring conf.py using configuration
Configuring api.rst using configuration
Configuring index.rst using configuration
Configuring quickstart.rst using configuration
Configuring installation.rst using configuration
Configuring mi.rst using configuration
Configuring config-schema.json using configuration
Program kernel-doc found: YES (/home/safl/git/libnvme/doc/kernel-doc)
Program kernel-doc-check found: YES (/bin/bash /home/safl/git/libnvme/doc/kernel-doc-check)
Build targets in project: 15

Found ninja-1.10.2.git.kitware.jobserver-1 at /usr/local/bin/ninja
Configuration located in: .build
-------------------------------------------------------
ninja -C .build
ninja: Entering directory `.build'
[51/51] Linking target test/test-cpp
cd .build && meson install
ninja: Entering directory `/home/safl/git/libnvme/.build'
ninja: no work to do.
Installing src/libnvme.so.1.1.0 to /usr/lib/x86_64-linux-gnu
Installing src/libnvme-mi.so.1.1.0 to /usr/lib/x86_64-linux-gnu
Installing /home/safl/git/libnvme/src/libnvme.h to /usr/include
Installing /home/safl/git/libnvme/src/libnvme-mi.h to /usr/include
Installing /home/safl/git/libnvme/src/nvme/api-types.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/fabrics.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/filters.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/ioctl.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/linux.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/log.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/tree.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/types.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/util.h to /usr/include/nvme
Installing /home/safl/git/libnvme/src/nvme/mi.h to /usr/include/nvme
Installing /home/safl/git/libnvme/.build/meson-private/libnvme.pc to /usr/lib/x86_64-linux-gnu/pkgconfig
Installing /home/safl/git/libnvme/.build/meson-private/libnvme-mi.pc to /usr/lib/x86_64-linux-gnu/pkgconfig
```

**Uninstall** (after ``make install``)

```
safl@debtop:~/git/libnvme$ sudo make uninstall
cd .build && meson --internal uninstall
Deleted: /usr/lib/x86_64-linux-gnu/libnvme.so.1.1.0
Deleted: /usr/lib/x86_64-linux-gnu/libnvme.so.1
Deleted: /usr/lib/x86_64-linux-gnu/libnvme.so
Deleted: /usr/lib/x86_64-linux-gnu/libnvme-mi.so.1.1.0
Deleted: /usr/lib/x86_64-linux-gnu/libnvme-mi.so.1
Deleted: /usr/lib/x86_64-linux-gnu/libnvme-mi.so
Deleted: /usr/include/libnvme.h
Deleted: /usr/include/libnvme-mi.h
Deleted: /usr/include/nvme/api-types.h
Deleted: /usr/include/nvme/fabrics.h
Deleted: /usr/include/nvme/filters.h
Deleted: /usr/include/nvme/ioctl.h
Deleted: /usr/include/nvme/linux.h
Deleted: /usr/include/nvme/log.h
Deleted: /usr/include/nvme/tree.h
Deleted: /usr/include/nvme/types.h
Deleted: /usr/include/nvme/util.h
Deleted: /usr/include/nvme/mi.h
Deleted: /usr/lib/x86_64-linux-gnu/pkgconfig/libnvme.pc
Deleted: /usr/lib/x86_64-linux-gnu/pkgconfig/libnvme-mi.pc

Uninstall finished.

Deleted: 20
Failed: 0

Remember that files created by custom scripts have not been removed.
```