### PR TITLE
fabrics: Add nvmf_hostkey_from_file()

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -40,7 +40,29 @@
 		PyDict_SetItemString(p, key, val); /* Does NOT steal reference to val .. */
 		Py_XDECREF(val);                   /* .. therefore decrement ref. count. */
 	}
-%}
+	PyObject *hostnqn_from_file() {
+		char * val = nvmf_hostnqn_from_file();
+		PyObject * obj = PyUnicode_FromString(val);
+		free(val);
+		return obj;
+	}
+	PyObject *hostid_from_file() {
+		char * val = nvmf_hostid_from_file();
+		PyObject * obj = PyUnicode_FromString(val);
+		free(val);
+		return obj;
+	}
+	PyObject *hostkey_from_file() {
+		char * val = nvmf_hostkey_from_file();
+		PyObject * obj = PyUnicode_FromString(val);
+		free(val);
+		return obj;
+	}
+%};
+PyObject *hostnqn_from_file();
+PyObject *hostid_from_file();
+PyObject *hostkey_from_file();
+
 
 %inline %{
 	struct host_iter {
@@ -448,20 +470,32 @@ struct nvme_ns {
 
 @return: None"
 %enddef
+%define SET_KEY_DOCSTRING
+"@brief Set or Clear Host's DHCHAP Key
+
+@param key: A DHCHAP key, or None to clear the key.
+@type key: str|None
+
+@return: None"
+%enddef
 
 %pythonappend nvme_host::nvme_host(struct nvme_root *r,
 				   const char *hostnqn,
 				   const char *hostid,
+				   const char *hostkey,
 				   const char *hostsymname) {
 	self.__parent = r  # Keep a reference to parent to ensure garbage collection happens in the right order}
 %extend nvme_host {
 	nvme_host(struct nvme_root *r,
 		  const char *hostnqn = NULL,
 		  const char *hostid = NULL,
+		  const char *hostkey = NULL,
 		  const char *hostsymname = NULL) {
 		nvme_host_t h = hostnqn ? nvme_lookup_host(r, hostnqn, hostid) : nvme_default_host(r);
 		if (hostsymname)
 			nvme_host_set_hostsymname(h, hostsymname);
+		if (hostkey)
+			nvme_host_set_dhchap_key(h, hostkey);
 		return h;
 	}
 	~nvme_host() {
@@ -472,6 +506,10 @@ struct nvme_ns {
 		nvme_host_set_hostsymname($self, hostsymname);
 	}
 
+	%feature("autodoc", SET_KEY_DOCSTRING) set_key;
+	void set_key(const char *key) {
+		nvme_host_set_dhchap_key($self, key);
+	}
 	PyObject* __str__() {
 		return PyUnicode_FromFormat("nvme.host(%s,%s)", STR_OR_NONE($self->hostnqn), STR_OR_NONE($self->hostid));
 	}

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+LIBNVME_1_4 {
+	global:
+		nvmf_hostkey_from_file;
+};
 
 LIBNVME_1_3 {
 	global:

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -39,9 +39,11 @@
 #include "private.h"
 
 #define NVMF_HOSTID_SIZE	37
+#define NVMF_HOSTKEY_SIZE	104
 
 #define NVMF_HOSTNQN_FILE	SYSCONFDIR "/nvme/hostnqn"
 #define NVMF_HOSTID_FILE	SYSCONFDIR "/nvme/hostid"
+#define NVMF_HOSTKEY_FILE	SYSCONFDIR "/nvme/hostkey"
 
 const char *nvmf_dev = "/dev/nvme-fabrics";
 
@@ -1166,6 +1168,11 @@ char *nvmf_hostnqn_from_file()
 char *nvmf_hostid_from_file()
 {
 	return nvmf_read_file(NVMF_HOSTID_FILE, NVMF_HOSTID_SIZE);
+}
+
+char *nvmf_hostkey_from_file()
+{
+	return nvmf_read_file(NVMF_HOSTKEY_FILE, NVMF_HOSTKEY_SIZE);
 }
 
 /**

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -268,6 +268,14 @@ char *nvmf_hostnqn_from_file();
 char *nvmf_hostid_from_file();
 
 /**
+ * nvmf_hostkey_from_file() - Reads the host key from the config default
+ * 			      location in @SYSCONFDIR@/nvme/.
+ * Return: The host key, or NULL if unsuccessful. If found, the caller
+ * 	   is responsible to free the string.
+ */
+char *nvmf_hostkey_from_file();
+
+/**
  * nvmf_connect_disc_entry() - Connect controller based on the discovery log page entry
  * @h:		Host to which the controller should be connected
  * @e:		Discovery log page entry


### PR DESCRIPTION
The [nvme-cli documentation](https://github.com/linux-nvme/nvme-cli/blob/master/Documentation/nvme-config.txt#L131) mentions that a default Host Key may be defined in /etc/nvme/hostkey. However, there was no function to read that default key. This patch adds the missing function.