### PR TITLE
mi: call nvme_mi_close on endpoint error path

### DIFF
--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -516,7 +516,7 @@ nvme_mi_ep_t nvme_mi_open_mctp(nvme_root_t root, unsigned int netid, __u8 eid)
 
 err_free_ep:
 	errno_save = errno;
-	free(ep);
+	nvme_mi_close(ep);
 	free(mctp);
 	errno = errno_save;
 	return NULL;

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -1517,7 +1517,7 @@ void nvme_mi_close(nvme_mi_ep_t ep)
 	nvme_mi_for_each_ctrl_safe(ep, ctrl, tmp)
 		nvme_mi_close_ctrl(ctrl);
 
-	if (ep->transport->close)
+	if (ep->transport && ep->transport->close)
 		ep->transport->close(ep);
 	list_del(&ep->root_entry);
 	free(ep);


### PR DESCRIPTION
We need to do more than free() on endpoint close, so call nvme_mi_close on endpoint creation failure.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>