### PR TITLE
fabrics: Do not ignore one char whitespace when string sanitizing

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -894,20 +894,20 @@ static void sanitize_discovery_log_entry(struct nvmf_disc_log_entry  *e)
 		switch (e->adrfam) {
 		case NVMF_ADDR_FAMILY_IP4:
 		case NVMF_ADDR_FAMILY_IP6:
-			strchomp(e->traddr, NVMF_TRADDR_SIZE - 1);
-			strchomp(e->trsvcid, NVMF_TRSVCID_SIZE - 1);
+			strchomp(e->traddr, NVMF_TRADDR_SIZE);
+			strchomp(e->trsvcid, NVMF_TRSVCID_SIZE);
 			break;
 		}
 		break;
         case NVMF_TRTYPE_FC:
 		switch (e->adrfam) {
 		case NVMF_ADDR_FAMILY_FC:
-			strchomp(e->traddr, NVMF_TRADDR_SIZE - 1);
+			strchomp(e->traddr, NVMF_TRADDR_SIZE);
 			break;
 		}
 		break;
 	case NVMF_TRTYPE_LOOP:
-		strchomp(e->traddr, NVMF_TRADDR_SIZE - 1);
+		strchomp(e->traddr, NVMF_TRADDR_SIZE);
 		break;
 	}
 }


### PR DESCRIPTION
strchomp() is handling the max length of a string correctly.

Reported-by: calebsander
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #https://github.com/linux-nvme/libnvme/pull/567#issuecomment-1419469773