### PR TITLE
linux: Add nvme_get_logical_block_size_attr()

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -7,6 +7,7 @@ LIBNVME_1_4 {
 		nvme_lookup_key;
 		nvme_set_keyring;
 		nvme_insert_tls_key;
+		nvme_get_logical_block_size_attr;
 };
 
 LIBNVME_1_3 {

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -108,6 +108,15 @@ int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log,
 int nvme_get_ana_log_len(int fd, size_t *analen);
 
 /**
+ * nvme_get_logical_block_size_attr() - Retrieve block size from sysfs
+ * @devname:   The basename of the [block|generic] device (e.g., nvme0n1)
+ * @blksize:   Pointer to where the block size will be set on success
+ *
+ * Return: 0 on success or negative value with errno set otherwise.
+ */
+int nvme_get_logical_block_size_attr(const char *devname, int *blksize);
+
+/**
  * nvme_get_logical_block_size() - Retrieve block size
  * @fd:		File descriptor of nvme device
  * @nsid:	Namespace id


### PR DESCRIPTION
This API will be used `nvme-cli` patches.


---
Add nvme_get_logical_block_size_attr() function to retrieve `logical_block_size` attribute from sysfs for the given device.  The device node should be either a block device (e.g., nvme0n1) or a generic device (e.g., ng0n1).

We can get the logical block size from IDENTIFY command just like nvme_get_logical_block_size() which has previously introduce in [1], someone might not want to issue any admin commands to figure out the logical block size.

If the given device is character controller device like nvme0, it returns error.  We can find a hidden blkdev node in /sys/block/nvme%dc%dn%d by receiving a device nsid, but it's a kind of burden to go.  So, simply allow block device or generic device to retrieve from.

[1] Commit b71bcc429 ("linux: Add nvme_get_logical_block_size()")