### PR TITLE
python: Remove redundant host.set_key() method

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -463,15 +463,6 @@ struct nvme_ns {
 @return: None"
 %enddef
 
-%define SET_KEY_DOCSTRING
-"@brief Set or Clear Host's DHCHAP Key
-
-@param key: A DHCHAP key, or None to clear the key.
-@type key: str|None
-
-@return: None"
-%enddef
-
 %pythonappend nvme_host::nvme_host(struct nvme_root *r,
 				   const char *hostnqn,
 				   const char *hostid,
@@ -499,10 +490,6 @@ struct nvme_ns {
 		nvme_host_set_hostsymname($self, hostsymname);
 	}
 
-	%feature("autodoc", SET_KEY_DOCSTRING) set_key;
-	void set_key(const char *key) {
-		nvme_host_set_dhchap_key($self, key);
-	}
 	PyObject* __str__() {
 		return PyUnicode_FromFormat("nvme.host(%s,%s)", STR_OR_NONE($self->hostnqn), STR_OR_NONE($self->hostid));
 	}


### PR DESCRIPTION
I just found out that the DHCHAP Key can be set as a property (e.g. host.dhchap_key = "THE-KEY"). So, we can remove the set_key() method that was added a few days ago.