### PR TITLE
python: trim white spaces from traddr and trsvcid

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -179,9 +179,17 @@ static void PyDict_SetItemStringDecRef(PyObject *p, const char *key, PyObject *v
 }
 %}
 
+%{
+static void strchomp(char *s, int l) {
+    while (l && (s[l] == '\0' || s[l] == ' '))
+      s[l--] = '\0';
+}
+%}
+
 %typemap(out) struct nvmf_discovery_log * {
   struct nvmf_discovery_log *log = $1;
   int numrec = log? log->numrec : 0, i;
+  char *traddr = NULL, *trsvcid = NULL;
   PyObject *obj = PyList_New(numrec);
   if (!obj)
     return NULL;
@@ -229,9 +237,13 @@ static void PyDict_SetItemStringDecRef(PyObject *p, const char *key, PyObject *v
       val = PyLong_FromLong(e->adrfam);
     }
     PyDict_SetItemStringDecRef(entry, "adrfam", val);
-    val = PyUnicode_FromString(e->traddr);
+    strchomp(e->traddr, NVMF_TRADDR_SIZE - 1);
+    strchomp(e->trsvcid, NVMF_TRSVCID_SIZE - 1);
+    traddr = e->traddr;
+    trsvcid = e->trsvcid;
+    val = PyUnicode_FromString(traddr);
     PyDict_SetItemStringDecRef(entry, "traddr", val);
-    val = PyUnicode_FromString(e->trsvcid);
+    val = PyUnicode_FromString(trsvcid);
     PyDict_SetItemStringDecRef(entry, "trsvcid", val);
     val = PyUnicode_FromString(e->subnqn);
     PyDict_SetItemStringDecRef(entry, "subnqn", val);


### PR DESCRIPTION
White spaces are currently not trimmed while parsing the traddr and trsvcid discovery log page entries in the python bindings file, unlike at other places in libnvme/nvme-cli. This causes invalid IP addresses to show up for overlying utilities such as nvme-stas resulting in connection errors as shown below:

stacd[3669]: Stac._config_ctrls_finish()        - discovered_ctrl_list = [{'transport': 'rdma',
'traddr': '192.168.3.101                                             \x01\x04\x01',
'trsvcid': '4420', 'host-traddr': '', 'host-iface': '',
'subsysnqn': 'nqn.1992-08.com.netapp:sn.f2f8dc578de611ed9d5a00a098fd5d4f:subsystem.s1'}

stacd[3669]: (rdma, 192.168.3.101                                    #001#004#001, 4420,
nqn.1992-08.com.netapp:sn.f2f8dc578de611ed9d5a00a098fd5d4f:subsystem.s1) IP address is not valid

Fix this by appropriately trimming these log entries in the bindings file.

Signed-off-by: Martin George <marting@netapp.com>