### PR TITLE
MI: switch from libsdbus to libdbus

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -40,11 +40,11 @@ executable(
     include_directories: [incdir, internal_incdir]
 )
 
-if libsystemd_dep.found()
+if libdbus_dep.found()
     executable(
         'mi-conf',
         ['mi-conf.c'],
-        dependencies: [libnvme_mi_dep, libsystemd_dep],
+        dependencies: [libnvme_mi_dep, libdbus_dep],
         include_directories: [incdir, internal_incdir]
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -89,24 +89,9 @@ if openssl_dep.found()
            description: 'OpenSSL/LibreSSL API version @0@'.format(api_version))
 endif
 
-# Check for libsystemd availability. Optional, only required for MCTP dbus scan
-libsystemd_dep = dependency('libsystemd', version: '>219', required: false)
-if libsystemd_dep.found()
-  # When the user has CFLAGS=-static environment variable set
-  # dependency() will find the shared library libsystemd Thus double
-  # check if we are able to link
-  if not cc.links('''#include <systemd/sd-bus.h>
-                     int main(void) {
-                         struct sd_bus *ret;
-                         return sd_bus_default(&ret);
-                   }
-                   ''',
-                   dependencies: libsystemd_dep,
-                   name: 'libsystemd')
-       libsystemd_dep = declare_dependency()
-  endif
-  conf.set('CONFIG_LIBSYSTEMD', libsystemd_dep.found(), description: 'Is libsystemd(>219) available?')
-endif
+# Check for libdus availability. Optional, only required for MCTP dbus scan
+libdbus_dep = dependency('dbus-1', required: false)
+conf.set('CONFIG_DBUS', libdbus_dep.found(), description: 'Enable dbus support?')
 
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,7 +33,7 @@ deps = [
 ]
 
 mi_deps = [
-    libsystemd_dep,
+    libdbus_dep,
 ]
 
 source_dir = meson.current_source_dir()


### PR DESCRIPTION
libsystemd is not generally available as a static library, and we would like to produce a static nvme-cli. This change switches to libdbus instead.

This requires slightly more boilerplate code for the dbus marshalling/unmarshalling as part of the MCTP endpoint scan, but means we have a simpler upstream lib dependency.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/1734

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>