### PR TITLE
python, meson: Assert that deps are present for -Dpython=true

### DIFF
--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -10,7 +10,7 @@ if want_python != 'false'
     python3 = import('python').find_installation('python3')
     py3_dep = python3.dependency(required: want_python == 'true')
     swig = find_program('swig', required: want_python == 'true')
-    header_found = cc.has_header('Python.h', dependencies: py3_dep)
+    header_found = cc.has_header('Python.h', dependencies: py3_dep, required: want_python == 'true')
     have_python_support = py3_dep.found() and swig.found() and header_found
 else
     have_python_support = false


### PR DESCRIPTION
The option `-Dpython` takes 3 values: `auto`, `true`, or `false`. For `auto` (default), the Python bindings will be built if all the dependencies are met and will be skipped in not. For `true`, the Python bindings MUST be built and therefore missing dependencies need to be treated as errors. For `false`, the Python bindings won't be built whether the dependencies are met or not.

Currently, with `-Dpython=true`, if a dependency required to build the Python bindings is missing, meson silently skips it (i.e. it behaves like `-Dpython=auto`). This PR fixes that issue.