### PR TITLE
tree: Fix string comparison

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1081,11 +1081,13 @@ nvme_ctrl_t __nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 		if (traddr && c->traddr &&
 		    strcasecmp(c->traddr, traddr))
 			continue;
-		if (host_traddr && c->cfg.host_traddr &&
-		    strcmp(c->cfg.host_traddr, host_traddr))
+		if (c->cfg.host_traddr != host_traddr &&
+		    (!c->cfg.host_traddr || !host_traddr ||
+		     strcasecmp(c->cfg.host_traddr, host_traddr)))
 			continue;
-		if (host_iface && c->cfg.host_iface &&
-		    strcmp(c->cfg.host_iface, host_iface))
+		if (c->cfg.host_iface != host_iface &&
+		    (!c->cfg.host_iface || !host_iface||
+		     strcmp(c->cfg.host_iface, host_iface)))
 			continue;
 		if (trsvcid && c->trsvcid &&
 		    strcmp(c->trsvcid, trsvcid))


### PR DESCRIPTION
When comparing host/subsystem/controller objects for equality, we may conclude erroneously that two objects are equal if, for example, one object contains a NULL pointer when the other object contains a non-NULL pointer.

For example, the following does not work as expected:

```
if (subsysnqn && s->subsysnqn &&
    strcmp(s->subsysnqn, subsysnqn))
	continue;
```

In the above code, if subsysnqn==NULL but s->subsysnqn!=NULL, we would not hit the "continue" statement as we ought to.

The correct way to compare two string pointers that may be NULL is as follows:

```
if ((subsysnqn != s->subsysnqn)
    && (!s->subsysnqn || !subsysnqn
	|| strcmp(s->subsysnqn, subsysnqn)))
	continue;
```

With this, the only time that the two strings will be considered equal is if both pointers are equal (including if they're both NULL) or if the strcmp() returns 0.

Also, one must use case-insensitive string comparison when comparing IPv6 addresses.