### PR TITLE
build: Make json-c dependency optional again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,11 +50,14 @@ conf.set('PROJECT_VERSION', '"@0@"'.format(meson.project_version()))
 
 conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 
-# Check for json-c availability
-json_c_dep = dependency('json-c',
-			version: '>=0.13',
-			required: true,
-			fallback : ['json-c', 'json_c_dep'])
+if get_option('json-c').disabled()
+    json_c_dep = dependency('', required: false)
+else
+    json_c_dep = dependency('json-c',
+                            version: '>=0.13',
+                            required: true,
+                            fallback : ['json-c', 'json_c_dep'])
+endif
 conf.set('CONFIG_JSONC', json_c_dep.found(), description: 'Is json-c required?')
 
 # Check for OpenSSL availability

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,3 +10,4 @@ option('docs-build', type : 'boolean', value : false,  description : 'build docu
 option('python', type : 'combo', choices : ['auto', 'true', 'false'], description : 'Generate libnvme python bindings')
 option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL support')
 option('libdbus', type : 'feature', value: 'auto', description : 'libdbus support')
+option('json-c', type : 'feature', value: 'auto', description : 'JSON support')

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,8 +23,10 @@ mi_sources = [
     'nvme/mi-mctp.c',
 ]
 
-if conf.get('CONFIG_JSONC')
+if json_c_dep.found()
     sources += 'nvme/json.c'
+else
+    sources += 'nvme/no-json.c'
 endif
 
 deps = [

--- a/src/nvme/no-json.c
+++ b/src/nvme/no-json.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2023 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include "tree.h"
+
+#include <errno.h>
+
+int json_read_config(nvme_root_t r, const char *config_file)
+{
+	return -ENOTSUP;
+}
+
+int json_update_config(nvme_root_t r, const char *config_file)
+{
+	return -ENOTSUP;
+}
+
+int json_dump_tree(nvme_root_t r)
+{
+	return -ENOTSUP;
+}


### PR DESCRIPTION
Make support for JSON related functionality optional again. Some embedded configuration do not want to have a lot of dependencies.

Signed-off-by: Daniel Wagner <dwagner@suse.de>