### PR TITLE
mi: don't return from mi_mctp_submit with a tag held

### DIFF
--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -333,13 +333,14 @@ retry:
 		nvme_msg(ep->root, LOG_ERR,
 			 "Failed polling on MCTP socket: %m");
 		errno = errno_save;
-		return -1;
+		goto out;
 	}
 
 	if (rc == 0) {
 		nvme_msg(ep->root, LOG_DEBUG, "Timeout on MCTP socket");
 		errno = ETIMEDOUT;
-		return -1;
+		rc = -1;
+		goto out;
 	}
 
 	rc = -1;


### PR DESCRIPTION
If the poll() times-out or fails, we'll exit early from nvme_mi_mctp_submit still holding the tag reservation. When using an i2c transport, this may mean we hold a lock on the i2c bus with no way to release.

Instead, always drop the tag on function exit.

Fixes: 6a08780 ("mi-mctp: Add timeout support to MCTP transport")