### PR TITLE
Python: Fix crash during garbage collection

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -612,7 +612,9 @@ struct nvme_ns {
 
 %pythonappend nvme_ctrl::connect(struct nvme_host *h,
 				 struct nvme_fabrics_config *cfg) {
-    self.__parent = h  # Keep a reference to parent to ensure garbage collection happens in the right order}
+    self.__host = h  # Keep a reference to parent to ensure ctrl obj gets GCed before host}
+%pythonappend nvme_ctrl::init(struct nvme_host *h, int instance) {
+    self.__host = h  # Keep a reference to parent to ensure ctrl obj gets GCed before host}
 %extend nvme_ctrl {
 	nvme_ctrl(struct nvme_root *r,
 		  const char *subsysnqn,


### PR DESCRIPTION
Same fix as PR: https://github.com/linux-nvme/libnvme/pull/583

Prevent Garbage Collector (GC) from deleting host and root objects before all controller objects under that root/host have been GCed. This time, it's the init() method that needed the fix. Previously we had only fixed the connect() method.