### PR TITLE
build: Initialize sysconfdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ project(
         'warning_level=1',
         'buildtype=debug',
         'prefix=/usr/local',
+        'sysconfdir=etc',
     ]
 )
 
@@ -31,7 +32,7 @@ includedir = join_paths(prefixdir, get_option('includedir'))
 datadir    = join_paths(prefixdir, get_option('datadir'))
 mandir     = join_paths(prefixdir, get_option('mandir'))
 bindir     = join_paths(prefixdir, get_option('bindir'))
-sysconfdir = prefixdir + get_option('sysconfdir')
+sysconfdir = join_paths(prefixdir, get_option('sysconfdir'))
 
 ################################################################################
 conf = configuration_data()


### PR DESCRIPTION
The default sysconfdir needs to be initialize so that Meson and muon expand to the same final result using join_paths().

Fixes: f6100dd16b49 ("build: Use prefixdir directly on sysconfdir")

See https://github.com/linux-nvme/libnvme/issues/588