### PR TITLE
build: Run cross build test under qemu

### DIFF
--- a/.github/cross/ubuntu-armhf.txt
+++ b/.github/cross/ubuntu-armhf.txt
@@ -4,6 +4,7 @@ ar = '/usr/arm-linux-gnueabihf/bin/ar'
 strip = '/usr/arm-linux-gnueabihf/bin/strip'
 pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
 ld = '/usr/bin/arm-linux/gnueabihf-ld'
+exe_wrapper = '/usr/bin/qemu-arm-static'
 
 [properties]
 root = '/usr/arm-linux-gnueabihf'

--- a/.github/cross/ubuntu-ppc64le.txt
+++ b/.github/cross/ubuntu-ppc64le.txt
@@ -4,6 +4,7 @@ ar = '/usr/powerpc64le-linux-gnu/bin/ar'
 strip = '/usr/powerpc64le-linux-gnu/bin/strip'
 pkgconfig = '/usr/bin/powerpc64le-linux-gnu-pkg-config'
 ld = '/usr/bin/powerpc64le-linux-gnu-ld'
+exe_wrapper = '/usr/bin/qemu-ppc64le-static'
 
 [properties]
 root = '/usr/powerpc64le-linux-gnu'

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -44,7 +44,7 @@ jobs:
           EOF
           sudo apt update
       - name: install armhf compiler
-        run: sudo apt install gcc-arm-linux-gnueabihf pkg-config
+        run: sudo apt install gcc-arm-linux-gnueabihf pkg-config qemu-user-static
       - name: install libraries
         run: sudo apt install uuid-dev:armhf libjson-c-dev:armhf
       - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
           # suppress python for now; the python headers currently assume native
           setup-options: --werror --cross-file=.github/cross/ubuntu-armhf.txt --wrap-mode=nofallback -Dpython=false
           options: --verbose
-          action: build
+          action: test
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -74,7 +74,7 @@ jobs:
           EOF
           sudo apt update
       - name: install powerpc64le compiler
-        run: sudo apt install gcc-powerpc64le-linux-gnu pkg-config
+        run: sudo apt install gcc-powerpc64le-linux-gnu pkg-config qemu-user-static
       - name: install libraries
         run: sudo apt install uuid-dev:ppc64el libjson-c-dev:ppc64el
       - uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
           # suppress python for now; the python headers currently assume native
           setup-options: --werror --cross-file=.github/cross/ubuntu-ppc64le.txt --wrap-mode=nofallback -Dpython=false
           options: --verbose
-          action: build
+          action: test
       - uses: actions/upload-artifact@v3
         if: failure()
         with:


### PR DESCRIPTION
Use qemu-user-static wrapper to run cross compiled tests.

Signed-off-by: Daniel Wagner <dwagner@suse.de>