### PR TITLE
Add setter and getter to track unique discovery controller

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -2,10 +2,12 @@
 
 LIBNVME_1_3 {
 	global:
-		nvme_io_mgmt_recv;
-		nvme_io_mgmt_send;
 		nvme_fdp_reclaim_unit_handle_status;
 		nvme_fdp_reclaim_unit_handle_update;
+		nvme_io_mgmt_recv;
+		nvme_io_mgmt_send;
+		nvme_ctrl_is_unique_discovery_ctrl;
+		nvme_ctrl_set_unique_discovery_ctrl;
 };
 
 LIBNVME_1_2 {

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -459,6 +459,7 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 	}
 	if (!strcmp(nvme_ctrl_get_subsysnqn(c), NVME_DISC_SUBSYS_NAME)) {
 		nvme_ctrl_set_discovery_ctrl(c, true);
+		nvme_ctrl_set_unique_discovery_ctrl(c, false);
 		discovery_nqn = true;
 	}
 	if (nvme_ctrl_is_discovery_ctrl(c))
@@ -738,11 +739,15 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 	switch (e->subtype) {
 	case NVME_NQN_CURR:
 		nvme_ctrl_set_discovered(c, true);
+		nvme_ctrl_set_unique_discovery_ctrl(c,
+				strcmp(e->subnqn, NVME_DISC_SUBSYS_NAME));
 		break;
 	case NVME_NQN_DISC:
 		if (discover)
 			*discover = true;
 		nvme_ctrl_set_discovery_ctrl(c, true);
+		nvme_ctrl_set_unique_discovery_ctrl(c,
+				strcmp(e->subnqn, NVME_DISC_SUBSYS_NAME));
 		break;
 	default:
 		nvme_msg(h->r, LOG_ERR, "unsupported subtype %d\n",
@@ -750,6 +755,7 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 		fallthrough;
 	case NVME_NQN_NVME:
 		nvme_ctrl_set_discovery_ctrl(c, false);
+		nvme_ctrl_set_unique_discovery_ctrl(c, false);
 		break;
 	}
 

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -85,6 +85,7 @@ struct nvme_ctrl {
 	char *cntrltype;
 	char *dctype;
 	bool discovery_ctrl;
+	bool unique_discovery_ctrl;
 	bool discovered;
 	bool persistent;
 	struct nvme_fabrics_config cfg;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -870,6 +870,16 @@ bool nvme_ctrl_is_discovery_ctrl(nvme_ctrl_t c)
 	return c->discovery_ctrl;
 }
 
+void nvme_ctrl_set_unique_discovery_ctrl(nvme_ctrl_t c, bool unique)
+{
+	c->unique_discovery_ctrl = unique;
+}
+
+bool nvme_ctrl_is_unique_discovery_ctrl(nvme_ctrl_t c)
+{
+	return c->unique_discovery_ctrl;
+}
+
 int nvme_ctrl_identify(nvme_ctrl_t c, struct nvme_id_ctrl *id)
 {
 	return nvme_identify_ctrl(nvme_ctrl_get_fd(c), id);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -969,6 +969,25 @@ void nvme_ctrl_set_discovery_ctrl(nvme_ctrl_t c, bool discovery);
 bool nvme_ctrl_is_discovery_ctrl(nvme_ctrl_t c);
 
 /**
+ * nvme_ctrl_set_unique_discovery_ctrl() - Set the 'unique_discovery_ctrl' flag
+ * @c:		Controller to be modified
+ * @unique:	value of the unique_disc_ctrl flag
+ *
+ * Sets the 'unique_discovery_ctrl' flag in @c to specify wheter
+ * @c is a unique discovery controller
+ *
+ */
+void nvme_ctrl_set_unique_discovery_ctrl(nvme_ctrl_t c, bool unique);
+
+/**
+ * nvme_ctrl_is_unique_discovery_ctrl() - Check the 'unique_discovery_ctrl' flag
+ * @c:		Controller to be checked
+ *
+ * Return: Value of the 'unique_discovery_ctrl' flag
+ */
+bool nvme_ctrl_is_unique_discovery_ctrl(nvme_ctrl_t c);
+
+/**
  * nvme_ctrl_identify() - Issues an 'identify controller' command
  * @c:	Controller instance
  * @id:	Identify controller data structure


### PR DESCRIPTION
Adds setter and getter for tracking unique discovery controller. The current library design is a bit awkward, as we have logic outside of the library and inside, so we end up exposing such APIs.

