### PR TITLE
examples: Fix wrong indentation in discover-loop.py

### DIFF
--- a/examples/discover-loop.py
+++ b/examples/discover-loop.py
@@ -56,7 +56,7 @@ except Exception as e:
     sys.exit(f'Failed to discover: {e}')
 
 try:
-c.disconnect()
+    c.disconnect()
 except Exception as e:
     sys.exit(f'Failed to disconnect: {e}')
 


### PR DESCRIPTION
Running `examples/discover-loop.py` fails:

```
  File "examples/discover-loop.py", line 59
    c.disconnect()
    ^
IndentationError: expected an indented block after 'try' statement on line 58
```