### PR TITLE
build: Add support to build libdbus as fallback

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install libraries
-        run: sudo apt-get install libjson-c-dev
+        run: sudo apt-get install libjson-c-dev libdbus-1-dev
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install libraries
-        run: sudo apt-get install libjson-c-dev lcov
+        run: sudo apt-get install libjson-c-dev libdbus-1-dev lcov
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:

--- a/meson.build
+++ b/meson.build
@@ -89,8 +89,24 @@ if openssl_dep.found()
            description: 'OpenSSL/LibreSSL API version @0@'.format(api_version))
 endif
 
-# Check for libdus availability. Optional, only required for MCTP dbus scan
-libdbus_dep = dependency('dbus-1', required: false)
+if get_option('libdbus').disabled()
+    libdbus_dep = dependency('', required: false)
+else
+    # Check for libdus availability. Optional, only required for MCTP dbus scan
+    libdbus_dep = dependency(
+        'dbus-1',
+        required: true,
+        fallback: ['dbus', 'libdbus_dep'],
+        default_options: [
+            'default_library=static',
+            'embedded_tests=false',
+            'message_bus=false',
+            'modular_tests=disabled',
+            'tools=false',
+        ],
+    )
+endif
+
 conf.set('CONFIG_DBUS', libdbus_dep.found(), description: 'Enable dbus support?')
 
 # local (cross-compilable) implementations of ccan configure steps

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,4 @@ option('docs-build', type : 'boolean', value : false,  description : 'build docu
 
 option('python', type : 'combo', choices : ['auto', 'true', 'false'], description : 'Generate libnvme python bindings')
 option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL support')
+option('libdbus', type : 'feature', value: 'auto', description : 'libdbus support')

--- a/subprojects/dbus.wrap
+++ b/subprojects/dbus.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://gitlab.freedesktop.org/dbus/dbus.git
+revision = 218b35a57cdeab667c75d6ef34f901b8ead00056
+depth = 1

--- a/subprojects/uuid.wrap
+++ b/subprojects/uuid.wrap
@@ -1,6 +1,0 @@
-[wrap-git]
-url = https://github.com/util-linux/util-linux.git
-revision = eefff5aac7bce6979c950e3931a578efe03acbac
-
-[provide]
-dependency_names = uuid


### PR DESCRIPTION
The dbus project supports to be consumed via Meson subproject mechanism.  Update the build configuration accordingly.