### PR TITLE
fabrics: use SECTYPE to determine whether to use TLS

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1033,8 +1033,7 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 		c->cfg.disable_sqflow = true;
 
 	if (e->trtype == NVMF_TRTYPE_TCP &&
-	    (e->treq & NVMF_TREQ_REQUIRED ||
-	     e->treq & NVMF_TREQ_NOT_REQUIRED))
+	    e->tsas.tcp.sectype != NVMF_TCP_SECTYPE_NONE)
 		c->cfg.tls = true;
 
 	ret = nvmf_add_ctrl(h, c, cfg);


### PR DESCRIPTION
The NVMe specfications are clear that the discovery log page entry SECTYPE field indicates whether TLS is supported.
Currently the TREQ field is used, which results in enabling TLS even when SECTYPE = "No Security" and TREQ = "Not required". Only enable TLS if SECTYPE indicates a TLS version is enabled.

From the NVMe/TCP transport specification, version 1.0c:
> Security Type (SECTYPE): Specifies the type of security used by the NVMe/TCP port. If SECTYPE is a value of 0h (No Security), then the host shall set up a normal TCP connection.

From TP8018:
> The SECTYPE value of 0h (No Security) specifies that TLS is not supported.

From TP8025 (the "TLS permitted" host case):
> If the SECTYPE field in the TSAS field in the discovery log entry for the remote entity is cleared to zero and the TSC field is not set to 01b (i.e., Required), then initiate TCP connections without TLS.