### PR TITLE
Fix spelling mistakes found by lintian

### DIFF
--- a/doc/man/nvme_dev_self_test.2
+++ b/doc/man/nvme_dev_self_test.2
@@ -15,7 +15,7 @@ controller and may include testing of the media associated with namespaces.
 The controller may return a response to this command immediately while
 running the self-test in the background.
 
-Set the 'nsid' field to 0 to not include namepsaces in the test. Set to
+Set the 'nsid' field to 0 to not include namespaces in the test. Set to
 0xffffffff to test all namespaces. All other values tests a specific
 namespace, if present.
 .SH "RETURN"

--- a/doc/man/nvme_get_feature_length.2
+++ b/doc/man/nvme_get_feature_length.2
@@ -1,6 +1,6 @@
 .TH "nvme_get_feature_length" 9 "nvme_get_feature_length" "October 2022" "libnvme API manual" LINUX
 .SH NAME
-nvme_get_feature_length \- Retreive the command payload length for a specific feature identifier
+nvme_get_feature_length \- Retrieve the command payload length for a specific feature identifier
 .SH SYNOPSIS
 .B "int" nvme_get_feature_length
 .BI "(int fid "  ","

--- a/doc/man/nvme_get_feature_length2.2
+++ b/doc/man/nvme_get_feature_length2.2
@@ -1,6 +1,6 @@
 .TH "nvme_get_feature_length2" 9 "nvme_get_feature_length2" "October 2022" "libnvme API manual" LINUX
 .SH NAME
-nvme_get_feature_length2 \- Retreive the command payload length for a specific feature identifier
+nvme_get_feature_length2 \- Retrieve the command payload length for a specific feature identifier
 .SH SYNOPSIS
 .B "int" nvme_get_feature_length2
 .BI "(int fid "  ","

--- a/doc/man/nvme_set_features_host_id.2
+++ b/doc/man/nvme_set_features_host_id.2
@@ -1,6 +1,6 @@
 .TH "nvme_set_features_host_id" 9 "nvme_set_features_host_id" "October 2022" "libnvme API manual" LINUX
 .SH NAME
-nvme_set_features_host_id \- Set enable extended host identifers feature
+nvme_set_features_host_id \- Set enable extended host identifiers feature
 .SH SYNOPSIS
 .B "int" nvme_set_features_host_id
 .BI "(int fd "  ","

--- a/doc/man/nvmf_exat_len.2
+++ b/doc/man/nvmf_exat_len.2
@@ -6,10 +6,10 @@ nvmf_exat_len \- Return length rounded up by 4
 .BI "(size_t val_len "  ");"
 .SH ARGUMENTS
 .IP "val_len" 12
-Value lenght
+Value length
 .SH "DESCRIPTION"
 Return the size in bytes, rounded to a multiple of 4 (e.g., size of
 __u32), of the buffer needed to hold the exat value of size
 \fIval_len\fP.
 .SH "RETURN"
-Lenght rounded up by 4
+Length rounded up by 4

--- a/doc/rst/ioctl.rst
+++ b/doc/rst/ioctl.rst
@@ -2911,7 +2911,7 @@ The nvme command status if a response was received (see
 
 .. c:function:: int nvme_set_features_host_id (int fd, bool exhid, bool save, __u8 *hostid)
 
-   Set enable extended host identifers feature
+   Set enable extended host identifiers feature
 
 **Parameters**
 
@@ -4307,7 +4307,7 @@ controller and may include testing of the media associated with namespaces.
 The controller may return a response to this command immediately while
 running the self-test in the background.
 
-Set the 'nsid' field to 0 to not include namepsaces in the test. Set to
+Set the 'nsid' field to 0 to not include namespaces in the test. Set to
 0xffffffff to test all namespaces. All other values tests a specific
 namespace, if present.
 

--- a/doc/rst/util.rst
+++ b/doc/rst/util.rst
@@ -226,7 +226,7 @@ otherwise.
 
 .. c:function:: int nvme_get_feature_length (int fid, __u32 cdw11, __u32 *len)
 
-   Retreive the command payload length for a specific feature identifier
+   Retrieve the command payload length for a specific feature identifier
 
 **Parameters**
 
@@ -248,7 +248,7 @@ recognize :c:type:`fid`.
 
 .. c:function:: int nvme_get_feature_length2 (int fid, __u32 cdw11, enum nvme_data_tfr dir, __u32 *len)
 
-   Retreive the command payload length for a specific feature identifier
+   Retrieve the command payload length for a specific feature identifier
 
 **Parameters**
 
@@ -433,7 +433,7 @@ usage: int x = round_up(13, sizeof(__u32)); // 13 -> 16
 **Parameters**
 
 ``size_t val_len``
-  Value lenght
+  Value length
 
 **Description**
 
@@ -443,7 +443,7 @@ __u32), of the buffer needed to hold the exat value of size
 
 **Return**
 
