### PR TITLE
Update fallbacks to lastet available version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,37 +61,42 @@ else
 endif
 conf.set('CONFIG_JSONC', json_c_dep.found(), description: 'Is json-c required?')
 
-# Check for OpenSSL availability
-openssl_dep = dependency('openssl',
-                         version: '>=1.1.0',
-                         required: get_option('openssl'),
-                         fallback : ['openssl', 'libssl_dep'])
-if openssl_dep.found()
-  conf.set('CONFIG_OPENSSL', true,
-           description: 'Is OpenSSL/LibreSSL available?')
+if get_option('openssl').disabled()
+  openssl_dep = dependency('', required: false)
+else
+  openssl_dep = dependency('openssl',
+                           version: '>=1.1.0',
+                           required: get_option('openssl'),
+                           fallback : ['openssl', 'libssl_dep'])
 
-  if openssl_dep.version().version_compare('<2.0.0')
-    api_version = 1
-  endif
-
-  if openssl_dep.version().version_compare('>=3.0.0')
-    api_version = 3
-
-    # Test for LibreSSL v3.x with incomplete OpenSSL v3 APIs
-    is_libressl = cc.has_header_symbol('openssl/opensslv.h',
-                                       'LIBRESSL_VERSION_NUMBER',
-                                       dependencies: openssl_dep)
-    has_header = cc.has_header('openssl/core_names.h',
-                               dependencies: openssl_dep)
-    if is_libressl and not has_header
+  if openssl_dep.found()
+    if openssl_dep.version().version_compare('<2.0.0')
       api_version = 1
     endif
 
-  endif
+    if openssl_dep.version().version_compare('>=3.0.0')
+      api_version = 3
+    endif
 
-  conf.set('CONFIG_OPENSSL_@0@'.format(api_version), true,
-           description: 'OpenSSL/LibreSSL API version @0@'.format(api_version))
+    # Test for LibreSSL v3.x with incomplete OpenSSL v3 APIs
+    if openssl_dep.type_name() != 'internal'
+      is_libressl = cc.has_header_symbol('openssl/opensslv.h',
+                                         'LIBRESSL_VERSION_NUMBER',
+                                         dependencies: openssl_dep)
+      has_header = cc.has_header('openssl/core_names.h',
+                                 dependencies: openssl_dep)
+      if is_libressl and not has_header
+        api_version = 1
+      endif
+    endif
+
+    conf.set('CONFIG_OPENSSL_@0@'.format(api_version), true,
+             description: 'OpenSSL/LibreSSL API version @0@'.format(api_version))
+  endif
 endif
+
+conf.set('CONFIG_OPENSSL', openssl_dep.found(),
+         description: 'Is OpenSSL/LibreSSL available?')
 
 if get_option('libdbus').disabled()
     libdbus_dep = dependency('', required: false)

--- a/subprojects/json-c.wrap
+++ b/subprojects/json-c.wrap
@@ -1,12 +1,12 @@
 [wrap-file]
-directory = json-c-0.15
-source_url = https://s3.amazonaws.com/json-c_releases/releases/json-c-0.15.tar.gz
-source_filename = json-c-0.15.tar.gz
-source_hash = b8d80a1ddb718b3ba7492916237bbf86609e9709fb007e7f7d4322f02341a4c6
-patch_filename = json-c_0.15-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/json-c_0.15-2/get_patch
-patch_hash = 2c5c95cf463804ac61309930c76ba9f57b157fef6247d1c6da4395b31a5bfac7
+directory = json-c-0.16
+source_url = https://s3.amazonaws.com/json-c_releases/releases/json-c-0.16.tar.gz
+source_filename = json-c-0.16.tar.gz
+source_hash = 8e45ac8f96ec7791eaf3bb7ee50e9c2100bbbc87b8d0f1d030c5ba8a0288d96b
+patch_filename = json-c_0.16-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/json-c_0.16-3/get_patch
+patch_hash = 6e712826ba1e6e1b6d21c6157a764984fedc6b594c9f92443498b972b6377a94
+wrapdb_version = 0.16-3
 
 [provide]
 json-c = json_c_dep
-

--- a/subprojects/openssl.wrap
+++ b/subprojects/openssl.wrap
@@ -1,14 +1,15 @@
 [wrap-file]
-directory = openssl-1.1.1l
-source_url = https://www.openssl.org/source/openssl-1.1.1l.tar.gz
-source_filename = openssl-1.1.1l.tar.gz
-source_hash = 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
-patch_filename = openssl_1.1.1l-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/openssl_1.1.1l-3/get_patch
-patch_hash = a0cb8285cda3ae0e1898b4e88427c19bf245184259f41395010182655f9f8ce6
+directory = openssl-3.0.7
+source_url = https://www.openssl.org/source/openssl-3.0.7.tar.gz
+source_filename = openssl-3.0.7.tar.gz
+source_hash = 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
+patch_filename = openssl_3.0.7-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openssl_3.0.7-2/get_patch
+patch_hash = dcc5d21bb602a5ca43bbaf14de858955f748b2abb2c0102ba193bd3964ac13a4
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/openssl_3.0.7-2/openssl-3.0.7.tar.gz
+wrapdb_version = 3.0.7-2
 
 [provide]
 libcrypto = libcrypto_dep
 libssl = libssl_dep
 openssl = openssl_dep
-


### PR DESCRIPTION
The OpenSSL fallback is a bit tricky as we have a workaround in place to figure out if we are building against LibreSSL. If this is the case we can't use cc.has_header_symbol() and cc.has_header() for the fallback (aka internal).