### PR TITLE
python: Update test data

### DIFF
--- a/libnvme/tests/test-nbft.py
+++ b/libnvme/tests/test-nbft.py
@@ -37,8 +37,8 @@ class Testclass(unittest.TestCase):
                 }
             ],
             "host": {
-                "host_id_configured": False,
-                "host_nqn_configured": False,
+                "host_id_configured": True,
+                "host_nqn_configured": True,
                 "id": "44454c4c-3400-1036-8038-b2c04f313233",
                 "nqn": "nqn.1988-11.com.dell:PowerEdge.R760.1234567",
                 "primary_admin_host_flag": "not indicated",


### PR DESCRIPTION
Since commit 1617d1a3f42a ("nbft: Parse the {HOSTID,HOSTNQN}_CONFIGURED flags") host_id_configured and host_nqn_configured are parsed. Thus we need to update the test case accordingly.