### PR TITLE
mi: add timeout functions to .map

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,7 +1,9 @@
 LIBNVME_MI_1_3 {
 	global:
-		nvme_mi_set_probe_enabled;
 		nvme_mi_admin_admin_passthru;
+		nvme_mi_ep_get_timeout;
+		nvme_mi_ep_set_timeout;
+		nvme_mi_set_probe_enabled;
 };
 
 LIBNVME_MI_1_2 {


### PR DESCRIPTION
Need to export nvme_mi_ep_set_timeout and nvme_mi_ep_get_timeout. These two functions were defined but left over in .map file.

Signed-off-by: Hao Jiang <jianghao@google.com>