### PR TITLE
types: Move enum nvme_data_tfr to types

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -7047,6 +7047,20 @@ enum nvme_fctype {
 };
 
 /**
+ * enum nvme_data_tfr - Data transfer direction of the command
+ * @NVME_DATA_TFR_NO_DATA_TFR:		No data transfer
+ * @NVME_DATA_TFR_HOST_TO_CTRL:		Host to controller
+ * @NVME_DATA_TFR_CTRL_TO_HOST:		Controller to host
+ * @NVME_DATA_TFR_BIDIRECTIONAL:	Bidirectional
+ */
+enum nvme_data_tfr {
+	NVME_DATA_TFR_NO_DATA_TFR	= 0x0,
+	NVME_DATA_TFR_HOST_TO_CTRL	= 0x1,
+	NVME_DATA_TFR_CTRL_TO_HOST	= 0x2,
+	NVME_DATA_TFR_BIDIRECTIONAL	= 0x3,
+};
+
+/**
  * enum nvme_io_opcode - Opcodes for I/O Commands
  * @nvme_cmd_flush:		Flush
  * @nvme_cmd_write:		Write

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -156,20 +156,6 @@ void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
 int nvme_get_feature_length(int fid, __u32 cdw11, __u32 *len);
 
 /**
- * enum nvme_data_tfr - Data transfer direction of the command
- * @NVME_DATA_TFR_NO_DATA_TFR:		No data transfer
- * @NVME_DATA_TFR_HOST_TO_CTRL:		Host to controller
- * @NVME_DATA_TFR_CTRL_TO_HOST:		Controller to host
- * @NVME_DATA_TFR_BIDIRECTIONAL:	Bidirectional
- */
-enum nvme_data_tfr {
-	NVME_DATA_TFR_NO_DATA_TFR,
-	NVME_DATA_TFR_HOST_TO_CTRL,
-	NVME_DATA_TFR_CTRL_TO_HOST,
-	NVME_DATA_TFR_BIDIRECTIONAL
-};
-
-/**
  * nvme_get_feature_length2() - Retreive the command payload length for a
  *			       specific feature identifier
  * @fid:   Feature identifier, see &enum nvme_features_id.


### PR DESCRIPTION
As this is part of the spec, let's move this to the types.h header file.

Signed-off-by: Daniel Wagner <dwagner@suse.de>