### PR TITLE
tree: Add getter for subsystem iopolicy

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -5,6 +5,7 @@ LIBNVME_1_6 {
 		nvme_host_release_fds;
 		nvme_ns_release_fd;
 		nvme_root_release_fds;
+		nvme_subsystem_get_iopolicy;
 		nvme_subsystem_release_fds;
 };
 

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -106,6 +106,7 @@ struct nvme_subsystem {
 	char *firmware;
 	char *subsystype;
 	char *application;
+	char *iopolicy;
 };
 
 struct nvme_host {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -382,6 +382,11 @@ void nvme_subsystem_set_application(nvme_subsystem_t s, const char *a)
 		s->application = strdup(a);
 }
 
+const char *nvme_subsystem_get_iopolicy(nvme_subsystem_t s)
+{
+	return s->iopolicy;
+}
+
 nvme_ctrl_t nvme_subsystem_first_ctrl(nvme_subsystem_t s)
 {
 	return list_top(&s->ctrls, struct nvme_ctrl, entry);
@@ -459,6 +464,8 @@ static void __nvme_free_subsystem(struct nvme_subsystem *s)
 		free(s->subsystype);
 	if (s->application)
 		free(s->application);
+	if (s->iopolicy)
+		free(s->iopolicy);
 	free(s);
 }
 
@@ -638,6 +645,7 @@ static int nvme_init_subsystem(nvme_subsystem_t s, const char *name)
 	s->sysfs_dir = (char *)path;
 	if (s->h->r->application)
 		s->application = strdup(s->h->r->application);
+	s->iopolicy = nvme_get_attr(path, "iopolicy");
 
 	return 0;
 }

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1187,6 +1187,14 @@ const char *nvme_subsystem_get_application(nvme_subsystem_t s);
 void nvme_subsystem_set_application(nvme_subsystem_t s, const char *a);
 
 /**
+ * nvme_subsystem_get_iopolicy() - Return the IO policy of subsytem
+ * @s:	nvme_subsystem_t object
+ *
+ * Return: IO policy used by current subsystem
+ */
+const char *nvme_subsystem_get_iopolicy(nvme_subsystem_t s);
+
+/**
  * nvme_scan_topology() - Scan NVMe topology and apply filter
  * @r:	    nvme_root_t object
  * @f:	    filter to apply


### PR DESCRIPTION
Allow to retrieve the iopolicy settings for the subsystem.

See https://github.com/linux-nvme/nvme-cli/issues/1963