### PR TITLE
Discovery log page optimizations

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1171,34 +1171,15 @@ static void sanitize_discovery_log_entry(struct nvmf_disc_log_entry *e)
 int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 			   int max_retries)
 {
-	struct nvmf_discovery_log *log;
-
-	struct nvme_get_log_args args = {
-		.args_size = sizeof(args),
-		.fd = nvme_ctrl_get_fd(c),
-		.nsid = NVME_NSID_NONE,
-		.lsp = NVMF_LOG_DISC_LSP_NONE,
-		.lsi = NVME_LOG_LSI_NONE,
-		.uuidx = NVME_UUID_NONE,
+	struct nvme_get_discovery_args args = {
+		.c = c,
+		.max_retries = max_retries,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result = NULL,
-		.lid = NVME_LOG_LID_DISCOVER,
-		.log = NULL,
-		.len = 0,
-		.csi = NVME_CSI_NVM,
-		.rae = false,
-		.ot = false,
+		.lsp = NVMF_LOG_DISC_LSP_NONE,
 	};
 
-	log = nvme_discovery_log(c, &args, max_retries);
-	if (!log)
-		return -1;
-
-	for (int i = 0; i < le64_to_cpu(log->numrec); i++)
-		sanitize_discovery_log_entry(&log->entries[i]);
-
-	*logp = log;
-	return 0;
+	*logp = nvmf_get_discovery_wargs(&args);
+	return *logp ? 0 : -1;
 }
 
 struct nvmf_discovery_log *nvmf_get_discovery_wargs(struct nvme_get_discovery_args *args)

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1060,39 +1060,34 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 						     int max_retries)
 {
 	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
-	struct nvmf_discovery_log *log = NULL;
-	int ret, retries = 0;
+	struct nvmf_discovery_log *log;
+	int retries = 0;
 	const char *name = nvme_ctrl_get_name(c);
 	uint64_t genctr, numrec;
-	unsigned int size;
 	int fd = nvme_ctrl_get_fd(c);
 
-	args->fd = fd;
+	log = __nvme_alloc(sizeof(*log));
+	if (!log) {
+		nvme_msg(r, LOG_ERR,
+			 "could not allocate memory for discovery log header\n");
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	nvme_msg(r, LOG_DEBUG, "%s: get header (try %d/%d)\n",
+		 name, retries, max_retries);
+	args->lpo = 0;
+	args->log = log;
+	args->len = sizeof(*log);
+	if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
+		nvme_msg(r, LOG_INFO,
+			 "%s: discover try %d/%d failed, error %d\n",
+			 name, retries, max_retries, errno);
+		goto out_free_log;
+	}
 
 	do {
-		size = sizeof(struct nvmf_discovery_log);
-
-		free(log);
-		log = __nvme_alloc(size);
-		if (!log) {
-			nvme_msg(r, LOG_ERR,
-				 "could not allocate memory for discovery log header\n");
-			errno = ENOMEM;
-			return NULL;
-		}
-
-		nvme_msg(r, LOG_DEBUG, "%s: get header (try %d/%d)\n",
-			name, retries, max_retries);
-		args->lpo = 0;
-		args->len = size;
-		args->log = log;
-		ret = nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args);
-		if (ret) {
-			nvme_msg(r, LOG_INFO,
-				 "%s: discover try %d/%d failed, error %d\n",
-				 name, retries, max_retries, errno);
-			goto out_free_log;
-		}
+		size_t entries_size;
 
 		numrec = le64_to_cpu(log->numrec);
 		genctr = le64_to_cpu(log->genctr);
@@ -1100,11 +1095,9 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		if (numrec == 0)
 			break;
 
-		size = sizeof(struct nvmf_discovery_log) +
-			sizeof(struct nvmf_disc_log_entry) * numrec;
-
 		free(log);
-		log = __nvme_alloc(size);
+		entries_size = sizeof(*log->entries) * numrec;
+		log = __nvme_alloc(sizeof(*log) + entries_size);
 		if (!log) {
 			nvme_msg(r, LOG_ERR,
 				 "could not alloc memory for discovery log page\n");
@@ -1113,15 +1106,13 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		}
 
 		nvme_msg(r, LOG_DEBUG,
-			 "%s: get %" PRIu64
-			 " records (length %d genctr %" PRIu64 ")\n",
-			 name, numrec, size, genctr);
+			 "%s: get %" PRIu64 " records (genctr %" PRIu64 ")\n",
+			 name, numrec, genctr);
 
