### PR TITLE
mi: Allow zero as a controller ID in nvme_mi_scan_ep

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -140,8 +140,6 @@ int nvme_mi_scan_ep(nvme_mi_ep_t ep, bool force_rescan)
 		__u16 id;
 
 		id = le32_to_cpu(list.identifier[i]);
-		if (!id)
-			continue;
 
 		ctrl = nvme_mi_init_ctrl(ep, id);
 		if (!ctrl)


### PR DESCRIPTION
ctrl_id of 0 should be still considered as valid. Remove the condition check correspondingly.

Signed-off-by: Hao Jiang <jianghao@google.com>