### PR TITLE
Add 'application' strings to nvme_root and nvme_subsystem

### DIFF
--- a/doc/config-schema.json.in
+++ b/doc/config-schema.json.in
@@ -59,6 +59,10 @@
 		    "type": "array",
 		    "items": { "$ref": "#/$defs/port" }
 		},
+		"application": {
+		    "description": "Program managing this subsystem",
+		    "type": "string"
+		},
 		"required": [ "nqn" ]
 	    }
 	},

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -346,10 +346,12 @@ struct nvme_subsystem {
 	%immutable model;
 	%immutable serial;
 	%immutable firmware;
+	%immutable application;
 	char *subsysnqn;
 	char *model;
 	char *serial;
 	char *firmware;
+	char *application;
 };
 
 struct nvme_ctrl {

--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -326,7 +326,9 @@ PyObject *hostid_from_file();
 
 struct nvme_root {
 	%immutable config_file;
+	%immutable application;
 	char *config_file;
+	char *application;
 };
 
 struct nvme_host {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -2,9 +2,11 @@
 
 LIBNVME_1_5 {
 	global:
-		nvme_nbft_read;
-		nvme_nbft_free;
 		nvme_ipaddrs_eq;
+		nvme_nbft_free;
+		nvme_nbft_read;
+		nvme_subsystem_get_application;
+		nvme_subsystem_set_application;
 };
 
 LIBNVME_1_4 {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -5,6 +5,8 @@ LIBNVME_1_5 {
 		nvme_ipaddrs_eq;
 		nvme_nbft_free;
 		nvme_nbft_read;
+		nvme_root_get_application;
+		nvme_root_set_application;
 		nvme_subsystem_get_application;
 		nvme_subsystem_set_application;
 };

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -155,6 +155,7 @@ struct nvme_fabric_options {
 
 struct nvme_root {
 	char *config_file;
+	char *application;
 	struct list_head hosts;
 	struct list_head endpoints; /* MI endpoints */
 	FILE *fp;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -104,6 +104,7 @@ struct nvme_subsystem {
 	char *serial;
 	char *firmware;
 	char *subsystype;
+	char *application;
 };
 
 struct nvme_host {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -197,6 +197,19 @@ int nvme_dump_tree(nvme_root_t r)
 	return json_dump_tree(r);
 }
 
+const char *nvme_root_get_application(nvme_root_t r)
+{
+	return r->application;
+}
+
+void nvme_root_set_application(nvme_root_t r, const char *a)
+{
+	if (r->application)
+		free(r->application);
+	if (a)
+		r->application = strdup(a);
+}
+
 nvme_host_t nvme_first_host(nvme_root_t r)
 {
 	return list_top(&r->hosts, struct nvme_host, entry);
@@ -293,6 +306,8 @@ void nvme_free_tree(nvme_root_t r)
 		__nvme_free_host(h);
 	if (r->config_file)
 		free(r->config_file);
+	if (r->application)
+		free(r->application);
 	free(r);
 }
 
@@ -404,6 +419,8 @@ static void __nvme_free_subsystem(struct nvme_subsystem *s)
 		free(s->firmware);
 	if (s->subsystype)
 		free(s->subsystype);
+	if (s->application)
+		free(s->application);
 	free(s);
 }
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -466,6 +466,12 @@ struct nvme_subsystem *nvme_lookup_subsystem(struct nvme_host *h,
 		if (name && s->name &&
 		    strcmp(s->name, name))
 			continue;
+		if (h->r->application) {
+			if (!s->application)
+				continue;
+			if (strcmp(h->r->application, s->application))
+				continue;
+		}
 		return s;
 	}
 	return nvme_alloc_subsystem(h, name, subsysnqn);
@@ -572,6 +578,8 @@ static int nvme_init_subsystem(nvme_subsystem_t s, const char *name)
 	}
 	s->name = strdup(name);
 	s->sysfs_dir = (char *)path;
+	if (s->h->r->application)
+		s->application = strdup(s->h->r->application);
 
 	return 0;
 }

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -316,6 +316,19 @@ const char *nvme_subsystem_get_type(nvme_subsystem_t s)
 	return s->subsystype;
 }
 
+const char *nvme_subsystem_get_application(nvme_subsystem_t s)
+{
+	return s->application;
+}
+
+void nvme_subsystem_set_application(nvme_subsystem_t s, const char *a)
+{
+	if (s->application)
+		free(s->application);
+	if (a)
+		s->application = strdup(a);
+}
+
 nvme_ctrl_t nvme_subsystem_first_ctrl(nvme_subsystem_t s)
 {
 	return list_top(&s->ctrls, struct nvme_ctrl, entry);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1105,6 +1105,23 @@ const char *nvme_subsystem_get_name(nvme_subsystem_t s);
 const char *nvme_subsystem_get_type(nvme_subsystem_t s);
 
 /**
+ * nvme_subsystem_get_application() - Return the application string
+ * @s:	nvme_subsystem_t object
+ *
+ * Return: Managing application string or NULL if not set.
+ */
+const char *nvme_subsystem_get_application(nvme_subsystem_t s);
+
+/**
+ * nvme_subsystem_set_application() - Set the application string
+ * @s:	nvme_subsystem_t object
+ * @a:  application string
+ *
+ * Sets the managing application string for @s.
+ */
+void nvme_subsystem_set_application(nvme_subsystem_t s, const char *a);
+
+/**
  * nvme_scan_topology() - Scan NVMe topology and apply filter
  * @r:	    nvme_root_t object
  * @f:	    filter to apply

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -45,6 +45,23 @@ typedef bool (*nvme_scan_filter_t)(nvme_subsystem_t, nvme_ctrl_t,
 nvme_root_t nvme_create_root(FILE *fp, int log_level);
 
 /**
+ * nvme_root_set_application - Specify managing application
+ * @r:	&nvme_root_t object
+ * @a:	Application string
+ *
+ * Sets the managing application string for @r.
+ */
+void nvme_root_set_application(nvme_root_t r, const char *a);
+
+/**
+ * nvme_root_get_application - Get managing application
+ * @r:	&nvme_root_t object
+ *
+ * Returns the managing application string for @r or NULL if not set.
+ */
+const char *nvme_root_get_application(nvme_root_t r);
+
+/**
  * nvme_free_tree() - Free root object
  * @r:	&nvme_root_t object
  *


### PR DESCRIPTION
This patchset adds an 'application' string to both, the nvme root and the nvme subsystem.
With that an application can restrict lookup to subsystems which are managed  by that application.
For any application not setting the string during initialisation (ie does not call `nvme_root_set_application()`)
lookup will ignore subsystems which have an application string set.
Application strings are automatically set when creating new subsystems.
