### PR TITLE
build: require meson 0.50.0+

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #
 project(
     'libnvme', ['c'],
-    meson_version: '>= 0.48.0',
+    meson_version: '>= 0.50.0',
     version: '1.2',
     license: 'LGPL-2.1-or-later',
     default_options: [


### PR DESCRIPTION
The Meson buildspec uses features introduced in Meson 0.50.0, but only specifies 0.48.0. Eliminates a Meson warning.

Signed-off-by: nick black <dankamongmen@gmail.com>