### PR TITLE
Patches for TLS support (v2)

### DIFF
--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -94,6 +94,10 @@
 		    "description": "Controller DH-HMAC-CHAP key",
 		    "type": "string"
 		},
+		"keyring": {
+		    "description": "Keyring to store and lookup keys",
+		    "type": "string",
+		},
 		"nr_io_queues": {
 		    "description": "Number of I/O queues",
 		    "type": "integer"

--- a/doc/config-schema.json
+++ b/doc/config-schema.json
@@ -98,6 +98,10 @@
 		    "description": "Keyring to store and lookup keys",
 		    "type": "string",
 		},
+		"tls_key": {
+		    "description": "TLS PSK for the connection",
+		    "type": "string",
+		},
 		"nr_io_queues": {
 		    "description": "Number of I/O queues",
 		    "type": "integer"

--- a/doc/rst/fabrics.rst
+++ b/doc/rst/fabrics.rst
@@ -28,6 +28,7 @@ Fabrics-specific definitions.
     int nr_poll_queues;
     int tos;
     int keyring;
+    int tls_key;
     bool duplicate_connect;
     bool disable_sqflow;
     bool hdr_digest;
@@ -72,6 +73,9 @@ Fabrics-specific definitions.
 
 ``keyring``
   Serial number of the keyring to store and lookup keys
+
+``tls_key``
+  Serial number of the TLS PSK for the connection
 
 ``duplicate_connect``
   Allow multiple connections to the same target

--- a/doc/rst/fabrics.rst
+++ b/doc/rst/fabrics.rst
@@ -27,6 +27,7 @@ Fabrics-specific definitions.
     int nr_write_queues;
     int nr_poll_queues;
     int tos;
+    int keyring;
     bool duplicate_connect;
     bool disable_sqflow;
     bool hdr_digest;
@@ -68,6 +69,9 @@ Fabrics-specific definitions.
 
 ``tos``
   Type of service
+
+``keyring``
+  Serial number of the keyring to store and lookup keys
 
 ``duplicate_connect``
   Allow multiple connections to the same target

--- a/meson.build
+++ b/meson.build
@@ -98,6 +98,15 @@ endif
 conf.set('CONFIG_OPENSSL', openssl_dep.found(),
          description: 'Is OpenSSL/LibreSSL available?')
 
+if get_option('keyutils').disabled()
+    keyutils_dep = dependency('', required: false)
+else
+    keyutils_dep = dependency('libkeyutils',
+                              required : get_option('keyutils'))
+endif
+conf.set('CONFIG_KEYUTILS', keyutils_dep.found(),
+         description: 'Is libkeyutils available?')
+
 if get_option('libdbus').disabled()
     libdbus_dep = dependency('', required: false)
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,3 +11,4 @@ option('python', type : 'feature', value: 'auto', description : 'Generate libnvm
 option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL support')
 option('libdbus', type : 'feature', value: 'disabled', description : 'libdbus support')
 option('json-c', type : 'feature', value: 'auto', description : 'JSON support')
+option('keyutils', type: 'feature', value: 'auto', description: 'keyutils support')

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+LIBNVME_1_4 {
+	global:
+		nvme_lookup_keyring;
+};
+
 LIBNVME_1_3 {
 	global:
 		nvme_ctrl_is_unique_discovery_ctrl;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -3,6 +3,9 @@
 LIBNVME_1_4 {
 	global:
 		nvme_lookup_keyring;
+		nvme_describe_key_serial;
+		nvme_lookup_key;
+		nvme_set_keyring;
 		nvme_insert_tls_key;
 };
 

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -3,6 +3,7 @@
 LIBNVME_1_4 {
 	global:
 		nvme_lookup_keyring;
+		nvme_insert_tls_key;
 };
 
 LIBNVME_1_3 {

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,6 +32,7 @@ endif
 deps = [
     json_c_dep,
     openssl_dep,
+    keyutils_dep,
 ]
 
 mi_deps = [

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -217,6 +217,7 @@ static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, fast_io_fail_tmo, 0);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, tos, -1);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, keyring, 0);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, tls_key, 0);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, duplicate_connect, false);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, disable_sqflow, false);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
@@ -245,6 +246,7 @@ void nvmf_update_config(nvme_ctrl_t c, const struct nvme_fabrics_config *cfg)
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, fast_io_fail_tmo, 0);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, tos, -1);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, keyring, 0);
+	UPDATE_CFG_OPTION(ctrl_cfg, cfg, tls_key, 0);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, duplicate_connect, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, disable_sqflow, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
@@ -520,6 +522,8 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 	    (strcmp(transport, "loop") &&
 	     add_int_argument(argstr, "tos", cfg->tos, true)) ||
 	    add_int_argument(argstr, "keyring", cfg->keyring, false) ||