-		args->lpo = sizeof(struct nvmf_discovery_log);
-		args->len = size - sizeof(struct nvmf_discovery_log);
+		args->lpo = sizeof(*log);
 		args->log = log->entries;
-		ret = nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args);
-		if (ret) {
+		args->len = entries_size;
+		if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",
 				 name, retries, max_retries, errno);
@@ -1135,10 +1126,9 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		nvme_msg(r, LOG_DEBUG, "%s: get header again\n", name);
 
 		args->lpo = 0;
-		args->len = sizeof(struct nvmf_discovery_log);
 		args->log = log;
-		ret = nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args);
-		if (ret) {
+		args->len = sizeof(*log);
+		if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",
 				 name, retries, max_retries, errno);

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1083,7 +1083,6 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 
 		nvme_msg(r, LOG_DEBUG, "%s: get header (try %d/%d)\n",
 			name, retries, max_retries);
-		args->rae = true;
 		args->lpo = 0;
 		args->len = size;
 		args->log = log;
@@ -1118,7 +1117,6 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 			 " records (length %d genctr %" PRIu64 ")\n",
 			 name, numrec, size, genctr);
 
-		args->rae = true;
 		args->lpo = sizeof(struct nvmf_discovery_log);
 		args->len = size - sizeof(struct nvmf_discovery_log);
 		args->log = log->entries;
@@ -1136,7 +1134,6 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		 */
 		nvme_msg(r, LOG_DEBUG, "%s: get header again\n", name);
 
-		args->rae = false;
 		args->lpo = 0;
 		args->len = sizeof(struct nvmf_discovery_log);
 		args->log = log;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1062,16 +1062,26 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
  */
 #define DISCOVERY_HEADER_LEN 20
 
-static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
-						     struct nvme_get_log_args *args,
-						     int max_retries)
+static struct nvmf_discovery_log *nvme_discovery_log(
+	const struct nvme_get_discovery_args *args)
 {
-	nvme_root_t r = c->s && c->s->h ? c->s->h->r : NULL;
+	nvme_root_t r = root_from_ctrl(args->c);
 	struct nvmf_discovery_log *log;
 	int retries = 0;
-	const char *name = nvme_ctrl_get_name(c);
+	const char *name = nvme_ctrl_get_name(args->c);
 	uint64_t genctr, numrec;
-	int fd = nvme_ctrl_get_fd(c);
+	int fd = nvme_ctrl_get_fd(args->c);
+	struct nvme_get_log_args log_args = {
+		.result = args->result,
+		.args_size = sizeof(log_args),
+		.timeout = args->timeout,
+		.lid = NVME_LOG_LID_DISCOVER,
+		.nsid = NVME_NSID_NONE,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = args->lsp,
+		.uuidx = NVME_UUID_NONE,
+	};
 
 	log = __nvme_alloc(sizeof(*log));
 	if (!log) {
@@ -1082,14 +1092,13 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 	}
 
 	nvme_msg(r, LOG_DEBUG, "%s: get header (try %d/%d)\n",
-		 name, retries, max_retries);
-	args->lpo = 0;
-	args->log = log;
-	args->len = DISCOVERY_HEADER_LEN;
-	if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
+		 name, retries, args->max_retries);
+	log_args.log = log;
+	log_args.len = DISCOVERY_HEADER_LEN;
+	if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &log_args)) {
 		nvme_msg(r, LOG_INFO,
 			 "%s: discover try %d/%d failed, error %d\n",
-			 name, retries, max_retries, errno);
+			 name, retries, args->max_retries, errno);
 		goto out_free_log;
 	}
 
@@ -1116,13 +1125,13 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 			 "%s: get %" PRIu64 " records (genctr %" PRIu64 ")\n",
 			 name, numrec, genctr);
 
-		args->lpo = sizeof(*log);
-		args->log = log->entries;
-		args->len = entries_size;
-		if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
+		log_args.lpo = sizeof(*log);
+		log_args.log = log->entries;
+		log_args.len = entries_size;
+		if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &log_args)) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",
-				 name, retries, max_retries, errno);
+				 name, retries, args->max_retries, errno);
 			goto out_free_log;
 		}
 
