### PR TITLE
Fixing documentation on readme for compile instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ completely "clean" all the build artifacts, one need only delete the
 To compile:
 
 ```
-meson -C .build
+meson compile -C .build
 ```
 
 ## To install libnvme


### PR DESCRIPTION
I believe the `meson -C .build` instruction is missing the `compile` command