### PR TITLE
update the Expected Logical Block Application Tag and Reference Tag in nvme copy command

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4660,8 +4660,7 @@ struct nvme_copy_range_f1 {
 	__le64			slba;
 	__le16			nlb;
 	__u8			rsvd18[8];
-	__u64			elbt_l;
-	__u16			elbt_h;
+	__u8			elbt[10];
 	__le16			elbat;
 	__le16			elbatm;
 };

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4640,8 +4640,8 @@ struct nvme_copy_range {
 	__le16			nlb;
 	__u8			rsvd18[6];
 	__le32			eilbrt;
-	__le16			elbatm;
 	__le16			elbat;
+	__le16			elbatm;
 };
 
 /**
@@ -4660,9 +4660,10 @@ struct nvme_copy_range_f1 {
 	__le64			slba;
 	__le16			nlb;
 	__u8			rsvd18[8];
-	__u8			elbt[10];
-	__le16			elbatm;
+	__u64			elbt_l;
+	__u16			elbt_h;
 	__le16			elbat;
+	__le16			elbatm;
 };
 
 /**

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -403,15 +403,17 @@ void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
 			  __u64 *slbas, __u64 *eilbrts, __u32 *elbatms,
 			  __u32 *elbats, __u16 nr)
 {
-	int i;
+	int i, j;
 
 	for (i = 0; i < nr; i++) {
 		copy[i].nlb = cpu_to_le16(nlbs[i]);
 		copy[i].slba = cpu_to_le64(slbas[i]);
-		copy[i].elbt_l = cpu_to_le64(eilbrts[i]);
-		copy[i].elbt_h = 0;
 		copy[i].elbatm = cpu_to_le16(elbatms[i]);
 		copy[i].elbat = cpu_to_le16(elbats[i]);
+		for (j = 0; j < 8; j++)
+			copy[i].elbt[9 - j] = (eilbrts[i] >> (8 * j)) & 0xff;
+		copy[i].elbt[1] = 0;
+		copy[i].elbt[0] = 0;
 	}  
 }
 

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -408,7 +408,8 @@ void nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
 	for (i = 0; i < nr; i++) {
 		copy[i].nlb = cpu_to_le16(nlbs[i]);
 		copy[i].slba = cpu_to_le64(slbas[i]);
-		copy[i].elbt[2] = cpu_to_le64(eilbrts[i]);
+		copy[i].elbt_l = cpu_to_le64(eilbrts[i]);
+		copy[i].elbt_h = 0;
 		copy[i].elbatm = cpu_to_le16(elbatms[i]);
 		copy[i].elbat = cpu_to_le16(elbats[i]);
 	}  


### PR DESCRIPTION
 1、The elbatm is behind elbat fields, whitch are defined in section 3.2.2 Copy command.
 2、Storage and Reference Space is declared as an big-endian order, the elbt[10] fields need to reassigned.