### PR TITLE
Fixes for recent changes

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -869,8 +869,8 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 			nvme_for_each_subsystem(h, s) {
 				fc = __nvme_lookup_ctrl(s, nvme_ctrl_get_transport(c),
 							nvme_ctrl_get_traddr(c),
-							nvme_ctrl_get_host_traddr(c),
-							nvme_ctrl_get_host_iface(c),
+							NULL,
+							NULL,
 							nvme_ctrl_get_trsvcid(c),
 							NULL);
 

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1274,6 +1274,9 @@ static char *nvme_ctrl_lookup_phy_slot(nvme_root_t r, const char *address)
 	DIR *slots_dir;
 	struct dirent *entry;
 
+	if (!address)
+		return NULL;
+
 	slots_dir = opendir(nvme_slots_sysfs_dir);
 	if (!slots_dir) {
 		nvme_msg(r, LOG_WARNING, "failed to open slots dir %s\n",


### PR DESCRIPTION
- `tree: Ignore NULL address pointer for phy slot lookup` fixes 42ac45359635 ("tree: Add PCI physical slot number for controller")
- `fabrics: Relax match on well known disc ctrl lookup` fixes ac1584a5eac1 ("fabrics: Filter discovery ctrls out during application context check")