### PR TITLE
tree: Fix leaking struct nvme_ns.generic_name

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1833,6 +1833,7 @@ static nvme_ns_t nvme_ns_open(const char *name)
 close_fd:
 	close(n->fd);
 free_ns:
+	free(n->generic_name);
 	free(n->name);
 	free(n);
 	return NULL;


### PR DESCRIPTION
```
==306445== 96 bytes in 16 blocks are definitely lost in loss record 3,171 of 3,553
==306445==    at 0x484386F: malloc (vg_replace_malloc.c:393)
==306445==    by 0x4FA2F6D: strdup (strdup.c:42)
==306445==    by 0x7B9C477: nvme_ns_set_generic_name (tree.c:1802)
==306445==    by 0x7B9C51B: nvme_ns_open (tree.c:1820)
==306445==    by 0x7B9C606: __nvme_scan_namespace (tree.c:1853)
==306445==    by 0x7B9CA0C: nvme_subsystem_scan_namespace (tree.c:1931)
==306445==    by 0x7B98C81: nvme_subsystem_scan_namespaces (tree.c:496)
==306445==    by 0x7B991BC: nvme_scan_subsystem (tree.c:597)
==306445==    by 0x7B97DA1: nvme_scan_topology (tree.c:118)
==306445==    by 0x7B97FA9: nvme_scan (tree.c:177)
```