### PR TITLE
MI quirk implementation

### DIFF
--- a/doc/mi.rst
+++ b/doc/mi.rst
@@ -13,6 +13,17 @@ Most of the MI API is transport-agnostic, except for the endpoint constructor
 functions. Once an endpoint object (``nvme_mi_ep_t``) is created, the generic
 functions can be used to manage it.
 
+When endpoints are created (through one of the transport-specific functions,
+like ``nvme_mi_open_mctp()``), the endpoint hardware will be probed to
+see if any device-specific workarounds ("quirks") are required. This is
+implemented as an Identify Controller command, requesting a small amount of
+data on controller ID 0.
+
+To suppress this probe, the ``LIBNVME_MI_PROBE_ENABLED`` environment var can be
+set. Values of ``0``, ``false`` and ``disabled`` will disable the probe, and no
+quirks will be applied. Other values, or an unset environment variable, will
+enable the probe.
+
 MCTP Transport
 --------------
 

--- a/doc/mi.rst.in
+++ b/doc/mi.rst.in
@@ -13,6 +13,17 @@ Most of the MI API is transport-agnostic, except for the endpoint constructor
 functions. Once an endpoint object (``nvme_mi_ep_t``) is created, the generic
 functions can be used to manage it.
 
+When endpoints are created (through one of the transport-specific functions,
+like ``nvme_mi_open_mctp()``), the endpoint hardware will be probed to
+see if any device-specific workarounds ("quirks") are required. This is
+implemented as an Identify Controller command, requesting a small amount of
+data on controller ID 0.
+
+To suppress this probe, the ``LIBNVME_MI_PROBE_ENABLED`` environment var can be
+set. Values of ``0``, ``false`` and ``disabled`` will disable the probe, and no
+quirks will be applied. Other values, or an unset environment variable, will
+enable the probe.
+
 MCTP Transport
 --------------
 

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,3 +1,8 @@
+LIBNVME_MI_1_3 {
+	global:
+		nvme_mi_set_probe_enabled;
+};
+
 LIBNVME_MI_1_2 {
 	global:
 		nvme_mi_admin_get_features;

--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -510,6 +510,8 @@ nvme_mi_ep_t nvme_mi_open_mctp(nvme_root_t root, unsigned int netid, __u8 eid)
 	 */
 	ep->timeout = 5000;
 
+	nvme_mi_ep_probe(ep);
+
 	return ep;
 
 err_free_ep:

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -165,7 +165,14 @@ void nvme_mi_ep_probe(struct nvme_mi_ep *ep)
 		goto out_close;
 	}
 
-	/* no quirks defined yet... */
+	/* Samsung MZUL2512: cannot receive commands sent within ~1ms of
+	 * the previous response. Set an inter-command delay of 1.2ms for
+	 * a little extra tolerance.
+	 */
+	if (nvme_mi_compare_vid_mn(ep, &id, 0x144d, "MZUL2512HCJQ")) {
+		ep->quirks |= NVME_QUIRK_MIN_INTER_COMMAND_TIME;
+		ep->inter_command_us = 1200;
+	}
 
 	/* If we're quirking for the inter-command time, record the last
 	 * command time now, so we don't conflict with the just-sent identify.

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -33,6 +33,7 @@ nvme_root_t nvme_mi_create_root(FILE *fp, int log_level)
 	}
 	r->log_level = log_level;
 	r->fp = stderr;
+	r->mi_probe_enabled = true;
 	if (fp)
 		r->fp = fp;
 	list_head_init(&r->hosts);
@@ -48,6 +49,20 @@ void nvme_mi_free_root(nvme_root_t root)
 		nvme_mi_close(ep);
 
 	free(root);
+}
+
+void nvme_mi_set_probe_enabled(nvme_root_t root, bool enabled)
+{
+	root->mi_probe_enabled = enabled;
+}
+
+void nvme_mi_ep_probe(struct nvme_mi_ep *ep)
+{
+	if (!ep->root->mi_probe_enabled)
+		return;
+
+	/* no quirks defined yet, nothing to probe! */
+	ep->quirks = 0;
 }
 
 struct nvme_mi_ep *nvme_mi_init_ep(nvme_root_t root)
