### PR TITLE
build: Update min version of meson to 0.48

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #
 project(
     'libnvme', ['c'],
-    meson_version: '>= 0.47.0',
+    meson_version: '>= 0.48.0',
     version: '1.1',
     license: 'LGPL-2.1-or-later',
     default_options: [


### PR DESCRIPTION
python3.extension_module() is depending on gnu_symbol_visibility. So arguably, this has been from day 0.

Version 0.47 was released on Jul 02, 2018 and 0.48 on Sep 22,
2018. Even Debian oldstable ships 0.49.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #496