### PR TITLE
build: Update dbus.wrap

### DIFF
--- a/subprojects/dbus.wrap
+++ b/subprojects/dbus.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/dbus/dbus.git
-revision = 218b35a57cdeab667c75d6ef34f901b8ead00056
+revision = cd1a9bb09a4e9330f8669fb6d385b1e095f97fc2
 depth = 1


### PR DESCRIPTION
The 'use list for dbus_static_flags' fix has been merged which adds support older version Meson.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

https://gitlab.freedesktop.org/dbus/dbus/-/commit/cd1a9bb09a4e9330f8669fb6d385b1e095f97fc2