### PR TITLE
examples: fix incorrect controller status in MI info output

### DIFF
--- a/examples/mi-mctp.c
+++ b/examples/mi-mctp.c
@@ -113,7 +113,7 @@ int do_info(nvme_mi_ep_t ep)
 	printf(" smart warnings:    0x%x\n", ss_health.sw);
 	printf(" composite temp:    %d\n", ss_health.ctemp);
 	printf(" drive life used:   %d%%\n", ss_health.pdlu);
-	printf(" controller status: 0x%04x\n", le16_to_cpu(ss_health.pdlu));
+	printf(" controller status: 0x%04x\n", le16_to_cpu(ss_health.ccs));
 
 	return 0;
 }


### PR DESCRIPTION
In the mi-mctp example, we're incorrectly reporting the percent drive life used as the controller status. Fix the controller status output to use the correct (ccs) field.