### PR TITLE
Extend execution context filtering

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -871,7 +871,7 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 		if (!app || strcmp(app, root_app)) {
 			nvme_msg(h->r, LOG_INFO, "skip %s, not managed by %s\n",
 				 nvme_subsystem_get_nqn(s), root_app);
-			errno = ENVME_CONNECT_INVAL;
+			errno = ENVME_CONNECT_IGNORED;
 			return -1;
 		}
 	}

--- a/src/nvme/util.h
+++ b/src/nvme/util.h
@@ -38,6 +38,7 @@
  * @ENVME_CONNECT_OPNOTSUPP:	not supported
  * @ENVME_CONNECT_CONNREFUSED:	connection refused
  * @ENVME_CONNECT_ADDRNOTAVAIL:	cannot assign requested address
+ * @ENVME_CONNECT_IGNORED:	connect attempt is ignored due to configuration
  */
 enum nvme_connect_err {
 	ENVME_CONNECT_RESOLVE	= 1000,
@@ -59,6 +60,7 @@ enum nvme_connect_err {
 	ENVME_CONNECT_OPNOTSUPP,
 	ENVME_CONNECT_CONNREFUSED,
 	ENVME_CONNECT_ADDRNOTAVAIL,
+	ENVME_CONNECT_IGNORED,
 };
 
 /**


### PR DESCRIPTION
The newly introduced feature to allow coexisting nvme-cli and nvme-stas needs some more tuning to get it working.

For example, we should also fitler out the well known discovery controllers.