### PR TITLE
examples/mi-conf: account for MCTP header in route MTU

### DIFF
--- a/examples/mi-conf.c
+++ b/examples/mi-conf.c
@@ -92,6 +92,13 @@ int set_local_mtu(sd_bus *bus, unsigned int net, uint8_t eid, uint32_t mtu)
 		return -1;
 	}
 
+	/* The NVMe-MI interfaces refer to their MTU as *not* including the
+	 * 4-byte MCTP header, whereas the MCTP specs *do* include it. When
+	 * we're setting the route MTU, we're using to the MCTP-style MTU,
+	 * which needs the extra four bytes included
+	 */
+	mtu += 4;
+
 	rc = sd_bus_call_method(bus, MCTP_DBUS_NAME, ep_path,
 				MCTP_DBUS_EP_IFACE, "SetMTU", &err, &resp,
 				"u", mtu);


### PR DESCRIPTION
The NVMe specs don't include the MCTP header when referring to the MCTP MTUs; we need to do so when setting the Linux route MTU.

This change uses the header-included value when setting the route MTU via mctpd over dbus.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>