### PR TITLE
mi: endian fixes

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -334,7 +334,7 @@ int nvme_mi_scan_ep(nvme_mi_ep_t ep, bool force_rescan)
 		struct nvme_mi_ctrl *ctrl;
 		__u16 id;
 
-		id = le32_to_cpu(list.identifier[i]);
+		id = le16_to_cpu(list.identifier[i]);
 
 		ctrl = nvme_mi_init_ctrl(ep, id);
 		if (!ctrl)
@@ -1280,7 +1280,7 @@ static int nvme_mi_read_data(nvme_mi_ep_t ep, __u32 cdw0,
 	req_hdr.hdr.nmp = (NVME_MI_ROR_REQ << 7) |
 		(NVME_MI_MT_MI << 3); /* we always use command slot 0 */
 	req_hdr.opcode = nvme_mi_mi_opcode_mi_data_read;
-	req_hdr.cdw0 = cdw0;
+	req_hdr.cdw0 = cpu_to_le32(cdw0);
 
 	memset(&req, 0, sizeof(req));
 	req.hdr = &req_hdr.hdr;

--- a/test/mi.c
+++ b/test/mi.c
@@ -1353,7 +1353,7 @@ static void test_admin_ns_mgmt_create(struct nvme_mi_ep *ep)
 	assert(!rc);
 	assert(ns == 0x01020304);
 
-	nsid.nsze = 42;
+	nsid.nsze = cpu_to_le64(42);
 	rc = nvme_mi_admin_ns_mgmt_create(ctrl, &nsid, 0, &ns);
 	assert(rc);
 }


### PR DESCRIPTION
We have a couple of endian issues in the mi code: one where we're not converting cdw0 for MI commands, and one where we're using the wrong byte length for an existing conversion. There is also an error in the test suite, where we should be converting the `nsze` field of a `nvme_id_ns`.

This change fixes those, so that the test suite passes on a BE platform (ppc64 in my case).

Fixes: https://github.com/linux-nvme/libnvme/issues/524
Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>