### PR TITLE
tree: Fix argument check in nvme_bytes_to_lba

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1481,7 +1481,7 @@ static int nvme_bytes_to_lba(nvme_ns_t n, off_t offset, size_t count,
 	int bs;
 
 	bs = nvme_ns_get_lba_size(n);
-	if (!count || offset & bs || count & bs) {
+	if (!count || offset & bs || count & (bs - 1)) {
 		errno = EINVAL;
 		return -1;
 	}


### PR DESCRIPTION
nvme_bytes_to_lba() argument checker is ensuring that all passed in values are valid. That means we have at least one block to write, the offset is aligned to a block starting address and the number of blocks is a multiple of the block size

The last check is wrong, thus fix it.

Fixes #611