+	    (!strcmp(transport, "tcp") &&
+	     add_int_argument(argstr, "tls_key", cfg->tls_key, false)) ||
 	    add_bool_argument(argstr, "duplicate_connect",
 			      cfg->duplicate_connect) ||
 	    add_bool_argument(argstr, "disable_sqflow",

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -216,6 +216,7 @@ static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,
 			  NVMF_DEF_CTRL_LOSS_TMO);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, fast_io_fail_tmo, 0);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, tos, -1);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, keyring, 0);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, duplicate_connect, false);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, disable_sqflow, false);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
@@ -243,6 +244,7 @@ void nvmf_update_config(nvme_ctrl_t c, const struct nvme_fabrics_config *cfg)
 			  NVMF_DEF_CTRL_LOSS_TMO);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, fast_io_fail_tmo, 0);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, tos, -1);
+	UPDATE_CFG_OPTION(ctrl_cfg, cfg, keyring, 0);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, duplicate_connect, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, disable_sqflow, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
@@ -517,6 +519,7 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 			      cfg->fast_io_fail_tmo, false)) ||
 	    (strcmp(transport, "loop") &&
 	     add_int_argument(argstr, "tos", cfg->tos, true)) ||
+	    add_int_argument(argstr, "keyring", cfg->keyring, false) ||
 	    add_bool_argument(argstr, "duplicate_connect",
 			      cfg->duplicate_connect) ||
 	    add_bool_argument(argstr, "disable_sqflow",

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -36,6 +36,7 @@
  * @nr_poll_queues:	Number of queues to reserve for polling completions
  * @tos:		Type of service
  * @keyring:		Keyring to store and lookup keys
+ * @tls_key:		TLS PSK for the connection
  * @duplicate_connect:	Allow multiple connections to the same target
  * @disable_sqflow:	Disable controller sq flow control
  * @hdr_digest:		Generate/verify header digest (TCP)
@@ -55,6 +56,7 @@ struct nvme_fabrics_config {
 	int nr_poll_queues;
 	int tos;
 	int keyring;
+	int tls_key;
 
 	bool duplicate_connect;
 	bool disable_sqflow;

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -35,6 +35,7 @@
  * @nr_write_queues:	Number of queues to use for exclusively for writing
  * @nr_poll_queues:	Number of queues to reserve for polling completions
  * @tos:		Type of service
+ * @keyring:		Keyring to store and lookup keys
  * @duplicate_connect:	Allow multiple connections to the same target
  * @disable_sqflow:	Disable controller sq flow control
  * @hdr_digest:		Generate/verify header digest (TCP)
@@ -53,6 +54,7 @@ struct nvme_fabrics_config {
 	int nr_write_queues;
 	int nr_poll_queues;
 	int tos;
+	int keyring;
 
 	bool duplicate_connect;
 	bool disable_sqflow;

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -78,6 +78,14 @@ static void json_update_attributes(nvme_ctrl_t c,
 				nvme_set_keyring(cfg->keyring);
 			}
 		}
+		if (!strcmp("tls_key", key_str) && cfg->tls_key == 0) {
+			long key;
+
+			key = nvme_lookup_key("psk",
+					      json_object_get_string(val_obj));
+			if (key)
+				cfg->tls_key = key;
+		}
 	}
 }
 
