### PR TITLE
Add nvme mi get log page

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,3 +1,8 @@
+LIBNVME_MI_1_4 {
+        global:
+                nvme_mi_admin_get_log_page;
+};
+
 LIBNVME_MI_1_3 {
 	global:
 		nvme_mi_admin_admin_passthru;

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -438,6 +438,8 @@ int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args)
 	void *ptr = args->log;
 	int ret;
 
+	args->fd = fd;
+
 	/*
 	 * 4k is the smallest possible transfer unit, so restricting to 4k
 	 * avoids having to check the MDTS value of the controller.

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -841,9 +841,10 @@ static int __nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl,
 	return rc;
 }
 
-int nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl, struct nvme_get_log_args *args)
+int nvme_mi_admin_get_log_page(nvme_mi_ctrl_t ctrl, __u32 xfer_size,
+			       struct nvme_get_log_args *args)
 {
-	const size_t max_xfer_size = 4096;
+	const size_t max_xfer_size = xfer_size;
 	off_t xfer_offset;
 	int rc = 0;
 
@@ -885,6 +886,11 @@ int nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl, struct nvme_get_log_args *args)
 		args->len = xfer_offset;
 
 	return rc;
+}
+
+int nvme_mi_admin_get_log(nvme_mi_ctrl_t ctrl, struct nvme_get_log_args *args)
+{
+	return nvme_mi_admin_get_log_page(ctrl, 4096, args);
 }
 
 int nvme_mi_admin_security_send(nvme_mi_ctrl_t ctrl,

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1418,6 +1418,28 @@ static inline int nvme_mi_admin_identify_secondary_ctrl_list(nvme_mi_ctrl_t ctrl
 }
 
 /**
+ * nvme_mi_admin_get_log_page() - Retrieve log page data from controller
+ * @ctrl: Controller to query
+ * @xfer_len: The chunk size of the read
+ * @args: Get Log Page command arguments
+ *
+ * Performs a Get Log Page Admin command as specified by @args. Response data
+ * is stored in @args->data, which should be a buffer of @args->data_len bytes.
+ * Resulting data length is stored in @args->data_len on successful
+ * command completion.
+ *
+ * This request may be implemented as multiple log page commands, in order
+ * to fit within MI message-size limits.
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ *
+ * See: &struct nvme_get_log_args
+ */
+int nvme_mi_admin_get_log_page(nvme_mi_ctrl_t ctrl, __u32 xfer_len,
+			       struct nvme_get_log_args *args);
+
+/**
  * nvme_mi_admin_get_log() - Retrieve log page data from controller
  * @ctrl: Controller to query
  * @args: Get Log Page command arguments


### PR DESCRIPTION
mi: Add nvme_mi_admin_get_log_page

The non MI API has an nvme_get_log_page() function which accepts the
transfer length. In order to be able to use the nvme_get_log_page()
function ins nvme-cli, the MI API needs to provide the same API so that
the transport abstraction wrappers work.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See #https://github.com/linux-nvme/nvme-cli/issues/1818