### PR TITLE
fabrics: fix potential invalid memory access in __nvmf_supported_option()

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -625,7 +625,7 @@ static  int __nvmf_supported_options(nvme_root_t r)
 {
 	char buf[0x1000], *options, *p, *v;
 	int fd, ret;
-	size_t len;
+	ssize_t len;
 
 	if (r->options)
 		return 0;


### PR DESCRIPTION

In __nvmf_supported_option(), len is declared as size_t (unsigned)

"len = read()" may return a negative number;
the check "if (len < 0)" will always be false and therefore "buf[len]" will dereference an invalid memory address.

len should be declared as a signed size_t (ssize_t)