### PR TITLE
util: Do not expose fallthrough defines

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -186,6 +186,29 @@ conf.set10(
     description: 'Is linux/mctp.h include-able?'
 )
 
+if meson.version().version_compare('>= 0.48')
+  has_fallthrough = cc.has_function_attribute('fallthrough')
+else
+  has_fallthrough = cc.compiles(
+    '''int main(int argc, char **argv) {
+           switch(argc) {
+               case 0:
+                   __attribute__((__fallthrough__));
+               case 1:
+                   return 1;
+           }
+           return 0;
+       }
+    ''',
+    name: 'has fallthrough')
+endif
+
+if has_fallthrough
+  conf.set('fallthrough', '__attribute__((__fallthrough__))')
+else
+  conf.set('fallthrough', 'do {} while (0) /* fallthrough */')
+endif
+
 ################################################################################
 substs = configuration_data()
 substs.set('NAME',    meson.project_name())

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -17,12 +17,6 @@
  * libnvme utility functions
  */
 
-#if __has_attribute(__fallthrough__)
-# define fallthrough __attribute__((__fallthrough__))
-#else
-# define fallthrough do {} while (0) /* fallthrough */
-#endif
-
 /**
  * enum nvme_connect_err - nvme connect error codes
  * @ENVME_CONNECT_RESOLVE:	failed to resolve host


### PR DESCRIPTION
Use meson to detect if the compiler supports the fallthrough attribute and if so just add corresponding define to the private config.h.

This avoid leaking the fallthrough define outside of the projects which can cause consuming projects to fail to compile.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See also #506 