### PR TITLE
Disable fallback on default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
           setup-options: >
             --werror
             --buildtype=debug
-            --wrap-mode=nofallback
           meson-version: 0.61.2
       - uses: BSFishy/meson-build@v1.0.3
         name: test
@@ -59,7 +58,6 @@ jobs:
           setup-options: >
             --werror
             --buildtype=release
-            --wrap-mode=nofallback
             -Dlibdbus=enabled
           meson-version: 0.61.2
       - uses: BSFishy/meson-build@v1.0.3
@@ -92,7 +90,6 @@ jobs:
           setup-options: >
             --werror
             --buildtype=release
-            --wrap-mode=nofallback
             --cross-file=.github/cross/clang.txt
             -Dlibdbus=enabled
           meson-version: 0.61.2
@@ -242,7 +239,6 @@ jobs:
           setup-options: >
             --werror
             --buildtype=release
-            --wrap-mode=nofallback
             --cross-file=.github/cross/ubuntu-armhf.txt
             -Dpython=disabled
           meson-version: 0.61.2
@@ -285,7 +281,6 @@ jobs:
           setup-options: >
             --werror
             --buildtype=release
-            --wrap-mode=nofallback
             --cross-file=.github/cross/ubuntu-ppc64le.txt
             -Dpython=disabled
           meson-version: 0.61.2
@@ -328,7 +323,6 @@ jobs:
           setup-options: >
             --werror
             --buildtype=release
-            --wrap-mode=nofallback
             --cross-file=.github/cross/ubuntu-s390x.txt
             -Dpython=disabled
           meson-version: 0.61.2

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -16,6 +16,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
+      - name: install libraries
+        run: sudo apt-get install gcc pkg-config libjson-c-dev libssl-dev python3-dev
+
       - uses: actions/checkout@v3
 
       - name: Build sdist

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ project(
         'buildtype=debug',
         'prefix=/usr/local',
         'sysconfdir=etc',
+        'wrap_mode=nofallback'
     ]
 )
 


### PR DESCRIPTION
meson's default setting for wrap mode is to attempt to download missing
dependencies. Disable this feature as the community is unhappy with
this default behavior.
