### PR TITLE
 Set log page offset for nvme_{mi}_get_log_telemetry_host

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1461,7 +1461,7 @@ static inline int nvme_get_log_telemetry_host(int fd, __u64 offset,
 			__u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
-		.lpo = 0,
+		.lpo = offset,
 		.result = NULL,
 		.log = log,
 		.args_size = sizeof(args),

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1658,7 +1658,7 @@ static inline int nvme_mi_admin_get_log_telemetry_host(nvme_mi_ctrl_t ctrl,
 						       void *log)
 {
 	struct nvme_get_log_args args = {
-		.lpo = 0,
+		.lpo = offset,
 		.result = NULL,
 		.log = log,
 		.args_size = sizeof(args),


### PR DESCRIPTION
These function do not sett the passed in offset. Fix this.

Fixes #472
