### PR TITLE
tree: Add persistent_discovery_ctrl config flag

### DIFF
--- a/doc/config-schema.json.in
+++ b/doc/config-schema.json.in
@@ -33,6 +33,10 @@
 		    "description": "NVMe host symbolic name",
 		    "type": "string"
 		},
+		"persistent_discovery_ctrl": {
+			"description": "Enable/disable Persistent Discovery Controller",
+			"type": "boolean"
+		},
 		"required": [ "hostnqn" ],
 		"subsystems": {
 		    "description": "Array of NVMe subsystem properties",

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -2,12 +2,14 @@
 
 LIBNVME_1_3 {
 	global:
+		nvme_ctrl_is_unique_discovery_ctrl;
+		nvme_ctrl_set_unique_discovery_ctrl;
 		nvme_fdp_reclaim_unit_handle_status;
 		nvme_fdp_reclaim_unit_handle_update;
 		nvme_io_mgmt_recv;
 		nvme_io_mgmt_send;
-		nvme_ctrl_is_unique_discovery_ctrl;
-		nvme_ctrl_set_unique_discovery_ctrl;
+		nvme_host_is_pdc_enabled;
+		nvme_host_set_pdc_enabled;
 };
 
 LIBNVME_1_2 {

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -148,6 +148,9 @@ static void json_parse_host(nvme_root_t r, struct json_object *host_obj)
 	attr_obj = json_object_object_get(host_obj, "hostsymname");
 	if (attr_obj)
 		nvme_host_set_hostsymname(h, json_object_get_string(attr_obj));
+	attr_obj = json_object_object_get(host_obj, "persistent_discovery_ctrl");
+	if (attr_obj)
+		nvme_host_set_pdc_enabled(h, json_object_get_boolean(attr_obj));
 	subsys_array = json_object_object_get(host_obj, "subsystems");
 	if (!subsys_array)
 		return;
@@ -354,6 +357,9 @@ int json_update_config(nvme_root_t r, const char *config_file)
 		if (hostsymname)
 			json_object_object_add(host_obj, "hostsymname",
 					       json_object_new_string(hostsymname));
+		if (h->pdc_enabled_valid)
+			json_object_object_add(host_obj, "persistent_discovery_ctrl",
+					       json_object_new_boolean(h->pdc_enabled));
 		subsys_array = json_object_new_array();
 		nvme_for_each_subsystem(h, s) {
 			json_update_subsys(subsys_array, s);
@@ -492,6 +498,9 @@ int json_dump_tree(nvme_root_t r)
 		if (dhchap_key)
 			json_object_object_add(host_obj, "dhchap_key",
 					       json_object_new_string(dhchap_key));
+		if (h->pdc_enabled_valid)
+			json_object_object_add(host_obj, "persistent_discovery_ctrl",
+					       json_object_new_boolean(h->pdc_enabled));
 		subsys_array = json_object_new_array();
 		nvme_for_each_subsystem(h, s) {
 			json_dump_subsys(subsys_array, s);

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -115,6 +115,9 @@ struct nvme_host {
 	char *hostid;
 	char *dhchap_key;
 	char *hostsymname;
+	bool pdc_enabled;
+	bool pdc_enabled_valid; /* set if pdc_enabled doesn't have an undefined
+				 * value */
 };
 
 struct nvme_root {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -252,6 +252,19 @@ void nvme_host_set_dhchap_key(nvme_host_t h, const char *key)
 		h->dhchap_key = strdup(key);
 }
 
+void nvme_host_set_pdc_enabled(nvme_host_t h, bool enabled)
+{
+	h->pdc_enabled_valid = true;
+	h->pdc_enabled = enabled;
+}
+
+bool nvme_host_is_pdc_enabled(nvme_host_t h, bool fallback)
+{
+	if (h->pdc_enabled_valid)
+		return h->pdc_enabled;
+	return fallback;
+}
+
 nvme_subsystem_t nvme_first_subsystem(nvme_host_t h)
 {
 	return list_top(&h->subsystems, struct nvme_subsystem, entry);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -107,6 +107,28 @@ const char *nvme_host_get_dhchap_key(nvme_host_t h);
 void nvme_host_set_dhchap_key(nvme_host_t h, const char *key);
 
 /**
+ * nvme_host_set_pdc_enabled() - Set Persistent Discovery Controller flag
+ * @h:		Host for which the falg should be set
+ * @enabled:	The bool to set the enabled flag
+ *
+ * When nvme_host_set_pdc_enabled() is not used to set the PDC flag,
+ * nvme_host_is_pdc_enabled() will return the default value which was
+ * passed into the function and not the undefined flag value.
+ */
+void nvme_host_set_pdc_enabled(nvme_host_t h, bool enabled);
+
+/**
+ * nvme_host_is_pdc_enabled() - Is Persistenct Discovery Controller enabled
+ * @h: 		Host which to check if PDC is enabled
+ * @fallback:	The fallback default value of the flag when
+ * 		@nvme_host_set_pdc_enabled has not be used
+ * 		to set the flag.
+ *
+ * Return: true if PDC is enabled for @h, else false
+ */
+bool nvme_host_is_pdc_enabled(nvme_host_t h, bool fallback);
+
+/**
  * nvme_default_host() - Initializes the default host
  * @r:	&nvme_root_t object
  *


### PR DESCRIPTION
Allow to overwrite the system default Persistent Discovery Controller behavior via the config.json file.

Signed-off-by: Daniel Wagner <dwagner@suse.de>