@@ -1132,17 +1141,17 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		 */
 		nvme_msg(r, LOG_DEBUG, "%s: get header again\n", name);
 
-		args->lpo = 0;
-		args->log = log;
-		args->len = DISCOVERY_HEADER_LEN;
-		if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
+		log_args.lpo = 0;
+		log_args.log = log;
+		log_args.len = DISCOVERY_HEADER_LEN;
+		if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &log_args)) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",
-				 name, retries, max_retries, errno);
+				 name, retries, args->max_retries, errno);
 			goto out_free_log;
 		}
 	} while (genctr != le64_to_cpu(log->genctr) &&
-		 ++retries < max_retries);
+		 ++retries < args->max_retries);
 
 	if (genctr != le64_to_cpu(log->genctr)) {
 		nvme_msg(r, LOG_INFO, "%s: discover genctr mismatch\n", name);
@@ -1186,24 +1195,7 @@ struct nvmf_discovery_log *nvmf_get_discovery_wargs(struct nvme_get_discovery_ar
 {
 	struct nvmf_discovery_log *log;
 
-	struct nvme_get_log_args _args = {
-		.args_size = sizeof(_args),
-		.fd = nvme_ctrl_get_fd(args->c),
-		.nsid = NVME_NSID_NONE,
-		.lsp = args->lsp,
-		.lsi = NVME_LOG_LSI_NONE,
-		.uuidx = NVME_UUID_NONE,
-		.timeout = args->timeout,
-		.result = args->result,
-		.lid = NVME_LOG_LID_DISCOVER,
-		.log = NULL,
-		.len = 0,
-		.csi = NVME_CSI_NVM,
-		.rae = false,
-		.ot = false,
-	};
-
-	log = nvme_discovery_log(args->c, &_args, args->max_retries);
+	log = nvme_discovery_log(args);
 	if (!log)
 		return NULL;
 

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1055,6 +1055,13 @@ nvme_ctrl_t nvmf_connect_disc_entry(nvme_host_t h,
 	return NULL;
 }
 
+/*
+ * Most of nvmf_discovery_log is reserved, so only fetch the initial bytes.
+ * 8 bytes for GENCTR, 8 for NUMREC, and 2 for RECFMT.
+ * Since only multiples of 4 bytes are allowed, round 18 up to 20.
+ */
+#define DISCOVERY_HEADER_LEN 20
+
 static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 						     struct nvme_get_log_args *args,
 						     int max_retries)
@@ -1078,7 +1085,7 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		 name, retries, max_retries);
 	args->lpo = 0;
 	args->log = log;
-	args->len = sizeof(*log);
+	args->len = DISCOVERY_HEADER_LEN;
 	if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
 		nvme_msg(r, LOG_INFO,
 			 "%s: discover try %d/%d failed, error %d\n",
@@ -1127,7 +1134,7 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 
 		args->lpo = 0;
 		args->log = log;
-		args->len = sizeof(*log);
+		args->len = DISCOVERY_HEADER_LEN;
 		if (nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args)) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",

--- a/test/ioctl/discovery.c
+++ b/test/ioctl/discovery.c
@@ -195,7 +195,7 @@ static void test_genctr_change(nvme_ctrl_t c)
 	};
 	/*
 	 * genctr changes after the entries are fetched the first time,
-	 * so the log page fetch is retried
+	 * so the log page entries are refetched
 	 */
 	struct mock_cmd mock_admin_cmds[] = {
 		{
@@ -212,13 +212,6 @@ static void test_genctr_change(nvme_ctrl_t c)
 			       | NVME_LOG_LID_DISCOVER, /* NUMDL */
 			.cdw12 = sizeof(header1), /* LPOL */
 			.out_data = entries1,
-		},
-		{
-			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header2),
-			.cdw10 = (sizeof(header2) / 4 - 1) << 16 /* NUMDL */
-			       | NVME_LOG_LID_DISCOVER, /* LID */
-			.out_data = &header2,
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
@@ -283,13 +276,6 @@ static void test_max_retries(nvme_ctrl_t c)
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header1), /* LPOL */
 			.out_data = &entry,