@@ -321,6 +329,15 @@ static void json_update_port(struct json_object *ctrl_array, nvme_ctrl_t c)
 
 		if (desc) {
 			json_object_object_add(port_obj, "keyring",
+					       json_object_new_string(desc));
+			free(desc);
+		}
+	}
+	if (cfg->tls_key) {
+		char *desc = nvme_describe_key_serial(cfg->tls_key);
+
+		if (desc) {
+			json_object_object_add(port_obj, "tls_key",
 					       json_object_new_string(desc));
 			free(desc);
 		}

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -28,6 +28,10 @@
 #endif
 #endif
 
+#ifdef CONFIG_KEYUTILS
+#include <keyutils.h>
+#endif
+
 #include <ccan/endian/endian.h>
 
 #include "linux.h"
@@ -638,3 +642,23 @@ out:
 	return err;
 }
 #endif /* !CONFIG_OPENSSL_3 */
+
+#ifdef CONFIG_KEYUTILS
+long nvme_lookup_keyring(const char *keyring)
+{
+	key_serial_t keyring_id;
+
+	keyring_id = find_key_by_type_and_desc("keyring", keyring, 0);
+	if (keyring_id < 0)
+		return 0;
+	return keyring_id;
+}
+#else
+long nvme_lookup_keyring(const char *keyring)
+{
+	nvme_msg(NULL, LOG_ERR, "key operations not supported; "\
+		 "recompile with keyutils support.\n");
+	errno = ENOTSUP;
+	return 0;
+}
+#endif

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -791,6 +791,35 @@ long nvme_lookup_keyring(const char *keyring)
 	return keyring_id;
 }
 
+char *nvme_describe_key_serial(long key_id)
+{
+	char *desc;
+
+	if (keyctl_describe_alloc(key_id, &desc) < 0)
+		desc = NULL;
+	return desc;
+}
+
+long nvme_lookup_key(const char *type, const char *identity)
+{
+	key_serial_t key;
+
+	key = keyctl_search(KEY_SPEC_SESSION_KEYRING, type, identity, 0);
+	if (key < 0)
+		return 0;
+	return key;
+}
+
+int nvme_set_keyring(long key_id)
+{
+	long err;
+
+	err = keyctl_link(key_id, KEY_SPEC_SESSION_KEYRING);
+	if (err < 0)
+		return -1;
+	return 0;
+}
+
 long nvme_insert_tls_key(const char *keyring, const char *key_type,
 			 const char *hostnqn, const char *subsysnqn, int hmac,
 			 unsigned char *configured_key, int key_len)
@@ -801,7 +830,7 @@ long nvme_insert_tls_key(const char *keyring, const char *key_type,
 	int ret = -1;
 
 	keyring_id = nvme_lookup_keyring(keyring);
-	if (keyring_id < 0)
+	if (keyring_id == 0)
 		return -1;
 
 	identity = malloc(strlen(hostnqn) + strlen(subsysnqn) + 12);
@@ -847,6 +876,30 @@ long nvme_lookup_keyring(const char *keyring)
 		 "recompile with keyutils support.\n");
 	errno = ENOTSUP;
 	return 0;
