### PR TITLE
types: add fdp data structures and helpers

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+LIBNVME_1_3 {
+	global:
+		nvme_io_mgmt_recv;
+		nvme_io_mgmt_send;
+		nvme_fdp_reclaim_unit_handle_status;
+		nvme_fdp_reclaim_unit_handle_update;
+};
+
 LIBNVME_1_2 {
 	global:
 		nvme_ctrl_get_dhchap_host_key;

--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -793,6 +793,50 @@ struct nvme_resv_report_args {
 };
 
 /**
+ * struct nvme_io_mgmt_recv_args - Arguments for the NVMe I/O Management Receive command
+ * @data:	Userspace address of the data
+ * @args_size:	Size of &struct nvme_io_mgmt_recv_args
+ * @fd:		File descriptor of nvme device
+ * @nsid:	Namespace identifier
+ * @data_len:	Length of @data
+ * @timeout:	Timeout in ms
+ * @mos		Management Operation Specific
+ * @mo		Management Operation
+ */
+struct nvme_io_mgmt_recv_args {
+	void *data;
+	int args_size;
+	int fd;
+	__u32 nsid;
+	__u32 data_len;
+	__u32 timeout;
+	__u16 mos;
+	__u8 mo;
+};
+
+/**
+ * struct nvme_io_mgmt_send_args - Arguments for the NVMe I/O Management Send command
+ * @data:	Userspace address of the data
+ * @args_size:	Size of &struct nvme_io_mgmt_send_args
+ * @fd:		File descriptor of nvme device
+ * @nsid:	Namespace identifier
+ * @data_len:	Length of @data
+ * @timeout:	Timeout in ms
+ * @mos		Management Operation Specific
+ * @mo		Management Operation
+ */
+struct nvme_io_mgmt_send_args {
+	void *data;
+	int args_size;
+	int fd;
+	__u32 nsid;
+	__u32 data_len;
+	__u32 timeout;
+	__u16 mos;
+	__u8 mo;
+};
+
+/**
  * struct nvme_zns_mgmt_send_args - Arguments for the NVMe ZNS Management Send command
  * @slba:	Starting logical block address
  * @result:	The command completion result from CQE dword0

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -1897,6 +1897,50 @@ int nvme_resv_report(struct nvme_resv_report_args *args)
 	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
 }
 
+int nvme_io_mgmt_recv(struct nvme_io_mgmt_recv_args *args)
+{
+	__u32 cdw10 = (args->mo & 0xf) | (args->mos & 0xff << 16);
+	__u32 cdw11 = (args->data_len >> 2) - 1;
+
+	struct nvme_passthru_cmd cmd = {
+		.opcode		= nvme_cmd_io_mgmt_recv,
+		.nsid		= args->nsid,
+		.cdw10		= cdw10,
+		.cdw11		= cdw11,
+		.addr		= (__u64)(uintptr_t)args->data,
+		.data_len	= args->data_len,
+		.timeout_ms	= args->timeout,
+	};
+
+	if (args->args_size < sizeof(*args)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return nvme_submit_io_passthru(args->fd, &cmd, NULL);
+}
+
+int nvme_io_mgmt_send(struct nvme_io_mgmt_send_args *args)
+{
+	__u32 cdw10 = (args->mo & 0xf) | ((args->mos & 0xff) << 16);
+
+	struct nvme_passthru_cmd cmd = {
+		.opcode		= nvme_cmd_io_mgmt_send,
+		.nsid		= args->nsid,
+		.cdw10		= cdw10,
+		.addr		= (__u64)(uintptr_t)args->data,
+		.data_len	= args->data_len,
+		.timeout_ms	= args->timeout,
+	};
+
+	if (args->args_size < sizeof(*args)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return nvme_submit_io_passthru(args->fd, &cmd, NULL);
+}
+
 int nvme_zns_mgmt_send(struct nvme_zns_mgmt_send_args *args)
 {
 	__u32 cdw10 = args->slba & 0xffffffff;

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1640,6 +1640,127 @@ static inline int nvme_get_log_predictable_lat_event(int fd, bool rae,
 }
 
 /**
+ * nvme_get_log_fdp_configurations() - Get list of Flexible Data Placement configurations
+ * @fd:		File descriptor of nvme device
+ * @egid:	Endurance group identifier
+ * @offset:	Offset into log page
+ * @len:	Length (in bytes) of provided user buffer to hold the log data
+ * @log:	Log page data buffer
+ */
+static inline int nvme_get_log_fdp_configurations(int fd, __u16 egid,
+			__u32 offset, __u32 len, void *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = offset,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_FDP_CONFIGS,
+		.len = len,
+		.nsid = NVME_NSID_NONE,
+		.csi = NVME_CSI_NVM,
+		.lsi = egid,
+		.lsp = NVME_LOG_LSP_NONE,
+		.uuidx = NVME_UUID_NONE,
+	};
+
+	return nvme_get_log(&args);
+}
+
+/**
+ * nvme_get_log_reclaim_unit_handle_usage() - Get reclaim unit handle usage
+ * @fd:		File descriptor of nvme device
+ * @nsid:	Namespace identifier
+ * @egid:	Endurance group identifier
+ * @offset:	Offset into log page
+ * @len:	Length (in bytes) of provided user buffer to hold the log data
+ * @log:	Log page data buffer
+ */
+static inline int nvme_get_log_reclaim_unit_handle_usage(int fd, __u32 nsid, __u16 egid,
+			__u32 offset, __u32 len, void *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = offset,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_FDP_RUH_USAGE,
+		.len = len,
+		.nsid = nsid,
+		.csi = NVME_CSI_NVM,
+		.lsi = egid,
+		.lsp = NVME_LOG_LSP_NONE,
+		.uuidx = NVME_UUID_NONE,
+	};
+
+	return nvme_get_log(&args);
+}
+
+/**
+ * nvme_get_log_fdp_stats() - Get Flexible Data Placement statistics
+ * @fd:		File descriptor of nvme device
+ * @egid:	Endurance group identifier
+ * @offset:	Offset into log page
+ * @len:	Length (in bytes) of provided user buffer to hold the log data
+ * @log:	Log page data buffer
+ */
+static inline int nvme_get_log_fdp_stats(int fd, __u16 egid, __u32 offset, __u32 len, void *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = offset,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_FDP_STATS,
+		.len = len,
+		.nsid = NVME_NSID_NONE,
+		.csi = NVME_CSI_NVM,
+		.lsi = egid,
+		.lsp = NVME_LOG_LSP_NONE,
+		.uuidx = NVME_UUID_NONE,
+	};
+
+	return nvme_get_log(&args);
+}
+
+/**
+ * nvme_get_log_fdp_events() - Get Flexible Data Placement events
+ * @fd:			File descriptor of nvme device
+ * @egid:		Endurance group identifier
+ * @host_events:	Whether to report host or controller events
+ * @offset:		Offset into log page
+ * @len:		Length (in bytes) of provided user buffer to hold the log data
+ * @log:		Log page data buffer
+ */
+static inline int nvme_get_log_fdp_events(int fd, __u16 egid, bool host_events, __u32 offset,
+		__u32 len, void *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = offset,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_FDP_EVENTS,
+		.len = len,
+		.nsid = NVME_NSID_NONE,
+		.csi = NVME_CSI_NVM,
+		.lsi = egid,
+		.lsp = (__u8)(host_events ? 0x1 : 0x0),
+		.uuidx = NVME_UUID_NONE,
+	};
+
+	return nvme_get_log(&args);
+}
+
+/**
  * nvme_get_log_ana() - Retrieve Asymmetric Namespace Access log page
  * @fd:		File descriptor of nvme device
  * @lsp:	Log specific, see &enum nvme_get_log_ana_lsp
@@ -3603,6 +3724,77 @@ int nvme_resv_release(struct nvme_resv_release_args *args);
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
 int nvme_resv_report(struct nvme_resv_report_args *args);
+
+/**
+ * nvme_io_mgmt_recv() - I/O Management Receive command
+ * @args:	&struct nvme_io_mgmt_recv_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_io_mgmt_recv(struct nvme_io_mgmt_recv_args *args);
+
+/**
+ * nvme_fdp_reclaim_unit_handle_status() - Get reclaim unit handle status
+ * @fd:		File descriptor of nvme device
+ * @nsid:	Namespace identifier
+ * @data_len:	Length of response buffer
+ * @data:	Response buffer
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+static inline int nvme_fdp_reclaim_unit_handle_status(int fd, __u32 nsid,
+			__u32 data_len, void *data)
+{
+	struct nvme_io_mgmt_recv_args args = {
+		.data = data,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.nsid = nsid,
+		.data_len = data_len,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.mo = NVME_IO_MGMT_RECV_RUH_STATUS,
+	};
+
+	return nvme_io_mgmt_recv(&args);
+}
+
+/**
+ * nvme_io_mgmt_send() - I/O Management Send command
+ * @args:	&struct nvme_io_mgmt_send_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_io_mgmt_send(struct nvme_io_mgmt_send_args *args);
+
+/**
+ * nvme_fdp_reclaim_unit_handle_update() - Update a list of reclaim unit handles
+ * @fd:		File descriptor of nvme device
+ * @nsid:	Namespace identifier
+ * @npids:	Number of placement identifiers
+ * @pids:	List of placement identifiers
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+static inline int nvme_fdp_reclaim_unit_handle_update(int fd, __u32 nsid,
+			unsigned int npids, __u16 *pids)
+{
+	struct nvme_io_mgmt_send_args args = {
+		.data = (void *)pids,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.nsid = nsid,
+		.data_len = (__u32)(npids * sizeof(__u16)),
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.mos = (__u16)(npids - 1),
+		.mo = NVME_IO_MGMT_SEND_RUH_UPDATE,
+	};
+
+	return nvme_io_mgmt_send(&args);
+}
 
 /**
  * nvme_zns_mgmt_send() - ZNS management send command


### PR DESCRIPTION
Add required data structures and helper functions for TP4146 ("Flexible Data Placement").

These data structures and helpers are used by the associated [changes for nvme-cli](https://github.com/linux-nvme/nvme-cli/pull/1756), to be PR'ed separately.