### PR TITLE
Rename fallthrough to LIBNVME_FALLTHROUGH

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -742,7 +742,7 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 	default:
 		nvme_msg(h->r, LOG_ERR, "unsupported subtype %d\n",
 			 e->subtype);
-		fallthrough;
+		LIBNVME_FALLTHROUGH;
 	case NVME_NQN_NVME:
 		nvme_ctrl_set_discovery_ctrl(c, false);
 		break;

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -503,7 +503,7 @@ int nvme_get_feature_length2(int fid, __u32 cdw11, enum nvme_data_tfr dir,
 			*len = 0;
 			break;
 		}
-		fallthrough;
+		LIBNVME_FALLTHROUGH;
 	default:
 		return nvme_get_feature_length(fid, cdw11, len);
 	}

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -18,9 +18,12 @@
  */
 
 #if __has_attribute(__fallthrough__)
-# define fallthrough __attribute__((__fallthrough__))
+#define LIBNVME_FALLTHROUGH __attribute__((__fallthrough__))
 #else
-# define fallthrough do {} while (0) /* fallthrough */
+#define LIBNVME_FALLTHROUGH \
+	do                      \
+	{                       \
+	} while (0) /* fallthrough */
 #endif
 
 /**


### PR DESCRIPTION
`fallthrough` is a well-known name that may reused by other libraries. E.g. https://github.com/nlohmann/json/blob/a3e6e26dc83a726b292f5be0492fcc408663ce55/include/nlohmann/thirdparty/hedley/hedley.hpp#L1704

Rename to a local named macro which follows other name convention. E.g: https://github.com/boostorg/config/blob/902273e7380fedaa15f53ea15d0c3d947915fe4f/include/boost/config/detail/suffix.hpp#L1032

Signed-off-by: Hao Jiang <jianghao@google.com>