-Lenght rounded up by 4
+Length rounded up by 4
 
 
 .. c:function:: __u16 nvmf_exat_size (size_t val_len)

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2409,7 +2409,7 @@ int nvme_set_features_sw_progress(int fd, __u8 pbslc, bool save,
 				  __u32 *result);
 
 /**
- * nvme_set_features_host_id() - Set enable extended host identifers feature
+ * nvme_set_features_host_id() - Set enable extended host identifiers feature
  * @fd:		File descriptor of nvme device
  * @exhid:	Enable Extended Host Identifier
  * @save:	Save value across power states
@@ -3389,7 +3389,7 @@ int nvme_sanitize_nvm(struct nvme_sanitize_nvm_args *args);
  * The controller may return a response to this command immediately while
  * running the self-test in the background.
  *
- * Set the 'nsid' field to 0 to not include namepsaces in the test. Set to
+ * Set the 'nsid' field to 0 to not include namespaces in the test. Set to
  * 0xffffffff to test all namespaces. All other values tests a specific
  * namespace, if present.
  *

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -325,7 +325,7 @@ static const char * const media_status[] = {
 };
 
 static const char * const path_status[] = {
-	[NVME_SC_ANA_INTERNAL_PATH_ERROR] = "Internal Path Error: An internal error specific to the controller processing the commmand prevented completion",
+	[NVME_SC_ANA_INTERNAL_PATH_ERROR] = "Internal Path Error: An internal error specific to the controller processing the command prevented completion",
 	[NVME_SC_ANA_PERSISTENT_LOSS]	  = "Asymmetric Access Persistent Loss: The controller is in a persistent loss state with the requested namespace",
 	[NVME_SC_ANA_INACCESSIBLE]	  = "Asymmetric Access Inaccessible: The controller is in an inaccessible state with the requested namespace",
 	[NVME_SC_ANA_TRANSITION]	  = "Asymmetric Access Transition: The controller is currently transitioning states with the requested namespace",
@@ -559,7 +559,7 @@ static const char * const libnvme_status[] = {
 	[ENVME_CONNECT_INVAL_TR] = "invalid transport type",
 	[ENVME_CONNECT_LOOKUP_SUBSYS_NAME] = "failed to lookup subsystem name",
 	[ENVME_CONNECT_LOOKUP_SUBSYS] = "failed to lookup subsystem",
-	[ENVME_CONNECT_ALREADY] = "already connnected",
+	[ENVME_CONNECT_ALREADY] = "already connected",
 	[ENVME_CONNECT_INVAL] = "invalid arguments/configuration",
 	[ENVME_CONNECT_ADDRINUSE] = "hostnqn already in use",
 	[ENVME_CONNECT_NODEV] = "invalid interface",

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -529,13 +529,13 @@ char *startswith(const char *s, const char *prefix);
 
 /**
  * nvmf_exat_len() - Return length rounded up by 4
- * @val_len: Value lenght
+ * @val_len: Value length
  *
  * Return the size in bytes, rounded to a multiple of 4 (e.g., size of
  * __u32), of the buffer needed to hold the exat value of size
  * @val_len.
  *
- * Return: Lenght rounded up by 4
+ * Return: Length rounded up by 4
  */
 static inline __u16 nvmf_exat_len(size_t val_len)
 {


### PR DESCRIPTION
lintian complains about following spelling mistakes in libnvme 1.2:

```
I: libnvme1: spelling-error-in-binary commmand command [usr/lib/x86_64-linux-gnu/libnvme.so.1.2.0]
I: libnvme1: spelling-error-in-binary connnected connected [usr/lib/x86_64-linux-gnu/libnvme.so.1.2.0]
I: libnvme-dev: typo-in-manual-page Lenght Length [usr/share/man/man2/nvmf_exat_len.2.gz:15]
I: libnvme-dev: typo-in-manual-page Retreive Retrieve [usr/share/man/man2/nvme_get_feature_length.2.gz:3]
I: libnvme-dev: typo-in-manual-page Retreive Retrieve [usr/share/man/man2/nvme_get_feature_length2.2.gz:3]
I: libnvme-dev: typo-in-manual-page identifers identifiers [usr/share/man/man2/nvme_set_features_host_id.2.gz:3]
I: libnvme-dev: typo-in-manual-page lenght length [usr/share/man/man2/nvmf_exat_len.2.gz:9]
I: libnvme-dev: typo-in-manual-page namepsaces namespaces [usr/share/man/man2/nvme_dev_self_test.2.gz:18]
```

Fix all occurrences of those spelling mistakes.