-		},
-		{
-			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header2),
-			.cdw10 = (sizeof(header2) / 4 - 1) << 16 /* NUMDL */
-			       | NVME_LOG_LID_DISCOVER, /* LID */
-			.out_data = &header2,
 		},
 		{
 			.opcode = nvme_admin_get_log_page,

--- a/test/ioctl/discovery.c
+++ b/test/ioctl/discovery.c
@@ -63,7 +63,6 @@ static void test_no_entries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header),
 			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -92,7 +91,6 @@ static void test_four_entries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header),
 			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -100,7 +98,6 @@ static void test_four_entries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(entries),
 			.cdw10 = (sizeof(entries) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header), /* LPOL */
 			.out_data = log_entries,
@@ -144,7 +141,6 @@ static void test_five_entries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header),
 			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -161,7 +157,6 @@ static void test_five_entries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = second_data_len,
 			.cdw10 = (second_data_len / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header) + first_data_len, /* LPOL */
 			.out_data = log_entries + first_entries,
@@ -207,7 +202,6 @@ static void test_genctr_change(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header1),
 			.cdw10 = (sizeof(header1) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header1,
 		},
@@ -215,7 +209,6 @@ static void test_genctr_change(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(entries1),
 			.cdw10 = (sizeof(entries1) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* NUMDL */
 			.cdw12 = sizeof(header1), /* LPOL */
 			.out_data = entries1,
@@ -231,7 +224,6 @@ static void test_genctr_change(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header2),
 			.cdw10 = (sizeof(header2) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header2,
 		},
@@ -239,7 +231,6 @@ static void test_genctr_change(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(entries2),
 			.cdw10 = (sizeof(entries2) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header2), /* LPOL */
 			.out_data = log_entries2,
@@ -282,7 +273,6 @@ static void test_max_retries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header1),
 			.cdw10 = (sizeof(header1) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header1,
 		},
@@ -290,7 +280,6 @@ static void test_max_retries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(entry),
 			.cdw10 = (sizeof(entry) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header1), /* LPOL */
 			.out_data = &entry,
@@ -306,7 +295,6 @@ static void test_max_retries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header2),
 			.cdw10 = (sizeof(header2) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header2,
 		},
@@ -314,7 +302,6 @@ static void test_max_retries(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(entry),
 			.cdw10 = (sizeof(entry) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header2), /* LPOL */
 			.out_data = &entry,
@@ -346,7 +333,6 @@ static void test_header_error(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = header_size,
 			.cdw10 = (header_size / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.err = NVME_SC_INVALID_OPCODE,
 		},
@@ -369,7 +355,6 @@ static void test_entries_error(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header),
 			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -377,7 +362,6 @@ static void test_entries_error(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = entry_size,
 			.cdw10 = (entry_size / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header), /* LPOL */
 			.err = -EIO,
@@ -402,7 +386,6 @@ static void test_genctr_error(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(header),
 			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -410,7 +393,6 @@ static void test_genctr_error(nvme_ctrl_t c)
 			.opcode = nvme_admin_get_log_page,
 			.data_len = sizeof(entry),
 			.cdw10 = (sizeof(entry) / 4 - 1) << 16 /* NUMDL */
-			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header), /* LPOL */
 			.out_data = &entry,

--- a/test/ioctl/discovery.c
+++ b/test/ioctl/discovery.c
@@ -13,6 +13,7 @@
 #include "util.h"
 
 #define TEST_FD 0xFD
+#define HEADER_LEN 20
 
 static void arbitrary_ascii_string(size_t max_len, char *str, char *log_str)
 {
@@ -61,8 +62,8 @@ static void test_no_entries(nvme_ctrl_t c)
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -89,8 +90,8 @@ static void test_four_entries(nvme_ctrl_t c)
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -104,8 +105,8 @@ static void test_four_entries(nvme_ctrl_t c)
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -139,8 +140,8 @@ static void test_five_entries(nvme_ctrl_t c)
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -163,8 +164,8 @@ static void test_five_entries(nvme_ctrl_t c)
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -200,8 +201,8 @@ static void test_genctr_change(nvme_ctrl_t c)
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header1),
-			.cdw10 = (sizeof(header1) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header1,
 		},
@@ -215,8 +216,8 @@ static void test_genctr_change(nvme_ctrl_t c)
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header2),
-			.cdw10 = (sizeof(header2) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header2,
 		},
@@ -230,8 +231,8 @@ static void test_genctr_change(nvme_ctrl_t c)
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header2),
-			.cdw10 = (sizeof(header2) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header2,
 		},
@@ -264,8 +265,8 @@ static void test_max_retries(nvme_ctrl_t c)
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header1),
-			.cdw10 = (sizeof(header1) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header1,
 		},
@@ -279,8 +280,8 @@ static void test_max_retries(nvme_ctrl_t c)
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header2),
-			.cdw10 = (sizeof(header2) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header2,
 		},
