### PR TITLE
Use nvme_get_log_page

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -34,6 +34,12 @@
 /* '0' is interpreted by the kernel to mean 'apply the default timeout' */
 #define NVME_DEFAULT_IOCTL_TIMEOUT 0
 
+/*
+ * 4k is the smallest possible transfer unit, so restricting to 4k
+ * avoids having to check the MDTS value of the controller.
+ */
+#define NVME_LOG_PAGE_PDU_SIZE 4096
+
 /**
  * struct nvme_passthru_cmd - nvme passthrough command structure
  * @opcode:	Operation code, see &enum nvme_io_opcodes and &enum nvme_admin_opcodes
@@ -1259,7 +1265,7 @@ static inline int nvme_get_nsid_log(int fd, bool rae,
 		.ot = false,
 	};
 
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 static inline int nvme_get_log_simple(int fd, enum nvme_cmd_get_log_lid lid,
@@ -1402,7 +1408,7 @@ static inline int nvme_get_log_cmd_effects(int fd, enum nvme_csi csi,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1452,7 +1458,7 @@ static inline int nvme_get_log_create_telemetry_host(int fd,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1488,7 +1494,7 @@ static inline int nvme_get_log_telemetry_host(int fd, __u64 offset,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1525,7 +1531,7 @@ static inline int nvme_get_log_telemetry_ctrl(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1564,7 +1570,7 @@ static inline int nvme_get_log_endurance_group(int fd, __u16 endgid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1596,7 +1602,7 @@ static inline int nvme_get_log_predictable_lat_nvmset(int fd, __u16 nvmsetid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1630,7 +1636,7 @@ static inline int nvme_get_log_predictable_lat_event(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1671,7 +1677,7 @@ static inline int nvme_get_log_ana(int fd, enum nvme_log_ana_lsp lsp, bool rae,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1724,7 +1730,7 @@ static inline int nvme_get_log_lba_status(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1758,7 +1764,7 @@ static inline int nvme_get_log_endurance_grp_evt(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1825,7 +1831,7 @@ static inline int nvme_get_log_boot_partition(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1862,7 +1868,7 @@ static inline int nvme_get_log_discovery(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1894,7 +1900,7 @@ static inline int nvme_get_log_media_unit_stat(int fd, __u16 domid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1926,7 +1932,7 @@ static inline int nvme_get_log_support_cap_config_list(int fd, __u16 domid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -1996,7 +2002,7 @@ static inline int nvme_get_log_zns_changed_zones(int fd, __u32 nsid, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -2030,7 +2036,7 @@ static inline int nvme_get_log_persistent_event(int fd,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log(&args);
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1226,6 +1226,17 @@ static inline int nvme_zns_identify_ctrl(int fd, struct nvme_zns_id_ctrl *id)
  */
 int nvme_get_log(struct nvme_get_log_args *args);
 
+/**
+ * nvme_get_log_page() - Get log page data
+ * @fd:		File descriptor of nvme device
+ * @xfer_len:	Max log transfer size per request to split the total.
+ * @args:	&struct nvme_get_log_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args);
+
 static inline int nvme_get_nsid_log(int fd, bool rae,
 			enum nvme_cmd_get_log_lid lid,
 			__u32 nsid, __u32 len, void *log)

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -117,45 +117,6 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 	return err;
 }
 
-int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args)
-{
-	__u64 offset = 0, xfer, data_len = args->len;
-	bool retain = true;
-	void *ptr = args->log;
-	int ret;
-
-	/*
-	 * 4k is the smallest possible transfer unit, so restricting to 4k
-	 * avoids having to check the MDTS value of the controller.
-	 */
-	do {
-		xfer = data_len - offset;
-		if (xfer > xfer_len)
-			xfer  = xfer_len;
-
-		/*
-		 * Always retain regardless of the RAE parameter until the very
-		 * last portion of this log page so the data remains latched
-		 * during the fetch sequence.
-		 */
-		if (offset + xfer == data_len)
-			retain = args->rae;
-
-		args->lpo = offset;
-		args->len = xfer;
-		args->log = ptr;
-		args->rae = retain;
-		ret = nvme_get_log(args);
-		if (ret)
-			return ret;
-
-		offset += xfer;
-		ptr += xfer;
-	} while (offset < data_len);
-
-	return 0;
-}
-
 static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
 				  struct nvme_telemetry_log **buf, enum nvme_telemetry_da da,
 				  size_t *size)

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -98,17 +98,6 @@ int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size);
 
 /**
- * nvme_get_log_page() - Get log page data
- * @fd:		File descriptor of nvme device
- * @xfer_len:	Max log transfer size per request to split the total.
- * @args:	&struct nvme_get_log_args argument structure
- *
- * Return: The nvme command status if a response was received (see
- * &enum nvme_status_field) or -1 with errno set otherwise.
- */
-int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args);
-
-/**
  * nvme_get_ana_log_len() - Retrieve size of the current ANA log
  * @fd:		File descriptor of nvme device
  * @analen:	Pointer to where the length will be set on success


### PR DESCRIPTION
We use directly nvme_get_log() calls for many of the defined helpers (e.g. nvme_get_log_persistent_event()). Though when the size of the data is really large, nvme_get_log() is not able to transfer the data (size exceeds what the kernel driver fit in a request).

Thus limit the transfer sizes in all helpers to 4k.


Fixes: https://github.com/linux-nvme/libnvme/issues/516