### PR TITLE
nvme-tree: avoid segfault in 'list-subsys /dev/nvmeXnY'

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -693,6 +693,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
 				continue;
 			s = _s;
 			__nvme_scan_subsystem(r, s, f, f_args);
+			break;
 		}
 	}
 	if (!s) {


### PR DESCRIPTION
While iterating through nvme_for_each_subsystem() in nvme_scan_subsystem() and after a subsystem match is found, one occasionally encounters a strcmp segfault further in the loop due to junk _s->name values showing up in certain error scenarios on a scaled up config. For e.g. with libnvme debug logging enabled:

nvme list-subsys /dev/nvme99n1
...
scan subsystem nvme-subsys0
filter out subsystem nvme-subsys0
NQN mismatch for subsystem 'nvme-subsys0'
failed to scan subsystem nvme-subsys0: Invalid argument scan subsystem nvme-subsys1
filter out subsystem nvme-subsys1
Segmentation fault (core dumped)
...

Avoid this segfault by breaking from the nvme_for_each_subsystem() loop once the subsystem match is found.

Fixes: fbd45f1 ("tree: Scan all subsystems")