### PR TITLE
ioctl: fix RAE bit on last Get Log Page command

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -434,7 +434,7 @@ int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args)
 {
 	__u64 offset = 0, xfer, data_len = args->len;
 	__u64 start = args->lpo;
-	bool retain = true;
+	bool retain = args->rae;
 	void *ptr = args->log;
 	int ret;
 
@@ -454,13 +454,10 @@ int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args)
 		 * last portion of this log page so the data remains latched
 		 * during the fetch sequence.
 		 */
-		if (offset + xfer == data_len)
-			retain = args->rae;
-
 		args->lpo = start + offset;
 		args->len = xfer;
 		args->log = ptr;
-		args->rae = retain;
+		args->rae = offset + xfer < data_len || retain;
 		ret = nvme_get_log(args);
 		if (ret)
 			return ret;


### PR DESCRIPTION
If `nvme_get_log_page()` requires multiple Get Log Page commands because the total log length exceeds the transfer length, `args->rae` is overwritten, causing the RAE bit to be set in all commands. Retrieve the value of `args->rae` before overwriting it so the RAE bit is set as requested in the last command.

A tcpdump of the previous behavior shows the RAE bit cleared on the last Get Log Page command of a discovery sequence if the full log page fits in the 4 KB transfer size:
```
28	0.002107	192.168.1.65	192.168.1.62	NVMe	138	NVMe Get Log Page NVMeOF Discovery
NVM Express (Cmd)
    Opcode: 0x02 Get Log Page
    .... ..00 = Fuse Operation: 0x0
    ..00 00.. = Reserved: 0x0
    01.. .... = PRP Or SGL: 0x1
    Command ID: 0x2005
    Namespace Id: 0x00000000
    Reserved: 0000000000000000
    Metadata Pointer: 0x0000000000000000
    SGL1
    DWORD 10: 0x00ff8070
        .... .... .... .... .... .... 0111 0000 = Log Page Identifier (LID): NVMeOF Discovery (0x70)
        .... .... .... .... ...0 0000 .... .... = Log Specific Field (LSP): 0x00
        .... .... .... .... .00. .... .... .... = Reserved: 0x0
        .... .... .... .... 1... .... .... .... = Retain Asynchronous Event (RAE): True
        0000 0000 1111 1111 .... .... .... .... = Number of Dwords Lower (NUMDL): 0x00ff
    Number of Dwords: 255 (1024 bytes)
    DWORD 11: 0x00000000
    Log Page Offset (DWORD 12 and DWORD 13): 0
    DWORD13: 0x00000000
    DWORD 14: 0x00000000
    DWORD15: 0x00000000
29	0.002189	192.168.1.62	192.168.1.65	NVMe	1114	NVMeOF Data for Get Log Page NVMeOF Discovery, offset 0
NVM Express
    Nvme Data: NVMe Get Log Page (NVMeOF Discovery)
        Generation Counter (GENCTR): 126
        Number of Records (NUMREC): 3
        Record Format (RECFMT): 0
        Reserved: 000000000000000000000000000000000000000000000000000000000000000000000000…
30	0.002221	192.168.1.65	192.168.1.62	NVMe	138	NVMe Get Log Page NVMeOF Discovery
NVM Express (Cmd)
    Opcode: 0x02 Get Log Page
    .... ..00 = Fuse Operation: 0x0
    ..00 00.. = Reserved: 0x0
    01.. .... = PRP Or SGL: 0x1
    Command ID: 0x2006
    Namespace Id: 0x00000000
    Reserved: 0000000000000000
    Metadata Pointer: 0x0000000000000000
    SGL1
    DWORD 10: 0x03ff0070
        .... .... .... .... .... .... 0111 0000 = Log Page Identifier (LID): NVMeOF Discovery (0x70)
        .... .... .... .... ...0 0000 .... .... = Log Specific Field (LSP): 0x00
        .... .... .... .... .00. .... .... .... = Reserved: 0x0
        .... .... .... .... 0... .... .... .... = Retain Asynchronous Event (RAE): False
        0000 0011 1111 1111 .... .... .... .... = Number of Dwords Lower (NUMDL): 0x03ff
    Number of Dwords: 1023 (4096 bytes)
    DWORD 11: 0x00000000
    Log Page Offset (DWORD 12 and DWORD 13): 0
    DWORD13: 0x00000000
    DWORD 14: 0x00000000
    DWORD15: 0x00000000
```
But if there are enough records that the discovery log page is larger than 4 KB, then the RAE bit is set in all commands:
```
36	7.871369	192.168.1.65	192.168.1.62	NVMe	138	NVMe Get Log Page NVMeOF Discovery
NVM Express (Cmd)
    Opcode: 0x02 Get Log Page
    .... ..00 = Fuse Operation: 0x0
    ..00 00.. = Reserved: 0x0
    01.. .... = PRP Or SGL: 0x1
    Command ID: 0x000d
    Namespace Id: 0x00000000
    Reserved: 0000000000000000
    Metadata Pointer: 0x0000000000000000
    SGL1
    DWORD 10: 0x00ff8070
        .... .... .... .... .... .... 0111 0000 = Log Page Identifier (LID): NVMeOF Discovery (0x70)
        .... .... .... .... ...0 0000 .... .... = Log Specific Field (LSP): 0x00
        .... .... .... .... .00. .... .... .... = Reserved: 0x0
        .... .... .... .... 1... .... .... .... = Retain Asynchronous Event (RAE): True
        0000 0000 1111 1111 .... .... .... .... = Number of Dwords Lower (NUMDL): 0x00ff
    Number of Dwords: 255 (1024 bytes)
    DWORD 11: 0x00000000
    Log Page Offset (DWORD 12 and DWORD 13): 0
    DWORD13: 0x00000000
    DWORD 14: 0x00000000
    DWORD15: 0x00000000
38	7.871467	192.168.1.62	192.168.1.65	NVMe	1114	NVMeOF Data for Get Log Page NVMeOF Discovery, offset 0
NVM Express
    Nvme Data: NVMe Get Log Page (NVMeOF Discovery)
        Generation Counter (GENCTR): 127
        Number of Records (NUMREC): 4
        Record Format (RECFMT): 0
        Reserved: 000000000000000000000000000000000000000000000000000000000000000000000000…
39	7.871516	192.168.1.65	192.168.1.62	NVMe	138	NVMe Get Log Page NVMeOF Discovery
NVM Express (Cmd)
    Opcode: 0x02 Get Log Page
    .... ..00 = Fuse Operation: 0x0
    ..00 00.. = Reserved: 0x0
    01.. .... = PRP Or SGL: 0x1
    Command ID: 0x000e
    Namespace Id: 0x00000000
    Reserved: 0000000000000000
    Metadata Pointer: 0x0000000000000000
    SGL1
    DWORD 10: 0x03ff8070
        .... .... .... .... .... .... 0111 0000 = Log Page Identifier (LID): NVMeOF Discovery (0x70)
        .... .... .... .... ...0 0000 .... .... = Log Specific Field (LSP): 0x00
        .... .... .... .... .00. .... .... .... = Reserved: 0x0
        .... .... .... .... 1... .... .... .... = Retain Asynchronous Event (RAE): True
        0000 0011 1111 1111 .... .... .... .... = Number of Dwords Lower (NUMDL): 0x03ff
    Number of Dwords: 1023 (4096 bytes)
    DWORD 11: 0x00000000
    Log Page Offset (DWORD 12 and DWORD 13): 0
    DWORD13: 0x00000000
    DWORD 14: 0x00000000
    DWORD15: 0x00000000
...
41	7.871633	192.168.1.65	192.168.1.62	NVMe	138	NVMe Get Log Page NVMeOF Discovery
NVM Express (Cmd)
    Opcode: 0x02 Get Log Page
    .... ..00 = Fuse Operation: 0x0
    ..00 00.. = Reserved: 0x0
    01.. .... = PRP Or SGL: 0x1
    Command ID: 0x000f
    Namespace Id: 0x00000000
    Reserved: 0000000000000000
    Metadata Pointer: 0x0000000000000000
    SGL1
    DWORD 10: 0x00ff8070
        .... .... .... .... .... .... 0111 0000 = Log Page Identifier (LID): NVMeOF Discovery (0x70)
        .... .... .... .... ...0 0000 .... .... = Log Specific Field (LSP): 0x00
        .... .... .... .... .00. .... .... .... = Reserved: 0x0
        .... .... .... .... 1... .... .... .... = Retain Asynchronous Event (RAE): True
        0000 0000 1111 1111 .... .... .... .... = Number of Dwords Lower (NUMDL): 0x00ff
    Number of Dwords: 255 (1024 bytes)
    DWORD 11: 0x00000000
    Log Page Offset (DWORD 12 and DWORD 13): 4096
    DWORD13: 0x00000000
    DWORD 14: 0x00000000
    DWORD15: 0x00000000
```

With this fix, the RAE bit is cleared in the last Get Log Page command regardless of whether the log page exceeds 4 KB.