### PR TITLE
build: Fix nss code snippet includes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,7 +199,10 @@ conf.set10(
 conf.set(
     'HAVE_LIBNSS',
     cc.links(
-      '''int main(int argc, char **argv) {
+      '''#include <sys/types.h>
+         #include <sys/socket.h>
+         #include <netdb.h>
+         int main(int argc, char **argv) {
              struct addrinfo hints, *result;
              return getaddrinfo(argv[1], argv[2], &hints, &result);
       }


### PR DESCRIPTION
With hardened distribution CFLAGS the meson code snippet wouldn't compile:

Compiler stderr:
```
  .build/meson-private/tmpy2z1t5q4/testfile.c: In function 'main':
  .build/meson-private/tmpy2z1t5q4/testfile.c:2:30: error: storage size of 'hints' isn't known
      2 |              struct addrinfo hints, *result;
        |                              ^~~~~
  .build/meson-private/tmpy2z1t5q4/testfile.c:3:21: warning: implicit declaration of function 'getaddrinfo' [-Wimplicit-function-declaration]
      3 |              return getaddrinfo(argv[1], argv[2], &hints, &result);
        |                     ^~~~~~~~~~~
```