### PR TITLE
mi: fix rc checking

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -703,6 +703,9 @@ int nvme_mi_admin_admin_passthru(nvme_mi_ctrl_t ctrl, __u8 opcode, __u8 flags,
 		return rc;
 
 	rc = nvme_mi_admin_parse_status(&resp, result);
+	if (rc)
+		return rc;
+
 	if (has_read_data && (resp.data_len != data_len)) {
 		errno = EPROTO;
 		return -1;


### PR DESCRIPTION
nvme_mi_admin_admin_passthru forgets to check the rc after nvme_mi_admin_parse_status.

Signed-off-by: Jinliang Wang <jinliangw@google.com>