### PR TITLE
Relax alignment requirements for MI responses

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -413,11 +413,6 @@ int nvme_mi_submit(nvme_mi_ep_t ep, struct nvme_mi_req *req,
 		return -1;
 	}
 
-	if (resp->data_len & 0x3) {
-		errno = EINVAL;
-		return -1;
-	}
-
 	if (ep->transport->mic_enabled)
 		nvme_mi_calc_req_mic(req);
 

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -580,8 +580,10 @@ int nvme_mi_admin_xfer(nvme_mi_ctrl_t ctrl,
 		return -1;
 	}
 
-	/* must be aligned */
-	if (resp_data_offset & 0x3) {
+	/* request and response lengths & offset must be aligned */
+	if ((req_data_size & 0x3) ||
+	    (*resp_data_size & 0x3) ||
+	    (resp_data_offset & 0x3)) {
 		errno = EINVAL;
 		return -1;
 	}


### PR DESCRIPTION
@birkelund has pointed out that a non-four-byte-aligned response to a MI command is possible; for example a Read MI Data (Controller List), when there are an even number of controllers and no padding applied.

This series allows unaligned responses; firstly we simplify the response handling code from using a scatter-gather buffer for the header/payload/MIC, to a simple linear buffer. Then we allow the unaligned response sizes for MI commands - both expected (where the caller provided an unaligned size) and unexpected (where the allocated size was aligned, but the response isn't).

@birkelund  - could you test this in your environment?