+}
+
+char *nvme_describe_key_serial(long key_id)
+{
+	nvme_msg(NULL, LOG_ERR, "key operations not supported; "\
+		 "recompile with keyutils support.\n");
+	errno = ENOTSUP;
+	return NULL;
+}
+
+long nvme_lookup_key(const char *type, const char *identity)
+{
+	nvme_msg(NULL, LOG_ERR, "key operations not supported; "\
+		 "recompile with keyutils support.\n");
+	errno = ENOTSUP;
+	return 0;
+}
+
+int nvme_set_keyring(long key_id)
+{
+	nvme_msg(NULL, LOG_ERR, "key operations not supported; "\
+		 "recompile with keyutils support.\n");
+	errno = ENOTSUP;
+	return -1;
 }
 
 long nvme_insert_tls_key(const char *keyring, const char *key_type,

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -206,6 +206,43 @@ int nvme_gen_dhchap_key(char *hostnqn, enum nvme_hmac_alg hmac,
 long nvme_lookup_keyring(const char *keyring);
 
 /**
+ * nvme_describe_key_serial() - Return key description
+ * @key_id:    Key serial number
+ *
+ * Fetches the description of the key or keyring identified
+ * by the serial number @key_id.
+ *
+ * Return: The description of @key_id or NULL on failure.
+ * The returned string needs to be freed by the caller.
+ */
+char *nvme_describe_key_serial(long key_id);
+
+/**
+ * nvme_lookup_key() - Lookup key serial number
+ * @type:        Key type
+ * @identity:    Key description
+ *
+ * Looks up the serial number of the key @identity
+ * with type %type in the current session keyring.
+ *
+ * Return: The key serial number of the key
+ * or 0 with errno set otherwise.
+ */
+long nvme_lookup_key(const char *type, const char *identity);
+
+/**
+ * nvme_set_keyring() - Link keyring for lookup
+ * @keyring_id:    Keyring id
+ *
+ * Links @keyring_id into the session keyring such that
+ * its keys are available for further key lookups.
+ *
+ * Return: 0 on success, a negative number on error
+ * with errno set.
+ */
+int nvme_set_keyring(long keyring_id);
+
+/**
  * nvme_insert_tls_key() - Derive and insert TLS key
  * @keyring:    Keyring to use
  * @key_type:	Type of the resulting key

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -205,4 +205,24 @@ int nvme_gen_dhchap_key(char *hostnqn, enum nvme_hmac_alg hmac,
  */
 long nvme_lookup_keyring(const char *keyring);
 
+/**
+ * nvme_insert_tls_key() - Derive and insert TLS key
+ * @keyring:    Keyring to use
+ * @key_type:	Type of the resulting key
+ * @hostnqn:	Host NVMe Qualified Name
+ * @subsysnqn:	Subsystem NVMe Qualified Name
+ * @hmac:	HMAC algorithm
+ * @configured_key:	Configured key data to derive the key from
+ * @key_len:	Length of @configured_key
+ *
+ * Derives a 'retained' TLS key as specified in NVMe TCP 1.0a and
+ * stores it as type @key_type in the keyring specified by @keyring.
+ *
+ * Return: The key serial number if the key could be inserted into
+ * the keyring or 0 with errno otherwise.
+ */
+long nvme_insert_tls_key(const char *keyring, const char *key_type,
+			 const char *hostnqn, const char *subsysnqn, int hmac,
+			 unsigned char *configured_key, int key_len);
+
 #endif /* _LIBNVME_LINUX_H */

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -194,4 +194,15 @@ int nvme_gen_dhchap_key(char *hostnqn, enum nvme_hmac_alg hmac,
 			unsigned int key_len, unsigned char *secret,
 			unsigned char *key);
 
+/**
+ * nvme_lookup_keyring() - Lookup keyring serial number
+ * @keyring:    Keyring name
+ *
+ * Looks up the serial number of the keyring @keyring.
+ *
+ * Return: The key serial number of the keyring
+ * or 0 with errno set otherwise.
+ */
+long nvme_lookup_keyring(const char *keyring);
+
 #endif /* _LIBNVME_LINUX_H */


### PR DESCRIPTION
Here's an updated version of my patches for the upcoming TLS support for NVMe/TCP.
The first patch is function to store a TLS PSK in the specified keyring, and the other patches add support for the fabrics options 'keyring' and 'tls_key'.
Idea of these options are that the 'keyring' option references a keyring which holds all valid keys for this connection; the kernel code will then look up keys from this keyring and start the TLS connection with these keys.
The 'tls_key' option specifies a single key with which the kernel should start the TLS connection.