### PR TITLE
util: rename ipaddrs_eq() to nvme_ipaddrs_eq() and make public.

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -4,6 +4,7 @@ LIBNVME_1_5 {
 	global:
 		nvme_nbft_read;
 		nvme_nbft_free;
+		nvme_ipaddrs_eq;
 };
 
 LIBNVME_1_4 {

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -906,7 +906,7 @@ int nvme_uuid_random(unsigned char uuid[NVME_UUID_LEN])
 	return 0;
 }
 
-bool ipaddrs_eq(const char *addr1, const char *addr2) {
+bool nvme_ipaddrs_eq(const char *addr1, const char *addr2) {
 	bool result = false;
 	struct addrinfo *info1 = NULL, hint1 = { .ai_flags=AI_NUMERICHOST, .ai_family=AF_UNSPEC };
 	struct addrinfo *info2 = NULL, hint2 = { .ai_flags=AI_NUMERICHOST, .ai_family=AF_UNSPEC };
@@ -914,7 +914,7 @@ bool ipaddrs_eq(const char *addr1, const char *addr2) {
 	if (addr1 == addr2)
 		return true;
 
-	if (!addr1 || ! addr2)
+	if (!addr1 || !addr2)
 		return false;
 
 	if (getaddrinfo(addr1, 0, &hint1, &info1) || !info1)

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -627,12 +627,12 @@ int nvme_uuid_from_string(const char *str, unsigned char uuid[NVME_UUID_LEN]);
 int nvme_uuid_random(unsigned char uuid[NVME_UUID_LEN]);
 
 /**
- * ipaddrs_eq - Check if 2 IP addresses are equal.
+ * nvme_ipaddrs_eq - Check if 2 IP addresses are equal.
  * @addr1: IP address (can be IPv4 or IPv6)
  * @addr2: IP address (can be IPv4 or IPv6)
  *
  * Return: true if addr1 == addr2. false otherwise.
  */
-bool ipaddrs_eq(const char *addr1, const char *addr2);
+bool nvme_ipaddrs_eq(const char *addr1, const char *addr2);
 
 #endif /* _LIBNVME_UTIL_H */

--- a/test/test-util.c
+++ b/test/test-util.c
@@ -8,7 +8,7 @@
 */
 
 /**
- * In this file we test private functions found in
+ * In this file we test private and public functions found in
  * "src/nvme/util.c". Note that the source files are included
  * directly because the private functions are not available from
  * the libnvme.so.
@@ -67,7 +67,7 @@ static bool test_ipaddrs_eq() {
 	}
 
 	for (i = 0; i < n; i++) {
-		bool result = ipaddrs_eq(addrs[i].a, addrs[i].b);
+		bool result = nvme_ipaddrs_eq(addrs[i].a, addrs[i].b);
 		bool pass = result == addrs[i].exp_result;
 		int pad_a = longest_a - safe_strlen(addrs[i].a);
 		int pad_b = longest_b - safe_strlen(addrs[i].b);
@@ -110,7 +110,7 @@ int main(int argc, char *argv[]) {
 
 	printf("\n------------------------------------------------------------------------------\n");
 	pass = test_ipaddrs_eq();
-	printf("ipaddrs_eq() %s", pass ? "[PASS]" : "[FAIL]");
+	printf("nvme_ipaddrs_eq() %s", pass ? "[PASS]" : "[FAIL]");
 	if (!pass)
 		exit_val = EXIT_FAILURE;
 


### PR DESCRIPTION
As per https://github.com/linux-nvme/libnvme/issues/648, make `nvme_ipaddrs_eq()`  public.