@@ -91,6 +106,11 @@ void nvme_mi_ep_set_mprt_max(nvme_mi_ep_t ep, unsigned int mprt_max_ms)
 unsigned int nvme_mi_ep_get_timeout(nvme_mi_ep_t ep)
 {
 	return ep->timeout;
+}
+
+static bool nvme_mi_ep_has_quirk(nvme_mi_ep_t ep, unsigned long quirk)
+{
+	return ep->quirks & quirk;
 }
 
 struct nvme_mi_ctrl *nvme_mi_init_ctrl(nvme_mi_ep_t ep, __u16 ctrl_id)

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -21,6 +21,20 @@
 static const int default_timeout = 1000; /* milliseconds; endpoints may
 					    override */
 
+static bool nvme_mi_probe_enabled_default(void)
+{
+	char *val;
+
+	val = getenv("LIBNVME_MI_PROBE_ENABLED");
+	if (!val)
+		return true;
+
+	return strcmp(val, "0") &&
+		strcasecmp(val, "false") &&
+		strncasecmp(val, "disable", 7);
+
+}
+
 /* MI-equivalent of nvme_create_root, but avoids clashing symbol names
  * when linking against both libnvme and libnvme-mi.
  */
@@ -33,7 +47,7 @@ nvme_root_t nvme_mi_create_root(FILE *fp, int log_level)
 	}
 	r->log_level = log_level;
 	r->fp = stderr;
-	r->mi_probe_enabled = true;
+	r->mi_probe_enabled = nvme_mi_probe_enabled_default();
 	if (fp)
 		r->fp = fp;
 	list_head_init(&r->hosts);

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <time.h>
 
 #include <ccan/array_size/array_size.h>
 #include <ccan/endian/endian.h>
@@ -78,6 +79,62 @@ void nvme_mi_ep_probe(struct nvme_mi_ep *ep)
 	/* no quirks defined yet, nothing to probe! */
 	ep->quirks = 0;
 }