@@ -294,8 +295,8 @@ static void test_max_retries(nvme_ctrl_t c)
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header3),
-			.cdw10 = (sizeof(header3) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header3,
 		},
@@ -312,13 +313,12 @@ static void test_max_retries(nvme_ctrl_t c)
 
 static void test_header_error(nvme_ctrl_t c)
 {
-	size_t header_size = sizeof(struct nvmf_discovery_log);
 	/* Stop after an error in fetching the header the first time */
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = header_size,
-			.cdw10 = (header_size / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.err = NVME_SC_INVALID_OPCODE,
 		},
@@ -339,8 +339,8 @@ static void test_entries_error(nvme_ctrl_t c)
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -370,8 +370,8 @@ static void test_genctr_error(nvme_ctrl_t c)
 	struct mock_cmd mock_admin_cmds[] = {
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.out_data = &header,
 		},
@@ -385,8 +385,8 @@ static void test_genctr_error(nvme_ctrl_t c)
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
-			.data_len = sizeof(header),
-			.cdw10 = (sizeof(header) / 4 - 1) << 16 /* NUMDL */
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.err = NVME_SC_INTERNAL,
 		},


### PR DESCRIPTION
Several improvements to fetching the discovery log page:
- Don't set the Retain Asynchronous Event bit. To ensure notifications aren't missed, this bit needs to be cleared on at least once Get Log Page command sent, which is not currently happening. The simplest solution is just to clear the bit in all commands, so do that.
- Avoid fetching the log page header twice in a row in case of a GENCTR mismatch
- Reduce the number of bytes of the header fetched from 1K to 20, since only the first 18 bytes currently have a defined meaning
- Implement `nvmf_get_discovery_log()` in terms of `nvmf_get_discovery_wargs()` to avoid code duplication
- Pass `struct nvme_get_discovery_args` instead of `struct nvme_get_log_args` to `nvme_discovery_log()`. This avoids confusion about which function is responsible for filling in which arguments, and avoids redundant arguments.

Tested with the mock ioctl test infrastructure in #688. The test cases were updated to match the new discovery behavior.

It also works when run against a real NVMe/TCP controller:
```
$ nvme discover --transport tcp --traddr 192.168.1.12 --trsvcid 4420

Discovery Log Number of Records 4, Generation counter 5
=====Discovery Log Entry 0======
trtype:  tcp
adrfam:  ipv4
subtype: nvme subsystem
treq:    not specified
portid:  12549
trsvcid: 4420
subnqn:  nqn.2010-06.com.purestorage:flasharray.58152d9d09e68236
traddr:  192.168.4.12
eflags:  none
sectype: none
=====Discovery Log Entry 1======
trtype:  tcp
adrfam:  ipv4
subtype: nvme subsystem
treq:    not specified
portid:  12550
trsvcid: 4420
subnqn:  nqn.2010-06.com.purestorage:flasharray.58152d9d09e68236
traddr:  192.168.2.12
eflags:  none
sectype: none
=====Discovery Log Entry 2======
trtype:  tcp
adrfam:  ipv4
subtype: nvme subsystem
treq:    not specified
portid:  12294
trsvcid: 4420
subnqn:  nqn.2010-06.com.purestorage:flasharray.58152d9d09e68236
traddr:  192.168.1.12
eflags:  none
sectype: none
=====Discovery Log Entry 3======
trtype:  tcp
adrfam:  ipv4
subtype: nvme subsystem
treq:    not specified
portid:  12293
trsvcid: 4420
subnqn:  nqn.2010-06.com.purestorage:flasharray.58152d9d09e68236
traddr:  192.168.3.12
eflags:  none
sectype: none
```