### PR TITLE
fabrics: Fix uuid_from_dmi_entries() read buffer initialization

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -946,7 +946,7 @@ static int uuid_from_dmi_entries(char *system_uuid)
 	int f;
 	DIR *d;
 	struct dirent *de;
-	char buf[512];
+	char buf[512] = {0};
 
 	system_uuid[0] = '\0';
 	d = opendir(PATH_DMI_ENTRIES);
@@ -964,7 +964,7 @@ static int uuid_from_dmi_entries(char *system_uuid)
 			continue;
 		len = read(f, buf, 512);
 		close(f);
-		if (len < 0)
+		if (len <= 0)
 			continue;
 		if (sscanf(buf, "%d", &type) != 1)
 			continue;
@@ -976,7 +976,7 @@ static int uuid_from_dmi_entries(char *system_uuid)
 			continue;
 		len = read(f, buf, 512);
 		close(f);
-		if (len < 0)
+		if (len <= 0)
 			continue;
 		/* Sigh. https://en.wikipedia.org/wiki/Overengineering */
 		/* DMTF SMBIOS 3.0 Section 7.2.1 System UUID */


### PR DESCRIPTION
Valgrind complaining about accessing uninitialized memory:

==159962== Conditional jump or move depends on uninitialised value(s)
==159962==    at 0x484BCF6: rawmemchr (vg_replace_strmem.c:1564)
==159962==    by 0x4F52B15: _IO_str_init_static_internal (strops.c:41)
==159962==    by 0x4F1DAB1: UnknownInlinedFun (strfile.h:95)
==159962==    by 0x4F1DAB1: __isoc99_sscanf (isoc99_sscanf.c:28)
==159962==    by 0x7B77C97: uuid_from_dmi_entries (fabrics.c:969)
==159962==    by 0x7B84192: UnknownInlinedFun (fabrics.c:1059)
==159962==    by 0x7B84192: nvmf_hostnqn_generate (fabrics.c:1070)