### PR TITLE
nvme-tree: avoid warning in 'list-subsys'

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -702,7 +702,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
 		else
 			ret = -ENOMEM;
 	} else if (strcmp(s->subsysnqn, subsysnqn)) {
-		nvme_msg(r, LOG_WARNING, "NQN mismatch for subsystem '%s'\n",
+		nvme_msg(r, LOG_DEBUG, "NQN mismatch for subsystem '%s'\n",
 			 name);
 		ret = -EINVAL;
 	}


### PR DESCRIPTION
With the recent change to scan all subsystems, 'nvme list-subsys /dev/nvmeXnY' now displays an annoying warning for the NQN mismatch for all other subsystems that don't match during the subsystem scan. For e.g.

NQN mismatch for subsystem 'nvme-subsys1'
NQN mismatch for subsystem 'nvme-subsys4'
nvme-subsys3 - NQN=nqn.1992-08.com.netapp:sn.48391d66c0a611ecaaa5d039ea165514:subsystem.subsys_CLIENT116_1
               hostnqn=nqn.2014-08.org.nvmexpress:uuid:e6550026-173e-4959-ba74-be367844bd8a
\
 +- nvme3 tcp traddr=192.168.1.116,trsvcid=4420,host_traddr=192.168.1.16,host_iface=eth5 live optimized
 +- nvme7 tcp traddr=192.168.2.116,trsvcid=4420,host_traddr=192.168.2.16 live optimized
 +- nvme8 tcp traddr=192.168.1.116,trsvcid=4420,host_traddr=192.168.2.16 live optimized

Avoid this warning by displaying it only under debug level.

Fixes: fbd45f1 ("tree: Scan all subsystems")