+
+static const int nsec_per_sec = 1000 * 1000 * 1000;
+/* timercmp and timersub, but for struct timespec */
+#define timespec_cmp(a, b, CMP)						\
+	(((a)->tv_sec == (b)->tv_sec)					\
+		? ((a)->tv_nsec CMP (b)->tv_nsec)			\
+		: ((a)->tv_sec CMP (b)->tv_sec))
+
+#define timespec_sub(a, b, result)					\
+	do {								\
+		(result)->tv_sec = (a)->tv_sec - (b)->tv_sec;		\
+		(result)->tv_nsec = (a)->tv_nsec - (b)->tv_nsec;	\
+		if ((result)->tv_nsec < 0) {				\
+			--(result)->tv_sec;				\
+			(result)->tv_nsec += nsec_per_sec;		\
+		}							\
+	} while (0)
+
+static void nvme_mi_insert_delay(struct nvme_mi_ep *ep)
+{
+	struct timespec now, next, delay;
+	int rc;
+
+	if (!ep->last_resp_time_valid)
+		return;
+
+	/* calculate earliest next command time */
+	next.tv_nsec = ep->last_resp_time.tv_nsec + ep->inter_command_us * 1000;
+	next.tv_sec = ep->last_resp_time.tv_sec;
+	if (next.tv_nsec > nsec_per_sec) {
+		next.tv_nsec -= nsec_per_sec;
+		next.tv_sec += 1;
+	}
+
+	rc = clock_gettime(CLOCK_MONOTONIC, &now);
+	if (rc) {
+		/* not much we can do; continue immediately */
+		return;
+	}
+
+	if (timespec_cmp(&now, &next, >=))
+		return;
+
+	timespec_sub(&next, &now, &delay);
+
+	nanosleep(&delay, NULL);
+}
+
+static void nvme_mi_record_resp_time(struct nvme_mi_ep *ep)
+{
+	int rc;
+
+	rc = clock_gettime(CLOCK_MONOTONIC, &ep->last_resp_time);
+	ep->last_resp_time_valid = !rc;
+}
+
 
 struct nvme_mi_ep *nvme_mi_init_ep(nvme_root_t root)
 {
@@ -257,7 +314,14 @@ int nvme_mi_submit(nvme_mi_ep_t ep, struct nvme_mi_req *req,
 	if (ep->transport->mic_enabled)
 		nvme_mi_calc_req_mic(req);
 
+	if (nvme_mi_ep_has_quirk(ep, NVME_QUIRK_MIN_INTER_COMMAND_TIME))
+		nvme_mi_insert_delay(ep);
+
 	rc = ep->transport->submit(ep, req, resp);
+
+	if (nvme_mi_ep_has_quirk(ep, NVME_QUIRK_MIN_INTER_COMMAND_TIME))
+		nvme_mi_record_resp_time(ep);
+
 	if (rc) {
 		nvme_msg(ep->root, LOG_INFO, "transport failure\n");
 		return rc;

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -403,6 +403,17 @@ nvme_root_t nvme_mi_create_root(FILE *fp, int log_level);
  */
 void nvme_mi_free_root(nvme_root_t root);
 
+/**
+ * nvme_mi_set_probe_enabled() - enable/disable the probe for new endpoints
+ * @root: &nvme_root_t object
+ * @enabled: whether to probe new endpoints
+ *
+ * Controls whether newly-created endpoints are probed for quirks on creation.
+ * Defaults to enabled, which results in some initial messaging with the
+ * endpoint to determine model-specific details.
+ */
+void nvme_mi_set_probe_enabled(nvme_root_t root, bool enabled);
+
 /* Top level management object: NVMe-MI Management Endpoint */
 struct nvme_mi_ep;
 

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -187,6 +187,14 @@ struct nvme_mi_transport {
 	int (*check_timeout)(struct nvme_mi_ep *ep, unsigned int timeout);
 };
 
+/* quirks */
+
+/* Set a minimum time between receiving a response from one command and
+ * sending the next request. Some devices may ignore new commands sent too soon
+ * after the previous request, so manually insert a delay
+ */
+#define NVME_QUIRK_MIN_INTER_COMMAND_TIME	(1 << 0)
+
 struct nvme_mi_ep {
 	struct nvme_root *root;
 	const struct nvme_mi_transport *transport;
@@ -197,6 +205,11 @@ struct nvme_mi_ep {
 	unsigned int timeout;
 	unsigned int mprt_max;
 	unsigned long quirks;
+
+	/* inter-command delay, for NVME_QUIRK_MIN_INTER_COMMAND_TIME */
+	unsigned int inter_command_us;
+	struct timespec last_resp_time;
+	bool last_resp_time_valid;
 };
 
 struct nvme_mi_ctrl {

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -125,6 +125,7 @@ struct nvme_root {
 	bool log_pid;
 	bool log_timestamp;
 	bool modified;
+	bool mi_probe_enabled;
 };
 
 int nvme_set_attr(const char *dir, const char *attr, const char *value);
@@ -195,6 +196,7 @@ struct nvme_mi_ep {
 	bool controllers_scanned;
 	unsigned int timeout;
 	unsigned int mprt_max;
+	unsigned long quirks;
 };
 
 struct nvme_mi_ctrl {
@@ -204,6 +206,7 @@ struct nvme_mi_ctrl {
 };
 
 struct nvme_mi_ep *nvme_mi_init_ep(struct nvme_root *root);
+void nvme_mi_ep_probe(struct nvme_mi_ep *ep);
 
 /* for tests, we need to calculate the correct MICs */
 __u32 nvme_mi_crc32_update(__u32 crc, void *data, size_t len);


### PR DESCRIPTION
We have found that some devices need small workarounds ("quirks") for proper MI-channel functionality.

This series introduces a little infrastructure for these changes, triggered by a probe of the Controller's Identify data. Based on that data, we have a new bitmask (`quirks`) in the endpoint structure:

```diff
@@ -195,6 +196,7 @@ struct nvme_mi_ep {
        bool controllers_scanned;
        unsigned int timeout;
        unsigned int mprt_max;
+       unsigned long quirks;
 };
```

which can be queried via a helper:

```c
static bool nvme_mi_ep_has_quirk(nvme_mi_ep_t ep, unsigned long quirk)
```

Using this, we introduce our first quirk: a delay between commands, required by a specific NVMe device:

```c
/* Set a minimum time between receiving a response from one command and
 * sending the next request. Some devices may ignore new commands sent too soon
 * after the previous request, so manually insert a delay
 */
#define NVME_QUIRK_MIN_INTER_COMMAND_TIME	(1 << 0)
```

The probing can be controlled via the MI API, or a new `LIBNVME_MI_PROBE_ENABLED` environment variable, documented in the `mi.rst` file.
