### PR TITLE
python: Change python option from combo to feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
             --buildtype=release
             --wrap-mode=nofallback
             --cross-file=.github/cross/ubuntu-armhf.txt
-            -Dpython=false
+            -Dpython=disabled
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -238,7 +238,7 @@ jobs:
             --buildtype=release
             --wrap-mode=nofallback
             --cross-file=.github/cross/ubuntu-ppc64le.txt
-            -Dpython=false
+            -Dpython=disabled
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -274,7 +274,7 @@ jobs:
             --buildtype=release
             --wrap-mode=nofallback
             --cross-file=.github/cross/ubuntu-s390x.txt
-            -Dpython=false
+            -Dpython=disabled
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -314,7 +314,7 @@ jobs:
           export PATH=$(pwd)/build-tools/muon/build:$PATH
 
           muon setup                \
-              -Dpython=false        \
+              -Dpython=disabled     \
               -Dopenssl=disabled    \
               -Dlibdbus=disabled    \
               -Djson-c=disabled     \

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Using meson is similar to projects that use a `configure` script before running 
 To `configure` the project:
 
 ```
-meson .build
+meson setup .build
 ```
 
 Which will default to build a shared library. To configure for static libraries call
 
 ```
-meson .build --default-library=static
+meson setup .build --default-library=static
 ```
 
 One nice feature of meson is that it doesn't mix build artifacts
@@ -160,10 +160,10 @@ rm -rf .build
 
 A few build options can be specified on the command line when invoking meson.
 
-| Option | Values [default]    | Description                                                  |
-| ------ | ------------------- | ------------------------------------------------------------ |
-| man    | true, [false]       | Instruct meson to configure the project to build the `libnvme` documentation. <br />Example: `meson .build -Dman=true` |
-| python | [auto], true, false | Whether to build the Python bindings. When set to `auto`, the default, meson will check for the presence of the  tools and libraries (e.g. `swig`) required to build the Python bindings. If found, meson will configure the project to build the Python bindings. If a tool or library is missing, then the Python bindings won't be built. Setting this to `true`, forces the Python bindings to be built. When set to `false`, meson will configure the project to not build the Python bindings.<br />Example: `meson .build -Dpython=false` |
+| Option | Values [default]          | Description                                                  |
+| ------ | ------------------------- | ------------------------------------------------------------ |
+| man    | true, [false]             | Instruct meson to configure the project to build the `libnvme` documentation. <br />Example: `meson .build -Dman=true` |
+| python | [auto], enabled, disabled | Whether to build the Python bindings. When set to `auto`, the default, meson will check for the presence of the  tools and libraries (e.g. `swig`) required to build the Python bindings. If found, meson will configure the project to build the Python bindings. If a tool or library is missing, then the Python bindings won't be built. Setting this to `enabled`, forces the Python bindings to be built. When set to `disabled`, meson will configure the project to not build the Python bindings.<br />Example: `meson setup .build -Dpython=disabled` |
 
 ### Changing the build options from the command-line (i.e. w/o modifying any files)
 
@@ -171,19 +171,19 @@ To configure a build for debugging purposes (i.e. optimization turned
 off and debug symbols enabled):
 
 ```bash
-meson .build -Dbuildtype=debug
+meson setup .build --buildtype=debug
 ```
 
 To enable address sanitizer (advanced debugging of memory issues):
 
 ```bash
-meson .build -Db_sanitize=address
+meson setup .build -Db_sanitize=address
 ```
 
 This option adds `-fsanitize=address` to the gcc options. Note that when using the sanitize feature, the library `libasan.so` must be available and must be the very first library loaded when running an executable. Ensuring that `libasan.so` gets loaded first can be achieved with the `LD_PRELOAD` environment variable as follows: 
 
 ```
-meson .build -Db_sanitize=address && LD_PRELOAD=/lib64/libasan.so.6 ninja -C .build test 
+meson setup .build -Db_sanitize=address && LD_PRELOAD=/lib64/libasan.so.6 ninja -C .build test 
 ```
 
 To list configuration options that are available and possible values:

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -6,17 +6,17 @@
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
 want_python = get_option('python')
-if want_python != 'false'
-    python3 = import('python').find_installation('python3')
-    py3_dep = python3.dependency(required: want_python == 'true')
-    swig = find_program('swig', required: want_python == 'true')
-    header_found = cc.has_header('Python.h', dependencies: py3_dep, required: want_python == 'true')
-    have_python_support = py3_dep.found() and swig.found() and header_found
+if want_python.disabled()
+    build_python_bindings = false
 else
-    have_python_support = false
+    python3 = import('python').find_installation('python3')
+    py3_dep = python3.dependency(required: want_python)
+    swig = find_program('swig', required: want_python)
+    header_found = cc.has_header('Python.h', dependencies: py3_dep, required: want_python)
+    build_python_bindings = py3_dep.found() and swig.found() and header_found
 endif
 
-if have_python_support
+if build_python_bindings
     pymod_swig = custom_target(
         'nvme.py',
         input:   ['nvme.i'],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,7 @@ option('rstdir', type : 'string', value : '', description : 'directory for ReST 
 option('docs', type : 'combo', choices : ['false', 'html', 'man', 'rst', 'all'], description : 'install documentation')
 option('docs-build', type : 'boolean', value : false,  description : 'build documentation')
 
-option('python', type : 'combo', choices : ['auto', 'true', 'false'], description : 'Generate libnvme python bindings')
+option('python', type : 'feature', value: 'auto', description : 'Generate libnvme python bindings')
 option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL support')
 option('libdbus', type : 'feature', value: 'disabled', description : 'libdbus support')
 option('json-c', type : 'feature', value: 'auto', description : 'JSON support')


### PR DESCRIPTION
@igaw - Per our earlier [discussion](https://github.com/linux-nvme/libnvme/pull/602#discussion_r1147668694), changing `python` option from a `combo` to a `feature`. 

Thanks for pointing me to `feature`. It is a bit cleaner than using a `combo` and it aligns with the rest of the options.