### PR TITLE
Python test: Check there is no SIGSEGV during garbage collection

### DIFF
--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -62,6 +62,7 @@ if have_python_support
 
     py_tests = [ 
         [ 'create ctrl object', files('tests/create-ctrl-obj.py') ], 
+        [ 'SIGSEGV during gc', files('tests/gc.py') ],
     ]
     foreach test: py_tests
         description = test[0]

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -278,6 +278,9 @@ static void PyDict_SetItemStringDecRef(PyObject *p, const char *key, PyObject *v
   }
   $result = obj;
  };
+
+#define STR_OR_NONE(str) (!(str) ? "None" : str)
+
 struct nvme_root {
   %immutable config_file;
   char *config_file;
@@ -444,11 +447,9 @@ struct nvme_ns {
   void set_symname(const char *hostsymname) {
     nvme_host_set_hostsymname($self, hostsymname);
   }
-  char *__str__() {
-    static char tmp[2048];
 
-    sprintf(tmp, "nvme_host(%s,%s)", $self->hostnqn, $self->hostid);
-    return tmp;
+  PyObject *__str__() {
+    return PyUnicode_FromFormat("nvme.host(%s,%s)", STR_OR_NONE($self->hostnqn), STR_OR_NONE($self->hostid));
   }
   struct host_iter __iter__() {
     struct host_iter ret = { .root = nvme_host_get_root($self),
@@ -514,11 +515,8 @@ struct nvme_ns {
   ~nvme_subsystem() {
     nvme_free_subsystem($self);
   }
-  char *__str__() {
-    static char tmp[1024];
-
-    sprintf(tmp, "nvme_subsystem(%s,%s)", $self->name,$self->subsysnqn);
-    return tmp;
+  PyObject *__str__() {
+    return PyUnicode_FromFormat("nvme.subsystem(%s,%s)", STR_OR_NONE($self->name), STR_OR_NONE($self->subsysnqn));
   }
   struct subsystem_iter __iter__() {
     struct subsystem_iter ret = { .host = nvme_subsystem_get_host($self),
@@ -736,11 +734,8 @@ struct nvme_ns {
   ~nvme_ns() {
     nvme_free_ns($self);
   }
-  char *__str__() {
-    static char tmp[1024];
-
-    sprintf(tmp, "nvme_ns(%u)", $self->nsid);
-    return tmp;
+  PyObject *__str__() {
+    return PyUnicode_FromFormat("nvme.ns(%u)", $self->nsid);
   }
   struct ns_iter __iter__() {
     struct ns_iter ret = { .ctrl = nvme_ns_get_ctrl($self),

--- a/libnvme/tests/gc.py
+++ b/libnvme/tests/gc.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+import gc
+import sys
+import pprint
+from libnvme import nvme
+
+root = nvme.root()
+root.log_level('debug')
+print(f'root: {root}')
+
+host = nvme.host(root)
+print(f'host: {host}')
+
+subsystem = host.subsystems()
+print(f'subsystem: {subsystem}')
+
+ctrls = []
+for i in range(10):
+    ctrl = nvme.ctrl(
+        root,
+        subsysnqn=nvme.NVME_DISC_SUBSYS_NAME,
+        transport='loop',
+    )
+    ctrls.append(ctrl)
+    print(f'ctrl {i}: {ctrl}')
+
+ns = subsystem.namespaces() if subsystem is not None else None
+print(f'ns: {ns}')
+
+# Deleting objects in the following order would create a segmentation
+# fault if it weren't for the %pythonappend in nvme.i. This test is to
+# make sure garbage collection is not impacted by object deletion order.
+root = None
+host = None
+
+gc.collect()  # Force garbage collection before controller/subsystem objects get deleted
+
+ctrls = None
+subsystem= None
+ns = None


### PR DESCRIPTION
This is to add a unit test to make sure we don't get a segmentation fault during garbage collection. This is to test that the changes made in PR https://github.com/linux-nvme/libnvme/pull/583 are working as expected and preventing SIGSEGV.

Another commit in this PR makes the `__str__()` methods more Pythonic by returning a `PyObject*` instead of a pointer to a `static char` array.