### PR TITLE
build: Use prefixdir directly on sysconfdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ includedir = join_paths(prefixdir, get_option('includedir'))
 datadir    = join_paths(prefixdir, get_option('datadir'))
 mandir     = join_paths(prefixdir, get_option('mandir'))
 bindir     = join_paths(prefixdir, get_option('bindir'))
-sysconfdir = join_paths(prefixdir, get_option('sysconfdir'))
+sysconfdir = prefixdir + get_option('sysconfdir')
 
 ################################################################################
 conf = configuration_data()


### PR DESCRIPTION
The sysconfdir is an explicit path '/etc' and the muon implementation of join_paths is dropping the prefixdir, thus we need to string concanate the syscondfir path instead of using the join_paths function.

Signed-off-by: Daniel Wagner <dwagner@suse.de>