### PR TITLE
mi: Add nvme_mi_ctrl_id to retrieve controller ID

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,3 +1,8 @@
+LIBNVME_MI_1_5 {
+	global:
+		nvme_mi_ctrl_id;
+};
+
 LIBNVME_MI_1_4 {
         global:
                 nvme_mi_admin_get_log_page;

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -304,6 +304,11 @@ struct nvme_mi_ctrl *nvme_mi_init_ctrl(nvme_mi_ep_t ep, __u16 ctrl_id)
 	return ctrl;
 }
 
+__u16 nvme_mi_ctrl_id(nvme_mi_ctrl_t ctrl)
+{
+	return ctrl->id;
+}
+
 int nvme_mi_scan_ep(nvme_mi_ep_t ep, bool force_rescan)
 {
 	struct nvme_ctrl_list list;

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -655,6 +655,20 @@ nvme_mi_ctrl_t nvme_mi_init_ctrl(nvme_mi_ep_t ep, __u16 ctrl_id);
 void nvme_mi_close_ctrl(nvme_mi_ctrl_t ctrl);
 
 /**
+ * nvme_mi_ctrl_id() - get the ID of a controller
+ * @ctrl: controller to query
+ *
+ * Retrieve the ID of the controller, as defined by hardware, and available
+ * in the Identify (Controller List) data. This is the value passed to
+ * @nvme_mi_init_ctrl, but may have been created internally via
+ * @nvme_mi_scan_ep.
+ *
+ * Return: the (locally-stored) ID of this controller.
+ */
+__u16 nvme_mi_ctrl_id(nvme_mi_ctrl_t ctrl);
+
+
+/**
  * nvme_mi_endpoint_desc - Get a string describing a MI endpoint.
  * @ep: endpoint to describe
  *


### PR DESCRIPTION
Controllers may be scanned through nvme_mi_scan_ep, in which case the caller will not have access to the underlying controller IDs.

Add an accessor function to retrieve the controller ID for use in subsequent commands (like namespace attach).