### PR TITLE
python: Add setter property for controller DHCHAP Key

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -774,6 +774,9 @@ struct nvme_ns {
 	const char *nvme_ctrl_dhchap_key_get(struct nvme_ctrl *c) {
 		return nvme_ctrl_get_dhchap_key(c);
 	}
+	void nvme_ctrl_dhchap_key_set(struct nvme_ctrl *c, const char *key) {
+		nvme_ctrl_set_dhchap_key(c, key);
+	}
 	const char *nvme_ctrl_dhchap_host_key_get(struct nvme_ctrl *c) {
 		return nvme_ctrl_get_dhchap_host_key(c);
 	}


### PR DESCRIPTION
Similar to the way we allow setting/getting the Host DHCHAP key, we need to allow setting/getting the Controller DHCHAP Key. There was already a "getter" property, but the "setter" property was missing.