### PR TITLE
build, meson: Print option summary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -252,3 +252,18 @@ subdir('libnvme')
 subdir('test')
 subdir('examples')
 subdir('doc')
+
+################################################################################
+if meson.version().version_compare('>=0.53.0')
+    summary_dict = {
+        'prefixdir':         prefixdir,
+        'sysconfdir':        sysconfdir,
+        'bindir':            bindir,
+        'includedir':        includedir,
+        'datadir':           datadir,
+        'mandir':            mandir,
+        'libdir':            libdir,
+        'build location':    meson.current_build_dir(),
+    }
+    summary(summary_dict)
+endif


### PR DESCRIPTION
This is purely a cosmetic change. 

At the end of the `meson setup` command, display the options so that we can quickly determine that we've configured the project properly. For example:
```bash
...
------------------------------------------------------------
prefixdir:   /usr/local
sysconfdir:  /usr/local/etc
bindir:      /usr/local/bin
includedir:  /usr/local/include
datadir:     /usr/local/share
mandir:      /usr/local/share/man
libdir:      /usr/local/lib/x86_64-linux-gnu
------------------------------------------------------------
CONFIG_DBUS:  false
CONFIG_JSONC:  true
CONFIG_OPENSSL:  true
CONFIG_OPENSSL_3:  true
GIT_VERSION:  "1.3-27-g18d9b3c"
HAVE_BIG_ENDIAN:  0
HAVE_BSWAP_64:  1
HAVE_BUILTIN_TYPES_COMPATIBLE_P:  1
HAVE_BYTESWAP_H:  1
HAVE_ISBLANK:  1
HAVE_LIBNSS:  true
HAVE_LINUX_MCTP_H:  1
HAVE_LITTLE_ENDIAN:  1
HAVE_STATEMENT_EXPR:  1
HAVE_TYPEOF:  1
PROJECT_VERSION:  "1.3"
SYSCONFDIR:  "/usr/local/etc"
fallthrough:  __attribute__((__fallthrough__))
------------------------------------------------------------

```