### PR TITLE
tree: Fix offset argument check in nvme_bytes_to_lba

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1482,7 +1482,7 @@ static int nvme_bytes_to_lba(nvme_ns_t n, off_t offset, size_t count,
 	int bs;
 
 	bs = nvme_ns_get_lba_size(n);
-	if (!count || offset & bs || count & (bs - 1)) {
+	if (!count || offset & (bs - 1) || count & (bs - 1)) {
 		errno = EINVAL;
 		return -1;
 	}


### PR DESCRIPTION
Also offset modulo blocksize needs to be 0. Commit 01c6055e5602 ("tree: Fix argument check in nvme_bytes_to_lba") missed to update this, thus do it now.

Fixes #616