### PR TITLE
Change handles from file-descriptors to 'struct dev_handle'

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -57,6 +57,8 @@ LIBNVME_MI_1_1 {
 		nvme_mi_open_mctp;
 		nvme_mi_scan_mctp;
 		nvme_mi_scan_ep;
+		get_dev;
+		dev_close;
 	local:
 		*;
 };

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -260,7 +260,7 @@ LIBNVME_1_0 {
 		nvme_ns_get_csi;
 		nvme_ns_get_ctrl;
 		nvme_ns_get_eui64;
-		nvme_ns_get_fd;
+		nvme_ns_get_hdl;
 		nvme_ns_get_firmware;
 		nvme_ns_get_generic_name;
 		nvme_ns_get_lba_count;

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,7 @@ mi_sources = [
     'nvme/log.c',
     'nvme/mi.c',
     'nvme/mi-mctp.c',
+    'nvme/handle.c',
 ]
 
 if json_c_dep.found()
@@ -131,6 +132,7 @@ install_headers([
         'nvme/types.h',
         'nvme/util.h',
         'nvme/mi.h',
+	'nvme/handle.h',
     ],
     subdir: 'nvme',
     install_mode: mode,

--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -25,12 +25,23 @@
  * be set to zero.
  */
 
+enum nvme_dev_type {
+	NVME_DEV_DIRECT,
+	NVME_DEV_MI,
+};
+
+struct dev_handle {
+        int fd;
+        enum nvme_dev_type dev_type;
+};
+
+
 /**
  * struct nvme_identify_args - Arguments for the NVMe Identify command
  * @result:		The command completion result from CQE dword0
  * @data:		User space destination address to transfer the data
+ * @hdl:		Device handle to nvme device
  * @args_size:		Size of &struct nvme_identify_args
- * @fd:			File descriptor of nvme device
  * @timeout:		Timeout in ms (0 for default timeout)
  * @cns:		The Controller or Namespace structure, see @enum nvme_identify_cns
  * @csi:		Command Set Identifier
@@ -42,8 +53,8 @@
 struct nvme_identify_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	enum nvme_identify_cns cns;
 	enum nvme_csi csi;
@@ -58,8 +69,8 @@ struct nvme_identify_args {
  * @lpo:	Log page offset for partial log transfers
  * @result:	The command completion result from CQE dword0
  * @log:	User space destination address to transfer the data
+ * @hdl:	Device handle to nvme device
  * @args_size:	Length of the structure
- * @fd:		File descriptor of nvme device
  * @timeout:	Timeout in ms
  * @lid:	Log page identifier, see &enum nvme_cmd_get_log_lid for known
  *		values
@@ -78,8 +89,8 @@ struct nvme_get_log_args {
 	__u64 lpo;
 	__u32 *result;
 	void *log;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	enum nvme_cmd_get_log_lid lid;
 	__u32 len;
@@ -96,8 +107,8 @@ struct nvme_get_log_args {
  * struct nvme_set_features_args - Arguments for the NVMe Admin Set Feature command
  * @result:	The command completion result from CQE dword0
  * @data:	User address of feature data, if applicable
+ * @hdl:	Device handle to nvme device
  * @args_size:	Size of &struct nvme_set_features_args
- * @fd:		File descriptor of nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID, if applicable
  * @cdw11:	Value to set the feature to
@@ -112,8 +123,8 @@ struct nvme_get_log_args {
 struct nvme_set_features_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 cdw11;
@@ -129,7 +140,7 @@ struct nvme_set_features_args {
 /**
  * struct nvme_get_features_args - Arguments for the NVMe Admin Get Feature command
  * @args_size:	Size of &struct nvme_get_features_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @result:	The command completion result from CQE dword0
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID, if applicable
@@ -144,8 +155,8 @@ struct nvme_set_features_args {
 struct nvme_get_features_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_get_features_sel sel;
@@ -159,7 +170,7 @@ struct nvme_get_features_args {
  * struct nvme_format_nvm_args - Arguments for the Format Nvme Namespace command
  * @result:	The command completion result from CQE dword0
  * @args_size:	Size of &struct nvme_format_nvm_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Set to override default timeout to this value in milliseconds;
  *		useful for long running formats. 0 will use system default.
  * @nsid:	Namespace ID to format
@@ -173,8 +184,8 @@ struct nvme_get_features_args {
  */
 struct nvme_format_nvm_args {
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_cmd_format_mset mset;
@@ -191,7 +202,7 @@ struct nvme_format_nvm_args {
  * @result:	NVMe command result
  * @ns:		Namespace identification descriptors
  * @args_size:	Size of &struct nvme_ns_mgmt_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace identifier
  * @sel:	Type of management operation to perform
@@ -203,8 +214,8 @@ struct nvme_format_nvm_args {
 struct nvme_ns_mgmt_args {
 	__u32 *result;
 	struct nvme_id_ns *ns;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_ns_mgmt_sel sel;
@@ -219,7 +230,7 @@ struct nvme_ns_mgmt_args {
  * @result:	NVMe command result
  * @ctrlist:	Controller list to modify attachment state of nsid
  * @args_size:	Size of &struct nvme_ns_attach_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID to execute attach selection
  * @sel:	Attachment selection, see &enum nvme_ns_attach_sel
@@ -227,8 +238,8 @@ struct nvme_ns_mgmt_args {
 struct nvme_ns_attach_args {
 	__u32 *result;
 	struct nvme_ctrl_list *ctrlist;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_ns_attach_sel sel;
@@ -237,7 +248,7 @@ struct nvme_ns_attach_args {
 /**
  * struct nvme_fw_download_args - Arguments for the NVMe Firmware Download command
  * @args_size:	Size of &struct nvme_fw_download_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @result:	The command completion result from CQE dword0
  * @timeout:	Timeout in ms
  * @offset:	Offset in the firmware data
@@ -247,8 +258,8 @@ struct nvme_ns_attach_args {
 struct nvme_fw_download_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 offset;
 	__u32 data_len;
@@ -257,7 +268,7 @@ struct nvme_fw_download_args {
 /**
  * struct nvme_fw_commit_args - Arguments for the NVMe Firmware Commit command
  * @args_size:	Size of &struct nvme_fw_commit_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @action:	Action to use for the firmware image, see &enum nvme_fw_commit_ca
  * @timeout:	Timeout in ms
  * @result:	The command completion result from CQE dword0
@@ -266,8 +277,8 @@ struct nvme_fw_download_args {
  */
 struct nvme_fw_commit_args {
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	enum nvme_fw_commit_ca action;
 	__u8 slot;
@@ -279,7 +290,7 @@ struct nvme_fw_commit_args {
  * @result:	The command completion result from CQE dword0
  * @data:	Security data payload to send
  * @args_size:	Size of &struct nvme_security_send_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID to issue security command on
  * @tl:		Protocol specific transfer length
@@ -292,8 +303,8 @@ struct nvme_fw_commit_args {
 struct nvme_security_send_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 tl;
@@ -309,7 +320,7 @@ struct nvme_security_send_args {
  * @result:	The command completion result from CQE dword0
  * @data:	Security data payload to send
  * @args_size:	Size of &struct nvme_security_receive_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID to issue security command on
  * @al:		Protocol specific allocation length
@@ -322,8 +333,8 @@ struct nvme_security_send_args {
 struct nvme_security_receive_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 al;
@@ -340,7 +351,7 @@ struct nvme_security_receive_args {
  * @result:	The command completion result from CQE dword0
  * @slba:	Starting logical block address to check statuses
  * @args_size:	Size of &struct nvme_get_lba_status_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID to retrieve LBA status
  * @mndw:	Maximum number of dwords to return
@@ -352,8 +363,8 @@ struct nvme_get_lba_status_args {
 	__u64 slba;
 	__u32 *result;
 	struct nvme_lba_status *lbas;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 mndw;
@@ -366,7 +377,7 @@ struct nvme_get_lba_status_args {
  * @result:	If successful, the CQE dword0 value
  * @data:	Data payload to be send
  * @args_size:	Size of &struct nvme_directive_send_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID, if applicable
  * @doper:	Directive send operation, see &enum nvme_directive_send_doper
@@ -378,8 +389,8 @@ struct nvme_get_lba_status_args {
 struct nvme_directive_send_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_directive_send_doper doper;
@@ -394,7 +405,7 @@ struct nvme_directive_send_args {
  * @result:	If successful, the CQE dword0 value
  * @data:	Userspace address of data payload
  * @args_size:	Size of &struct nvme_directive_recv_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID, if applicable
  * @doper:	Directive send operation, see &enum nvme_directive_send_doper
@@ -406,8 +417,8 @@ struct nvme_directive_send_args {
 struct nvme_directive_recv_args {
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_directive_receive_doper doper;
@@ -421,7 +432,7 @@ struct nvme_directive_recv_args {
  * struct nvme_capacity_mgmt_args - Arguments for the NVMe Capacity Management command
  * @result:	If successful, the CQE dword0 value
  * @args_size:	Size of &struct nvme_capacity_mgmt_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cdw11:	Least significant 32 bits of the capacity in bytes of the
  *		Endurance Group or NVM Set to be created
  * @cdw12:	Most significant 32 bits of the capacity in bytes of the
@@ -432,8 +443,8 @@ struct nvme_directive_recv_args {
  */
 struct nvme_capacity_mgmt_args {
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 cdw11;
 	__u32 cdw12;
@@ -444,7 +455,7 @@ struct nvme_capacity_mgmt_args {
 /**
  * struct nvme_lockdown_args - Arguments for the NVME Lockdown command
  * @args_size:	Size of &struct nvme_lockdown_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @result:	The command completion result from CQE dword0
  * @timeout:	Timeout in ms (0 for default timeout)
  * @scp:	Scope of the command
@@ -455,8 +466,8 @@ struct nvme_capacity_mgmt_args {
  */
 struct nvme_lockdown_args {
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u8 scp;
 	__u8 prhbt;
@@ -468,7 +479,7 @@ struct nvme_lockdown_args {
 /**
  * struct nvme_set_property_args - Arguments for NVMe Set Property command
  * @args_size:	Size of &struct nvme_set_property_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @result:	The command completion result from CQE dword0
  * @timeout:	Timeout in ms
  * @offset:	Property offset from the base to set
@@ -477,8 +488,8 @@ struct nvme_lockdown_args {
 struct nvme_set_property_args {
 	__u64 value;
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	int offset;
 };
@@ -487,14 +498,14 @@ struct nvme_set_property_args {
  * struct nvme_get_property_args - Arguments for NVMe Get Property command
  * @value:	Where the property's value will be stored on success
  * @args_size:	Size of &struct nvme_get_property_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @offset:	Property offset from the base to retrieve
  * @timeout:	Timeout in ms
  */
 struct nvme_get_property_args {
 	__u64 *value;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	int offset;
 };
@@ -503,7 +514,7 @@ struct nvme_get_property_args {
  * struct nvme_sanitize_nvm_args - Arguments for the NVMe Sanitize NVM command
  * @result:	The command completion result from CQE dword0
  * @args_size:	Size of &struct nvme_sanitize_nvm_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @ovrpat:	Overwrite pattern
  * @sanact:	Sanitize action, see &enum nvme_sanitize_sanact
@@ -514,8 +525,8 @@ struct nvme_get_property_args {
  */
 struct nvme_sanitize_nvm_args {
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	enum nvme_sanitize_sanact sanact;
 	__u32 ovrpat;
@@ -529,15 +540,15 @@ struct nvme_sanitize_nvm_args {
  * struct nvme_dev_self_test_args - Arguments for the NVMe Device Self Test command
  * @result:	The command completion result from CQE dword0
  * @args_size:	Size of &struct nvme_dev_self_test_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID to test
  * @stc:	Self test code, see &enum nvme_dst_stc
  * @timeout:	Timeout in ms
  */
 struct nvme_dev_self_test_args {
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_dst_stc stc;
@@ -547,7 +558,7 @@ struct nvme_dev_self_test_args {
  * struct nvme_virtual_mgmt_args - Arguments for the NVMe Virtualization
  *			    resource management command
  * @args_size:	Size of &struct nvme_virtual_mgmt_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @result:	If successful, the CQE dword0
  * @timeout:	Timeout in ms
  * @act:	Virtual resource action, see &enum nvme_virt_mgmt_act
@@ -557,8 +568,8 @@ struct nvme_dev_self_test_args {
  */
 struct nvme_virtual_mgmt_args {
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	enum nvme_virt_mgmt_act act;
 	enum nvme_virt_mgmt_rt rt;
@@ -575,7 +586,7 @@ struct nvme_virtual_mgmt_args {
  * @data:	Pointer to user address of the data buffer
  * @metadata:	Pointer to user address of the metadata buffer
  * @args_size:	Size of &struct nvme_io_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID
  * @data_len:	Length of user buffer, @data, in bytes
@@ -611,8 +622,8 @@ struct nvme_io_args {
 	__u32 *result;
 	void *data;
 	void *metadata;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 reftag;
@@ -635,7 +646,7 @@ struct nvme_io_args {
  * @result:	The command completion result from CQE dword0
  * @dsm:	The data set management attributes
  * @args_size:	Size of &struct nvme_dsm_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace identifier
  * @attrs:	DSM attributes, see &enum nvme_dsm_attributes
@@ -644,8 +655,8 @@ struct nvme_io_args {
 struct nvme_dsm_args {
 	__u32 *result;
 	struct nvme_dsm_range *dsm;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 attrs;
@@ -658,7 +669,7 @@ struct nvme_dsm_args {
  * @result:	The command completion result from CQE dword0
  * @copy:	Range description
  * @args_size:	Size of &struct nvme_copy_args
- * @fd:		File descriptor of the nvme device
+ * @hdl:		File descriptor of the nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace identifier
  * @ilbrt:	Initial logical block reference tag
@@ -679,8 +690,8 @@ struct nvme_copy_args {
 	__u64 sdlba;
 	__u32 *result;
 	struct nvme_copy_range *copy;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 ilbrt;
@@ -704,7 +715,7 @@ struct nvme_copy_args {
  * @iekey:	Set to ignore the existing key
  * @result:	The command completion result from CQE dword0
  * @args_size:	Size of &struct nvme_resv_acquire_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace identifier
  * @rtype:	The type of reservation to be create, see &enum nvme_resv_rtype
@@ -715,8 +726,8 @@ struct nvme_resv_acquire_args {
 	__u64 crkey;
 	__u64 nrkey;
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_resv_rtype rtype;
@@ -731,7 +742,7 @@ struct nvme_resv_acquire_args {
  *		replace
  * @result:	The command completion result from CQE dword0
  * @args_size:	Size of &struct nvme_resv_register_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier
  * @rrega:	The registration action, see &enum nvme_resv_rrega
  * @cptpl:	Change persist through power loss, see &enum nvme_resv_cptpl
@@ -742,8 +753,8 @@ struct nvme_resv_register_args {
 	__u64 crkey;
 	__u64 nrkey;
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_resv_rrega rrega;
@@ -756,7 +767,7 @@ struct nvme_resv_register_args {
  * @crkey:	The current reservation key to release
  * @result:	The command completion result from CQE dword0
  * @args_size:	Size of &struct nvme_resv_release_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace identifier
  * @rtype:	The type of reservation to be create, see &enum nvme_resv_rtype
@@ -766,8 +777,8 @@ struct nvme_resv_register_args {
 struct nvme_resv_release_args {
 	__u64 crkey;
 	__u32 *result;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_resv_rtype rtype;
@@ -781,7 +792,7 @@ struct nvme_resv_release_args {
  * @report:	The user space destination address to store the reservation
  *		report
  * @args_size:	Size of &struct nvme_resv_report_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace identifier
  * @len:	Number of bytes to request transferred with this command
@@ -790,8 +801,8 @@ struct nvme_resv_release_args {
 struct nvme_resv_report_args {
 	__u32 *result;
 	struct nvme_resv_status *report;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 len;
@@ -802,7 +813,7 @@ struct nvme_resv_report_args {
  * struct nvme_io_mgmt_recv_args - Arguments for the NVMe I/O Management Receive command
  * @data:	Userspace address of the data
  * @args_size:	Size of &struct nvme_io_mgmt_recv_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier
  * @data_len:	Length of @data
  * @timeout:	Timeout in ms
@@ -811,8 +822,8 @@ struct nvme_resv_report_args {
  */
 struct nvme_io_mgmt_recv_args {
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 nsid;
 	__u32 data_len;
 	__u32 timeout;
@@ -824,7 +835,7 @@ struct nvme_io_mgmt_recv_args {
  * struct nvme_io_mgmt_send_args - Arguments for the NVMe I/O Management Send command
  * @data:	Userspace address of the data
  * @args_size:	Size of &struct nvme_io_mgmt_send_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier
  * @data_len:	Length of @data
  * @timeout:	Timeout in ms
@@ -833,8 +844,8 @@ struct nvme_io_mgmt_recv_args {
  */
 struct nvme_io_mgmt_send_args {
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 nsid;
 	__u32 data_len;
 	__u32 timeout;
@@ -848,7 +859,7 @@ struct nvme_io_mgmt_send_args {
  * @result:	The command completion result from CQE dword0
  * @data:	Userspace address of the data
  * @args_size:	Size of &struct nvme_zns_mgmt_send_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	timeout in ms
  * @nsid:	Namespace ID
  * @zsa:	Zone send action
@@ -860,8 +871,8 @@ struct nvme_zns_mgmt_send_args {
 	__u64 slba;
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_zns_send_action zsa;
@@ -876,7 +887,7 @@ struct nvme_zns_mgmt_send_args {
  * @result:	The command completion result from CQE dword0
  * @data:	Userspace address of the data
  * @args_size:	Size of &struct nvme_zns_mgmt_recv_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	timeout in ms
  * @nsid:	Namespace ID
  * @zra:	zone receive action
@@ -888,8 +899,8 @@ struct nvme_zns_mgmt_recv_args {
 	__u64 slba;
 	__u32 *result;
 	void *data;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	enum nvme_zns_recv_action zra;
@@ -905,7 +916,7 @@ struct nvme_zns_mgmt_recv_args {
  * @data:	Userspace address of the data
  * @metadata:	Userspace address of the metadata
  * @args_size:	Size of &struct nvme_zns_append_args
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @nsid:	Namespace ID
  * @ilbrt:	Initial logical block reference tag
@@ -925,8 +936,8 @@ struct nvme_zns_append_args {
 	__u64 *result;
 	void *data;
 	void *metadata;
+	struct dev_handle *hdl;
 	int args_size;
-	int fd;
 	__u32 timeout;
 	__u32 nsid;
 	__u32 ilbrt;
@@ -945,7 +956,7 @@ struct nvme_zns_append_args {
  * @result:	Set on completion to the command's CQE DWORD 0 controller response.
  * @data:	Pointer to the DIM data
  * @args_size:	Length of the structure
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @timeout:	Timeout in ms
  * @data_len:	Length of @data
  * @tas:	Task field of the Command Dword 10 (cdw10)
@@ -953,8 +964,8 @@ struct nvme_zns_append_args {
 struct nvme_dim_args {
 	__u32	*result;
 	void	*data;
+	struct dev_handle *hdl;
 	int	args_size;
-	int	fd;
 	__u32	timeout;
 	__u32	data_len;
 	__u8	tas;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1062,9 +1062,9 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 	const char *name = nvme_ctrl_get_name(c);
 	uint64_t genctr, numrec;
 	unsigned int size;
-	int fd = nvme_ctrl_get_fd(c);
+	struct dev_handle *hdl = nvme_ctrl_get_fd(c);
 
-	args->fd = fd;
+	args->hdl = hdl;
 
 	do {
 		size = sizeof(struct nvmf_discovery_log);
@@ -1084,7 +1084,7 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		args->lpo = 0;
 		args->len = size;
 		args->log = log;
-		ret = nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args);
+		ret = nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, args);
 		if (ret) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",
@@ -1119,7 +1119,7 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		args->lpo = sizeof(struct nvmf_discovery_log);
 		args->len = size - sizeof(struct nvmf_discovery_log);
 		args->log = log->entries;
-		ret = nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args);
+		ret = nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, args);
 		if (ret) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",
@@ -1137,7 +1137,8 @@ static struct nvmf_discovery_log *nvme_discovery_log(nvme_ctrl_t c,
 		args->lpo = 0;
 		args->len = sizeof(struct nvmf_discovery_log);
 		args->log = log;
-		ret = nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, args);
+		ret = nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, args);
+
 		if (ret) {
 			nvme_msg(r, LOG_INFO,
 				 "%s: discover try %d/%d failed, error %d\n",
@@ -1198,7 +1199,7 @@ int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,
 
 	struct nvme_get_log_args args = {
 		.args_size = sizeof(args),
-		.fd = nvme_ctrl_get_fd(c),
+		.hdl = nvme_ctrl_get_fd(c),
 		.nsid = NVME_NSID_NONE,
 		.lsp = NVMF_LOG_DISC_LSP_NONE,
 		.lsi = NVME_LOG_LSI_NONE,
@@ -1230,7 +1231,7 @@ struct nvmf_discovery_log *nvmf_get_discovery_wargs(struct nvme_get_discovery_ar
 
 	struct nvme_get_log_args _args = {
 		.args_size = sizeof(_args),
-		.fd = nvme_ctrl_get_fd(args->c),
+		.hdl = nvme_ctrl_get_fd(args->c),
 		.nsid = NVME_NSID_NONE,
 		.lsp = args->lsp,
 		.lsi = NVME_LOG_LSI_NONE,
@@ -1589,7 +1590,7 @@ static int nvmf_dim(nvme_ctrl_t c, enum nvmf_dim_tas tas, __u8 trtype,
 
 	struct nvme_dim_args args = {
 		.args_size = sizeof(args),
-		.fd = nvme_ctrl_get_fd(c),
+		.hdl = nvme_ctrl_get_fd(c),
 		.result = result,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.tas = tas

--- a/src/nvme/handle.c
+++ b/src/nvme/handle.c
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2023
+ *
+ * Authors: Vikash Kumar <vikash.k5@samsung.com>
+ */
+#include <errno.h>
+#include <getopt.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <math.h>
+#include <dirent.h>
+#include <libgen.h>
+#include <signal.h>
+#include <syslog.h>
+#include <linux/fs.h>
+
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "mi.h"
+#include "handle.h"
+
+static bool is_chardev(struct nvme_dev *dev)
+{
+        return S_ISCHR(dev->direct.stat.st_mode);
+}
+
+static bool is_blkdev(struct nvme_dev *dev)
+{
+        return S_ISBLK(dev->direct.stat.st_mode);
+}
+
+static int open_dev_direct(struct nvme_dev **devp, char *devstr, int flags)
+{
+        struct nvme_dev *dev;
+        int err;
+
+        dev = calloc(1, sizeof(*dev));
+        if (!dev)
+                return -1;
+
+        dev->type = NVME_DEV_DIRECT;
+        dev->name = basename(devstr);
+        err = open(devstr, flags);
+        if (err < 0) {
+                perror(devstr);
+                goto err_free;
+        }
+        dev->direct.hdl.fd = err;
+        dev->direct.hdl.dev_type = NVME_DEV_DIRECT;
+        err = fstat(dev->direct.hdl.fd, &dev->direct.stat);
+        if (err < 0) {
+                perror(devstr);
+                goto err_close;
+        }
+        if (!is_chardev(dev) && !is_blkdev(dev)) {
+                fprintf(stderr, "%s is not a block or character device\n",
+                        devstr);
+                err = -ENODEV;
+                goto err_close;
+        }
+        *devp = dev;
+        return 0;
+
+err_close:
+        close(dev_hdl(dev)->fd);
+err_free:
+        free(dev);
+        return err;
+}
+
+static int parse_mi_dev(char *dev, unsigned int *net, uint8_t *eid,
+                        unsigned int *ctrl)
+{
+        int rc;
+
+        /* <net>,<eid>:<ctrl-id> form */
+        rc = sscanf(dev, "mctp:%u,%hhu:%u", net, eid, ctrl);
+        if (rc == 3)
+                return 0;
+
+        /* <net>,<eid> form, implicit ctrl-id = 0 */
+        *ctrl = 0;
+        rc = sscanf(dev, "mctp:%u,%hhu", net, eid);
+        if (rc == 2)
+                return 0;
+
+        return -1;
+}
+
+static int open_dev_mi_mctp(struct nvme_dev **devp, char *devstr)
+{
+        unsigned int net, ctrl_id;
+        struct nvme_dev *dev;
+        unsigned char eid;
+        int rc;
+
+        rc = parse_mi_dev(devstr, &net, &eid, &ctrl_id);
+        if (rc) {
+                fprintf(stderr, "invalid device specifier '%s'\n", devstr);
+                return rc;
+        }
+
+        dev = calloc(1, sizeof(*dev));
+        if (!dev)
+                return -1;
+
+        dev->type = NVME_DEV_MI;
+        dev->name = devstr;
+
+        /* todo: verbose argument */
+        dev->mi.root = nvme_mi_create_root(stderr, LOG_WARNING);
+        if (!dev->mi.root)
+                goto err_free;
+
+        dev->mi.ep = nvme_mi_open_mctp(dev->mi.root, net, eid);
+        if (!dev->mi.ep)
+                goto err_free_root;
+
+        dev->mi.ctrl = nvme_mi_init_ctrl(dev->mi.ep, ctrl_id);
+        if (!dev->mi.ctrl)
+                goto err_close_ep;
+
+        *devp = dev;
+        return 0;
+
+err_close_ep:
+        nvme_mi_close(dev->mi.ep);
+err_free_root:
+        nvme_mi_free_root(dev->mi.root);
+err_free:
+        free(dev);
+        return -1;
+}
+
+static int check_arg_dev(int argc, char **argv)
+{
+        if (optind >= argc) {
+                errno = EINVAL;
+                perror(argv[0]);
+                return -EINVAL;
+        }
+        return 0;
+}
+
+int get_dev(struct nvme_dev **dev, int argc, char **argv, int flags)
+{
+        char *devname;
+        int ret;
+
+        ret = check_arg_dev(argc, argv);
+        if (ret)
+                return ret;
+
+        devname = argv[optind];
+        if (!strncmp(devname, "mctp:", strlen("mctp:")))
+                ret = open_dev_mi_mctp(dev, devname);
+        else
+		ret = open_dev_direct(dev, devname, flags);
+
+        return ret;
+}
+
+void dev_close(struct nvme_dev *dev)
+{
+        switch (dev->type) {
+        case NVME_DEV_DIRECT:
+                close(dev->direct.hdl.fd);
+                break;
+        case NVME_DEV_MI:
+                nvme_mi_close(dev->mi.ep);
+                nvme_mi_free_root(dev->mi.root);
+                break;
+        }
+        free(dev);
+}

--- a/src/nvme/handle.h
+++ b/src/nvme/handle.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2023
+ *
+ * Authors: Vikash Kumar <vikash.k5@samsung.com>
+ */
+#ifndef _HANDLE_H
+#define _HANDLE_H
+
+#include <getopt.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/errno.h>
+
+#include "mi.h"
+
+struct nvme_dev {
+        enum nvme_dev_type type;
+        union {
+                struct {
+                        struct dev_handle hdl;
+                        struct stat stat;
+                } direct;
+                struct {
+                        nvme_root_t root;
+                        nvme_mi_ep_t ep;
+                        nvme_mi_ctrl_t ctrl;
+                } mi;
+        };
+
+        const char *name;
+};
+
+#define dev_hdl(d) __dev_hdl(d, __func__, __LINE__)
+
+static inline struct dev_handle* __dev_hdl(struct nvme_dev *dev, const char *func, int line)
+{
+        if (dev->type != NVME_DEV_DIRECT) {
+                fprintf(stderr,
+                        "warning: %s:%d not a direct transport!\n",
+                        func, line);
+                return NULL;
+        }
+        return &(dev->direct.hdl);
+}
+
+static inline nvme_mi_ep_t dev_mi_ep(struct nvme_dev *dev)
+{
+        if (dev->type != NVME_DEV_MI) {
+                fprintf(stderr,
+                        "warning: not a MI transport!\n");
+                return NULL;
+        }
+        return dev->mi.ep;
+}
+
+int get_dev(struct nvme_dev **dev, int argc, char **argv, int flags);
+
+void dev_close(struct nvme_dev *dev);
+
+#endif /* _HANDLE_H */

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -38,65 +38,76 @@ static int nvme_verify_chr(int fd)
 	return 0;
 }
 
-int nvme_subsystem_reset(int fd)
+int nvme_subsystem_reset(struct dev_handle *hdl)
 {
 	int ret;
 
-	ret = nvme_verify_chr(fd);
+	ret = nvme_verify_chr(hdl->fd);
 	if (ret)
 		return ret;
-	return ioctl(fd, NVME_IOCTL_SUBSYS_RESET);
+	return ioctl(hdl->fd, NVME_IOCTL_SUBSYS_RESET);
 }
 
-int nvme_ctrl_reset(int fd)
+int nvme_ctrl_reset(struct dev_handle *hdl)
 {
 	int ret;
 
-	ret = nvme_verify_chr(fd);
+	ret = nvme_verify_chr(hdl->fd);
 	if (ret)
 		return ret;
-	return ioctl(fd, NVME_IOCTL_RESET);
+	return ioctl(hdl->fd, NVME_IOCTL_RESET);
 }
 
-int nvme_ns_rescan(int fd)
+int nvme_ns_rescan(struct dev_handle *hdl)
 {
 	int ret;
 
-	ret = nvme_verify_chr(fd);
+	ret = nvme_verify_chr(hdl->fd);
 	if (ret)
 		return ret;
-	return ioctl(fd, NVME_IOCTL_RESCAN);
+	return ioctl(hdl->fd, NVME_IOCTL_RESCAN);
 }
 
-int nvme_get_nsid(int fd, __u32 *nsid)
+int nvme_get_nsid(struct dev_handle *hdl, __u32 *nsid)
 {
 	errno = 0;
-	*nsid = ioctl(fd, NVME_IOCTL_ID);
+	if (hdl->dev_type == NVME_DEV_DIRECT)
+		*nsid = ioctl(hdl->fd, NVME_IOCTL_ID);
 	return -1 * (errno != 0);
 }
 
-static int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
+static int nvme_submit_passthru64(struct dev_handle *hdl, unsigned long ioctl_cmd,
 				  struct nvme_passthru_cmd64 *cmd,
 				  __u64 *result)
 {
-	int err = ioctl(fd, ioctl_cmd, cmd);
+	int err = -1;
+
+	if (hdl->dev_type == NVME_DEV_DIRECT) {
+		err = ioctl(hdl->fd, ioctl_cmd, cmd);
+
+	}
 
 	if (err >= 0 && result)
 		*result = cmd->result;
 	return err;
 }
 
-static int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
+static int nvme_submit_passthru(struct dev_handle *hdl, unsigned long ioctl_cmd,
 				struct nvme_passthru_cmd *cmd, __u32 *result)
 {
-	int err = ioctl(fd, ioctl_cmd, cmd);
+        int err = -1;
 
-	if (err >= 0 && result)
-		*result = cmd->result;
-	return err;
+        if (hdl->dev_type == NVME_DEV_DIRECT) {
+                err = ioctl(hdl->fd, ioctl_cmd, cmd);
+
+        }
+
+        if (err >= 0 && result)
+                *result = cmd->result;
+        return err;
 }
 
-static int nvme_passthru64(int fd, unsigned long ioctl_cmd, __u8 opcode,
+static int nvme_passthru64(struct dev_handle *hdl, unsigned long ioctl_cmd, __u8 opcode,
 			   __u8 flags, __u16 rsvd, __u32 nsid, __u32 cdw2,
 			   __u32 cdw3, __u32 cdw10, __u32 cdw11, __u32 cdw12,
 			   __u32 cdw13, __u32 cdw14, __u32 cdw15,
@@ -123,10 +134,10 @@ static int nvme_passthru64(int fd, unsigned long ioctl_cmd, __u8 opcode,
 		.timeout_ms	= timeout_ms,
 	};
 
-	return nvme_submit_passthru64(fd, ioctl_cmd, &cmd, result);
+	return nvme_submit_passthru64(hdl, ioctl_cmd, &cmd, result);
 }
 
-static int nvme_passthru(int fd, unsigned long ioctl_cmd, __u8 opcode,
+static int nvme_passthru(struct dev_handle *hdl, unsigned long ioctl_cmd, __u8 opcode,
 			 __u8 flags, __u16 rsvd, __u32 nsid, __u32 cdw2,
 			 __u32 cdw3, __u32 cdw10, __u32 cdw11, __u32 cdw12,
 			 __u32 cdw13, __u32 cdw14, __u32 cdw15, __u32 data_len,
@@ -153,41 +164,41 @@ static int nvme_passthru(int fd, unsigned long ioctl_cmd, __u8 opcode,
 		.timeout_ms	= timeout_ms,
 	};
 
-	return nvme_submit_passthru(fd, ioctl_cmd, &cmd, result);
+	return nvme_submit_passthru(hdl, ioctl_cmd, &cmd, result);
 }
 
-int nvme_submit_admin_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
+int nvme_submit_admin_passthru64(struct dev_handle *hdl, struct nvme_passthru_cmd64 *cmd,
 				 __u64 *result)
 {
-	return nvme_submit_passthru64(fd, NVME_IOCTL_ADMIN64_CMD, cmd, result);
+	return nvme_submit_passthru64(hdl, NVME_IOCTL_ADMIN64_CMD, cmd, result);
 }
 
-int nvme_admin_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_admin_passthru64(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 			 __u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10,
 			 __u32 cdw11, __u32 cdw12, __u32 cdw13, __u32 cdw14,
 			 __u32 cdw15, __u32 data_len, void *data,
 			 __u32 metadata_len, void *metadata, __u32 timeout_ms,
 			 __u64 *result)
 {
-	return nvme_passthru64(fd, NVME_IOCTL_ADMIN64_CMD, opcode, flags, rsvd,
+	return nvme_passthru64(hdl, NVME_IOCTL_ADMIN64_CMD, opcode, flags, rsvd,
 			       nsid, cdw2, cdw3, cdw10, cdw11, cdw12, cdw13,
 			       cdw14, cdw15, data_len, data, metadata_len,
 			       metadata, timeout_ms, result);
 }
 
-int nvme_submit_admin_passthru(int fd, struct nvme_passthru_cmd *cmd, __u32 *result)
+int nvme_submit_admin_passthru(struct dev_handle *hdl, struct nvme_passthru_cmd *cmd, __u32 *result)
 {
-	return nvme_submit_passthru(fd, NVME_IOCTL_ADMIN_CMD, cmd, result);
+	return nvme_submit_passthru(hdl, NVME_IOCTL_ADMIN_CMD, cmd, result);
 }
 
-int nvme_admin_passthru(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_admin_passthru(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 			__u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10,
 			__u32 cdw11, __u32 cdw12, __u32 cdw13, __u32 cdw14,
 			__u32 cdw15, __u32 data_len, void *data,
 			__u32 metadata_len, void *metadata, __u32 timeout_ms,
 			__u32 *result)
 {
-	return nvme_passthru(fd, NVME_IOCTL_ADMIN_CMD, opcode, flags, rsvd,
+	return nvme_passthru(hdl, NVME_IOCTL_ADMIN_CMD, opcode, flags, rsvd,
 			     nsid, cdw2, cdw3, cdw10, cdw11, cdw12, cdw13,
 			     cdw14, cdw15, data_len, data, metadata_len,
 			     metadata, timeout_ms, result);
@@ -367,6 +378,8 @@ enum features {
 	NVME_FEATURES_IOCSP_IOCSCI_MASK				= 0xff,
 };
 
+
+
 int nvme_identify(struct nvme_identify_args *args)
 {
 	__u32 cdw10 = NVME_SET(args->cntid, IDENTIFY_CDW10_CNTID) |
@@ -390,7 +403,7 @@ int nvme_identify(struct nvme_identify_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_get_log(struct nvme_get_log_args *args)
@@ -427,10 +440,10 @@ int nvme_get_log(struct nvme_get_log_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
-int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args)
+int nvme_get_log_page(struct dev_handle *hdl, __u32 xfer_len, struct nvme_get_log_args *args)
 {
 	__u64 offset = 0, xfer, data_len = args->len;
 	__u64 start = args->lpo;
@@ -438,7 +451,7 @@ int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args)
 	void *ptr = args->log;
 	int ret;
 
-	args->fd = fd;
+	args->hdl = hdl;
 
 	/*
 	 * 4k is the smallest possible transfer unit, so restricting to 4k
@@ -492,15 +505,15 @@ int nvme_set_features(struct nvme_set_features_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
-static int __nvme_set_features(int fd, __u8 fid, __u32 cdw11, bool save,
+static int __nvme_set_features(struct dev_handle *hdl, __u8 fid, __u32 cdw11, bool save,
 			       __u32 *result)
 {
 	struct nvme_set_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = fid,
 		.nsid = NVME_NSID_NONE,
 		.cdw11 = cdw11,
@@ -516,7 +529,7 @@ static int __nvme_set_features(int fd, __u8 fid, __u32 cdw11, bool save,
 	return nvme_set_features(&args);
 }
 
-int nvme_set_features_arbitration(int fd, __u8 ab, __u8 lpw, __u8 mpw,
+int nvme_set_features_arbitration(struct dev_handle *hdl, __u8 ab, __u8 lpw, __u8 mpw,
 				  __u8 hpw, bool save, __u32 *result)
 {
 	__u32 value = NVME_SET(ab, FEAT_ARBITRATION_BURST) |
@@ -524,27 +537,27 @@ int nvme_set_features_arbitration(int fd, __u8 ab, __u8 lpw, __u8 mpw,
 			NVME_SET(mpw, FEAT_ARBITRATION_MPW) |
 			NVME_SET(hpw, FEAT_ARBITRATION_HPW);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_ARBITRATION, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_ARBITRATION, value, save,
 				   result);
 }
 
-int nvme_set_features_power_mgmt(int fd, __u8 ps, __u8 wh, bool save,
+int nvme_set_features_power_mgmt(struct dev_handle *hdl, __u8 ps, __u8 wh, bool save,
 				 __u32 *result)
 {
 	__u32 value = NVME_SET(ps, FEAT_PWRMGMT_PS) |
 			NVME_SET(wh, FEAT_PWRMGMT_PS);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_POWER_MGMT, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_POWER_MGMT, value, save,
 				   result);
 }
 
-int nvme_set_features_lba_range(int fd, __u32 nsid, __u32 nr_ranges, bool save,
+int nvme_set_features_lba_range(struct dev_handle *hdl, __u32 nsid, __u32 nr_ranges, bool save,
 				struct nvme_lba_range_type *data, __u32 *result)
 {
 	return -1;
 }
 
-int nvme_set_features_temp_thresh(int fd, __u16 tmpth, __u8 tmpsel,
+int nvme_set_features_temp_thresh(struct dev_handle *hdl, __u16 tmpth, __u8 tmpsel,
 				  enum nvme_feat_tmpthresh_thsel thsel,
 				  bool save, __u32 *result)
 {
@@ -552,79 +565,79 @@ int nvme_set_features_temp_thresh(int fd, __u16 tmpth, __u8 tmpsel,
 			NVME_SET(tmpsel, FEAT_TT_TMPSEL) |
 			NVME_SET(thsel, FEAT_TT_THSEL);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_TEMP_THRESH, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_TEMP_THRESH, value, save,
 				   result);
 }
 
-int nvme_set_features_err_recovery(int fd, __u32 nsid, __u16 tler, bool dulbe,
+int nvme_set_features_err_recovery(struct dev_handle *hdl, __u32 nsid, __u16 tler, bool dulbe,
 				   bool save, __u32 *result)
 {
 	__u32 value = NVME_SET(tler, FEAT_ERROR_RECOVERY_TLER) |
 			NVME_SET(!!dulbe, FEAT_ERROR_RECOVERY_DULBE);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_ERR_RECOVERY, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_ERR_RECOVERY, value, save,
 				   result);
 }
 
-int nvme_set_features_volatile_wc(int fd, bool wce, bool save, __u32 *result)
+int nvme_set_features_volatile_wc(struct dev_handle *hdl, bool wce, bool save, __u32 *result)
 {
 	__u32 value = NVME_SET(!!wce, FEAT_VWC_WCE);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_VOLATILE_WC, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_VOLATILE_WC, value, save,
 				   result);
 }
 
-int nvme_set_features_irq_coalesce(int fd, __u8 thr, __u8 time, bool save,
+int nvme_set_features_irq_coalesce(struct dev_handle *hdl, __u8 thr, __u8 time, bool save,
 				   __u32 *result)
 {
 	__u32 value = NVME_SET(thr, FEAT_IRQC_TIME) |
 			NVME_SET(time, FEAT_IRQC_THR);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_IRQ_COALESCE, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_IRQ_COALESCE, value, save,
 				   result);
 }
 
-int nvme_set_features_irq_config(int fd, __u16 iv, bool cd, bool save,
+int nvme_set_features_irq_config(struct dev_handle *hdl, __u16 iv, bool cd, bool save,
 				 __u32 *result)
 {
 	__u32 value = NVME_SET(iv, FEAT_ICFG_IV) |
 			NVME_SET(!!cd, FEAT_ICFG_CD);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_IRQ_CONFIG, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_IRQ_CONFIG, value, save,
 				   result);
 }
 
-int nvme_set_features_write_atomic(int fd, bool dn, bool save, __u32 *result)
+int nvme_set_features_write_atomic(struct dev_handle *hdl, bool dn, bool save, __u32 *result)
 {
 	__u32 value = NVME_SET(!!dn, FEAT_WA_DN);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_WRITE_ATOMIC, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_WRITE_ATOMIC, value, save,
 				   result);
 }
 
-int nvme_set_features_async_event(int fd, __u32 events,
+int nvme_set_features_async_event(struct dev_handle *hdl, __u32 events,
 				  bool save, __u32 *result)
 {
-	return __nvme_set_features(fd, NVME_FEAT_FID_ASYNC_EVENT, events, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_ASYNC_EVENT, events, save,
 				   result);
 }
 
-int nvme_set_features_auto_pst(int fd, bool apste, bool save,
+int nvme_set_features_auto_pst(struct dev_handle *hdl, bool apste, bool save,
 			       struct nvme_feat_auto_pst *apst, __u32 *result)
 {
 	__u32 value = NVME_SET(!!apste, FEAT_APST_APSTE);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_AUTO_PST, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_AUTO_PST, value, save,
 				   result);
 }
 
-int nvme_set_features_timestamp(int fd, bool save, __u64 timestamp)
+int nvme_set_features_timestamp(struct dev_handle *hdl, bool save, __u64 timestamp)
 {
 	__le64 t = cpu_to_le64(timestamp);
 	struct nvme_timestamp ts;
 	struct nvme_set_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.nsid = NVME_NSID_NONE,
 		.cdw11 = 0,
 		.cdw12 = 0,
@@ -641,30 +654,30 @@ int nvme_set_features_timestamp(int fd, bool save, __u64 timestamp)
 	return nvme_set_features(&args);
 }
 
-int nvme_set_features_hctm(int fd, __u16 tmt2, __u16 tmt1,
+int nvme_set_features_hctm(struct dev_handle *hdl, __u16 tmt2, __u16 tmt1,
 			   bool save, __u32 *result)
 {
 	__u32 value = NVME_SET(tmt2, FEAT_HCTM_TMT2) |
 			NVME_SET(tmt1, FEAT_HCTM_TMT1);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_HCTM, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_HCTM, value, save,
 				   result);
 }
 
-int nvme_set_features_nopsc(int fd, bool noppme, bool save, __u32 *result)
+int nvme_set_features_nopsc(struct dev_handle *hdl, bool noppme, bool save, __u32 *result)
 {
 	__u32 value = NVME_SET(noppme, FEAT_NOPS_NOPPME);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_NOPSC, value, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_NOPSC, value, save,
 				   result);
 }
 
-int nvme_set_features_rrl(int fd, __u8 rrl, __u16 nvmsetid,
+int nvme_set_features_rrl(struct dev_handle *hdl, __u8 rrl, __u16 nvmsetid,
 			  bool save, __u32 *result)
 {
 	struct nvme_set_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_RRL,
 		.nsid = NVME_NSID_NONE,
 		.cdw11 = nvmsetid,
@@ -681,12 +694,12 @@ int nvme_set_features_rrl(int fd, __u8 rrl, __u16 nvmsetid,
 	return nvme_set_features(&args);
 }
 
-int nvme_set_features_plm_config(int fd, bool plm, __u16 nvmsetid, bool save,
+int nvme_set_features_plm_config(struct dev_handle *hdl, bool plm, __u16 nvmsetid, bool save,
 				 struct nvme_plm_config *data, __u32 *result)
 {
 	struct nvme_set_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_PLM_CONFIG,
 		.nsid = NVME_NSID_NONE,
 		.cdw11 = nvmsetid,
@@ -703,13 +716,13 @@ int nvme_set_features_plm_config(int fd, bool plm, __u16 nvmsetid, bool save,
 	return nvme_set_features(&args);
 }
 
-int nvme_set_features_plm_window(int fd, enum nvme_feat_plm_window_select sel,
+int nvme_set_features_plm_window(struct dev_handle *hdl, enum nvme_feat_plm_window_select sel,
 				 __u16 nvmsetid, bool save, __u32 *result)
 {
 	__u32 cdw12 = NVME_SET(sel, FEAT_PLMW_WS);
 	struct nvme_set_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_PLM_WINDOW,
 		.nsid = NVME_NSID_NONE,
 		.cdw11 = nvmsetid,
@@ -726,22 +739,22 @@ int nvme_set_features_plm_window(int fd, enum nvme_feat_plm_window_select sel,
 	return nvme_set_features(&args);
 }
 
-int nvme_set_features_lba_sts_interval(int fd, __u16 lsiri, __u16 lsipi,
+int nvme_set_features_lba_sts_interval(struct dev_handle *hdl, __u16 lsiri, __u16 lsipi,
 				       bool save, __u32 *result)
 {
 	__u32 value = NVME_SET(lsiri, FEAT_LBAS_LSIRI) |
 			NVME_SET(lsipi, FEAT_LBAS_LSIPI);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_LBA_STS_INTERVAL, value,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_LBA_STS_INTERVAL, value,
 				   save, result);
 }
 
-int nvme_set_features_host_behavior(int fd, bool save,
+int nvme_set_features_host_behavior(struct dev_handle *hdl, bool save,
 	struct nvme_feat_host_behavior *data)
 {
 	struct nvme_set_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_HOST_BEHAVIOR,
 		.nsid = NVME_NSID_NONE,
 		.cdw11 = 0,
@@ -758,35 +771,35 @@ int nvme_set_features_host_behavior(int fd, bool save,
 	return nvme_set_features(&args);
 }
 
-int nvme_set_features_sanitize(int fd, bool nodrm, bool save, __u32 *result)
+int nvme_set_features_sanitize(struct dev_handle *hdl, bool nodrm, bool save, __u32 *result)
 {
-	return __nvme_set_features(fd, NVME_FEAT_FID_SANITIZE, !!nodrm, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_SANITIZE, !!nodrm, save,
 				   result);
 }
 
-int nvme_set_features_endurance_evt_cfg(int fd, __u16 endgid, __u8 egwarn,
+int nvme_set_features_endurance_evt_cfg(struct dev_handle *hdl, __u16 endgid, __u8 egwarn,
 					bool save, __u32 *result)
 {
 	__u32 value = endgid | egwarn << 16;
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_ENDURANCE_EVT_CFG, value,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_ENDURANCE_EVT_CFG, value,
 				   save, result);
 }
 
-int nvme_set_features_sw_progress(int fd, __u8 pbslc, bool save,
+int nvme_set_features_sw_progress(struct dev_handle *hdl, __u8 pbslc, bool save,
 				  __u32 *result)
 {
-	return __nvme_set_features(fd, NVME_FEAT_FID_SW_PROGRESS, pbslc, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_SW_PROGRESS, pbslc, save,
 				   result);
 }
 
-int nvme_set_features_host_id(int fd, bool save, bool exhid, __u8 *hostid)
+int nvme_set_features_host_id(struct dev_handle *hdl, bool save, bool exhid, __u8 *hostid)
 {
 	__u32 len = exhid ? 16 : 8;
 	__u32 value = !!exhid;
 	struct nvme_set_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_HOST_ID,
 		.nsid = NVME_NSID_NONE,
 		.cdw11 = value,
@@ -803,30 +816,30 @@ int nvme_set_features_host_id(int fd, bool save, bool exhid, __u8 *hostid)
 	return nvme_set_features(&args);
 }
 
-int nvme_set_features_resv_mask(int fd, __u32 mask, bool save, __u32 *result)
+int nvme_set_features_resv_mask(struct dev_handle *hdl, __u32 mask, bool save, __u32 *result)
 {
-	return __nvme_set_features(fd, NVME_FEAT_FID_RESV_MASK, mask, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_RESV_MASK, mask, save,
 				   result);
 }
 
-int nvme_set_features_resv_persist(int fd, bool ptpl, bool save, __u32 *result)
+int nvme_set_features_resv_persist(struct dev_handle *hdl, bool ptpl, bool save, __u32 *result)
 {
-	return __nvme_set_features(fd, NVME_FEAT_FID_RESV_PERSIST, !!ptpl, save,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_RESV_PERSIST, !!ptpl, save,
 				   result);
 }
 
-int nvme_set_features_write_protect(int fd, enum nvme_feat_nswpcfg_state state,
+int nvme_set_features_write_protect(struct dev_handle *hdl, enum nvme_feat_nswpcfg_state state,
 				    bool save, __u32 *result)
 {
-	return __nvme_set_features(fd, NVME_FEAT_FID_WRITE_PROTECT, state,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_WRITE_PROTECT, state,
 				   save, result);
 }
 
-int nvme_set_features_iocs_profile(int fd, __u8 iocsi, bool save)
+int nvme_set_features_iocs_profile(struct dev_handle *hdl, __u8 iocsi, bool save)
 {
 	__u32 value = NVME_SET(iocsi, FEAT_IOCSP_IOCSCI);
 
-	return __nvme_set_features(fd, NVME_FEAT_FID_IOCS_PROFILE, value,
+	return __nvme_set_features(hdl, NVME_FEAT_FID_IOCS_PROFILE, value,
 				   save, NULL);
 }
 
@@ -851,15 +864,15 @@ int nvme_get_features(struct nvme_get_features_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
-static int __nvme_get_features(int fd, enum nvme_features_id fid,
+static int __nvme_get_features(struct dev_handle *hdl, enum nvme_features_id fid,
 			       enum nvme_get_features_sel sel, __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = fid,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -874,25 +887,25 @@ static int __nvme_get_features(int fd, enum nvme_features_id fid,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_arbitration(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_arbitration(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_ARBITRATION, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_ARBITRATION, sel, result);
 }
 
-int nvme_get_features_power_mgmt(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_power_mgmt(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_POWER_MGMT, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_POWER_MGMT, sel, result);
 }
 
-int nvme_get_features_lba_range(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_lba_range(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				struct nvme_lba_range_type *data,
 				__u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_LBA_RANGE,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -907,44 +920,44 @@ int nvme_get_features_lba_range(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_temp_thresh(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_temp_thresh(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_TEMP_THRESH, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_TEMP_THRESH, sel, result);
 }
 
-int nvme_get_features_err_recovery(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_err_recovery(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_ERR_RECOVERY, sel,
+	return __nvme_get_features(hdl, NVME_FEAT_FID_ERR_RECOVERY, sel,
 				   result);
 }
 
-int nvme_get_features_volatile_wc(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_volatile_wc(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_VOLATILE_WC, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_VOLATILE_WC, sel, result);
 }
 
-int nvme_get_features_num_queues(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_num_queues(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_NUM_QUEUES, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_NUM_QUEUES, sel, result);
 }
 
-int nvme_get_features_irq_coalesce(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_irq_coalesce(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_IRQ_COALESCE, sel,
+	return __nvme_get_features(hdl, NVME_FEAT_FID_IRQ_COALESCE, sel,
 				   result);
 }
 
-int nvme_get_features_irq_config(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_irq_config(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u16 iv, __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_LBA_RANGE,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -959,25 +972,25 @@ int nvme_get_features_irq_config(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_write_atomic(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_write_atomic(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_WRITE_ATOMIC, sel,
+	return __nvme_get_features(hdl, NVME_FEAT_FID_WRITE_ATOMIC, sel,
 				   result);
 }
 
-int nvme_get_features_async_event(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_async_event(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_ASYNC_EVENT, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_ASYNC_EVENT, sel, result);
 }
 
-int nvme_get_features_auto_pst(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_auto_pst(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 			       struct nvme_feat_auto_pst *apst, __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_LBA_RANGE,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -992,18 +1005,18 @@ int nvme_get_features_auto_pst(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_host_mem_buf(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_host_mem_buf(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_HOST_MEM_BUF, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_HOST_MEM_BUF, sel, result);
 }
 
-int nvme_get_features_timestamp(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_timestamp(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				struct nvme_timestamp *ts)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_TIMESTAMP,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -1018,33 +1031,33 @@ int nvme_get_features_timestamp(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_kato(int fd, enum nvme_get_features_sel sel, __u32 *result)
+int nvme_get_features_kato(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_KATO, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_KATO, sel, result);
 }
 
-int nvme_get_features_hctm(int fd, enum nvme_get_features_sel sel, __u32 *result)
+int nvme_get_features_hctm(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_HCTM, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_HCTM, sel, result);
 }
 
-int nvme_get_features_nopsc(int fd, enum nvme_get_features_sel sel, __u32 *result)
+int nvme_get_features_nopsc(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_NOPSC, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_NOPSC, sel, result);
 }
 
-int nvme_get_features_rrl(int fd, enum nvme_get_features_sel sel, __u32 *result)
+int nvme_get_features_rrl(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_RRL, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_RRL, sel, result);
 }
 
-int nvme_get_features_plm_config(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_plm_config(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u16 nvmsetid, struct nvme_plm_config *data,
 				 __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_PLM_CONFIG,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -1059,12 +1072,12 @@ int nvme_get_features_plm_config(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_plm_window(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_plm_window(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u16 nvmsetid, __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_PLM_WINDOW,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -1079,20 +1092,20 @@ int nvme_get_features_plm_window(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_lba_sts_interval(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_lba_sts_interval(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				       __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_LBA_STS_INTERVAL, sel,
+	return __nvme_get_features(hdl, NVME_FEAT_FID_LBA_STS_INTERVAL, sel,
 				   result);
 }
 
-int nvme_get_features_host_behavior(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_host_behavior(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				    struct nvme_feat_host_behavior *data,
 				    __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_HOST_BEHAVIOR,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -1107,18 +1120,18 @@ int nvme_get_features_host_behavior(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_sanitize(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_sanitize(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 			       __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_SANITIZE, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_SANITIZE, sel, result);
 }
 
-int nvme_get_features_endurance_event_cfg(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_endurance_event_cfg(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 					  __u16 endgid, __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_ENDURANCE_EVT_CFG,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -1133,18 +1146,18 @@ int nvme_get_features_endurance_event_cfg(int fd, enum nvme_get_features_sel sel
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_sw_progress(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_sw_progress(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_SW_PROGRESS, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_SW_PROGRESS, sel, result);
 }
 
-int nvme_get_features_host_id(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_host_id(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 			      bool exhid, __u32 len, __u8 *hostid)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_HOST_ID,
 		.nsid = NVME_NSID_NONE,
 		.sel = sel,
@@ -1159,25 +1172,25 @@ int nvme_get_features_host_id(int fd, enum nvme_get_features_sel sel,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_resv_mask(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_resv_mask(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				__u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_RESV_MASK, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_RESV_MASK, sel, result);
 }
 
-int nvme_get_features_resv_persist(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_resv_persist(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_RESV_PERSIST, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_RESV_PERSIST, sel, result);
 }
 
-int nvme_get_features_write_protect(int fd, __u32 nsid,
+int nvme_get_features_write_protect(struct dev_handle *hdl, __u32 nsid,
 				    enum nvme_get_features_sel sel,
 				    __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.fid = NVME_FEAT_FID_WRITE_PROTECT,
 		.nsid = nsid,
 		.sel = sel,
@@ -1192,10 +1205,10 @@ int nvme_get_features_write_protect(int fd, __u32 nsid,
 	return nvme_get_features(&args);
 }
 
-int nvme_get_features_iocs_profile(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_iocs_profile(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result)
 {
-	return __nvme_get_features(fd, NVME_FEAT_FID_IOCS_PROFILE, sel, result);
+	return __nvme_get_features(hdl, NVME_FEAT_FID_IOCS_PROFILE, sel, result);
 }
 
 int nvme_format_nvm(struct nvme_format_nvm_args *args)
@@ -1227,7 +1240,7 @@ int nvme_format_nvm(struct nvme_format_nvm_args *args)
 		.timeout_ms	= args->timeout,
 	};
 
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_ns_mgmt(struct nvme_ns_mgmt_args *args)
@@ -1262,7 +1275,7 @@ int nvme_ns_mgmt(struct nvme_ns_mgmt_args *args)
 			cmd.addr = (__u64)(uintptr_t)args->ns;
 		}
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_ns_attach(struct nvme_ns_attach_args *args)
@@ -1282,7 +1295,7 @@ int nvme_ns_attach(struct nvme_ns_attach_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_fw_download(struct nvme_fw_download_args *args)
@@ -1303,7 +1316,7 @@ int nvme_fw_download(struct nvme_fw_download_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_fw_commit(struct nvme_fw_commit_args *args)
@@ -1322,7 +1335,7 @@ int nvme_fw_commit(struct nvme_fw_commit_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_security_send(struct nvme_security_send_args *args)
@@ -1347,7 +1360,7 @@ int nvme_security_send(struct nvme_security_send_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_security_receive(struct nvme_security_receive_args *args)
@@ -1372,7 +1385,7 @@ int nvme_security_receive(struct nvme_security_receive_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_get_lba_status(struct nvme_get_lba_status_args *args)
@@ -1398,7 +1411,7 @@ int nvme_get_lba_status(struct nvme_get_lba_status_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_directive_send(struct nvme_directive_send_args *args)
@@ -1423,10 +1436,10 @@ int nvme_directive_send(struct nvme_directive_send_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-        return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+        return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
-int nvme_directive_send_id_endir(int fd, __u32 nsid, bool endir,
+int nvme_directive_send_id_endir(struct dev_handle *hdl, __u32 nsid, bool endir,
 				 enum nvme_directive_dtype dtype,
 				 struct nvme_id_directives *id)
 {
@@ -1434,7 +1447,7 @@ int nvme_directive_send_id_endir(int fd, __u32 nsid, bool endir,
 		NVME_SET(endir, DIRECTIVE_SEND_IDENTIFY_CDW12_ENDIR);
 	struct nvme_directive_send_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.nsid = nsid,
 		.dspec = 0,
 		.dtype = NVME_DIRECTIVE_DTYPE_IDENTIFY,
@@ -1471,7 +1484,7 @@ int nvme_directive_recv(struct nvme_directive_recv_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_capacity_mgmt(struct nvme_capacity_mgmt_args *args)
@@ -1490,7 +1503,7 @@ int nvme_capacity_mgmt(struct nvme_capacity_mgmt_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_lockdown(struct nvme_lockdown_args *args)
@@ -1511,7 +1524,7 @@ int nvme_lockdown(struct nvme_lockdown_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_set_property(struct nvme_set_property_args *args)
@@ -1532,7 +1545,7 @@ int nvme_set_property(struct nvme_set_property_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_get_property(struct nvme_get_property_args *args)
@@ -1551,7 +1564,7 @@ int nvme_get_property(struct nvme_get_property_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru64(args->fd, &cmd, args->value);
+	return nvme_submit_admin_passthru64(args->hdl, &cmd, args->value);
 }
 
 int nvme_sanitize_nvm(struct nvme_sanitize_nvm_args *args)
@@ -1574,7 +1587,7 @@ int nvme_sanitize_nvm(struct nvme_sanitize_nvm_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_dev_self_test(struct nvme_dev_self_test_args *args)
@@ -1592,7 +1605,7 @@ int nvme_dev_self_test(struct nvme_dev_self_test_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_virtual_mgmt(struct nvme_virtual_mgmt_args *args)
@@ -1613,39 +1626,39 @@ int nvme_virtual_mgmt(struct nvme_virtual_mgmt_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }
 
-int nvme_submit_io_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
+int nvme_submit_io_passthru64(struct dev_handle *hdl, struct nvme_passthru_cmd64 *cmd,
 			      __u64 *result)
 {
-	return nvme_submit_passthru64(fd, NVME_IOCTL_IO64_CMD, cmd, result);
+	return nvme_submit_passthru64(hdl, NVME_IOCTL_IO64_CMD, cmd, result);
 }
 
-int nvme_io_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_io_passthru64(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 		       __u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10,
 		       __u32 cdw11, __u32 cdw12, __u32 cdw13, __u32 cdw14,
 		       __u32 cdw15, __u32 data_len, void *data, __u32 metadata_len,
 		       void *metadata, __u32 timeout_ms, __u64 *result)
 {
-	return nvme_passthru64(fd, NVME_IOCTL_IO64_CMD, opcode, flags, rsvd,
+	return nvme_passthru64(hdl, NVME_IOCTL_IO64_CMD, opcode, flags, rsvd,
 			       nsid, cdw2, cdw3, cdw10, cdw11, cdw12, cdw13,
 			       cdw14, cdw15, data_len, data, metadata_len, metadata,
 			       timeout_ms, result);
 }
 
-int nvme_submit_io_passthru(int fd, struct nvme_passthru_cmd *cmd, __u32 *result)
+int nvme_submit_io_passthru(struct dev_handle *hdl, struct nvme_passthru_cmd *cmd, __u32 *result)
 {
-	return nvme_submit_passthru(fd, NVME_IOCTL_IO_CMD, cmd, result);
+	return nvme_submit_passthru(hdl, NVME_IOCTL_IO_CMD, cmd, result);
 }
 
-int nvme_io_passthru(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_io_passthru(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 		     __u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10,
 		     __u32 cdw11, __u32 cdw12, __u32 cdw13, __u32 cdw14,
 		     __u32 cdw15, __u32 data_len, void *data, __u32 metadata_len,
 		     void *metadata, __u32 timeout_ms, __u32 *result)
 {
-	return nvme_passthru(fd, NVME_IOCTL_IO_CMD, opcode, flags, rsvd, nsid,
+	return nvme_passthru(hdl, NVME_IOCTL_IO_CMD, opcode, flags, rsvd, nsid,
 			     cdw2, cdw3, cdw10, cdw11, cdw12, cdw13, cdw14,
 			     cdw15, data_len, data, metadata_len, metadata,
 			     timeout_ms, result);
@@ -1745,7 +1758,7 @@ int nvme_io(struct nvme_io_args *args, __u8 opcode)
 		.timeout_ms	= args->timeout,
 	};
 
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_dsm(struct nvme_dsm_args *args)
@@ -1764,7 +1777,7 @@ int nvme_dsm(struct nvme_dsm_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_copy(struct nvme_copy_args *args)
@@ -1811,7 +1824,7 @@ int nvme_copy(struct nvme_copy_args *args)
 		.timeout_ms	= args->timeout,
 	};
 
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_resv_acquire(struct nvme_resv_acquire_args *args)
@@ -1837,7 +1850,7 @@ int nvme_resv_acquire(struct nvme_resv_acquire_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_resv_register(struct nvme_resv_register_args *args)
@@ -1863,7 +1876,7 @@ int nvme_resv_register(struct nvme_resv_register_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_resv_release(struct nvme_resv_release_args *args)
@@ -1886,7 +1899,7 @@ int nvme_resv_release(struct nvme_resv_release_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_resv_report(struct nvme_resv_report_args *args)
@@ -1905,7 +1918,7 @@ int nvme_resv_report(struct nvme_resv_report_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_io_mgmt_recv(struct nvme_io_mgmt_recv_args *args)
@@ -1928,7 +1941,7 @@ int nvme_io_mgmt_recv(struct nvme_io_mgmt_recv_args *args)
 		return -1;
 	}
 
-	return nvme_submit_io_passthru(args->fd, &cmd, NULL);
+	return nvme_submit_io_passthru(args->hdl, &cmd, NULL);
 }
 
 int nvme_io_mgmt_send(struct nvme_io_mgmt_send_args *args)
@@ -1949,7 +1962,7 @@ int nvme_io_mgmt_send(struct nvme_io_mgmt_send_args *args)
 		return -1;
 	}
 
-	return nvme_submit_io_passthru(args->fd, &cmd, NULL);
+	return nvme_submit_io_passthru(args->hdl, &cmd, NULL);
 }
 
 int nvme_zns_mgmt_send(struct nvme_zns_mgmt_send_args *args)
@@ -1975,7 +1988,7 @@ int nvme_zns_mgmt_send(struct nvme_zns_mgmt_send_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_zns_mgmt_recv(struct nvme_zns_mgmt_recv_args *args)
@@ -2003,7 +2016,7 @@ int nvme_zns_mgmt_recv(struct nvme_zns_mgmt_recv_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	return nvme_submit_io_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru(args->hdl, &cmd, args->result);
 }
 
 int nvme_zns_append(struct nvme_zns_append_args *args)
@@ -2046,7 +2059,7 @@ int nvme_zns_append(struct nvme_zns_append_args *args)
 		.timeout_ms	= args->timeout,
 	};
 
-	return nvme_submit_io_passthru64(args->fd, &cmd, args->result);
+	return nvme_submit_io_passthru64(args->hdl, &cmd, args->result);
 }
 
 int nvme_dim_send(struct nvme_dim_args *args)
@@ -2066,5 +2079,5 @@ int nvme_dim_send(struct nvme_dim_args *args)
 		return -1;
 	}
 
-	return nvme_submit_admin_passthru(args->fd, &cmd, args->result);
+	return nvme_submit_admin_passthru(args->hdl, &cmd, args->result);
 }

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -202,7 +202,7 @@ struct nvme_uring_cmd {
 /**
  * nvme_submit_admin_passthru64() - Submit a 64-bit nvme passthrough admin
  *				    command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cmd:	The nvme admin command to send
  * @result:	Optional field to return the result from the CQE DW0-1
  *
@@ -211,12 +211,12 @@ struct nvme_uring_cmd {
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_submit_admin_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
+int nvme_submit_admin_passthru64(struct dev_handle *hdl, struct nvme_passthru_cmd64 *cmd,
 				 __u64 *result);
 
 /**
  * nvme_admin_passthru64() - Submit a 64-bit nvme passthrough command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
  * @rsvd:	Reserved for future use
@@ -244,7 +244,7 @@ int nvme_submit_admin_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_admin_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_admin_passthru64(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 		__u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10, __u32 cdw11,
 		__u32 cdw12, __u32 cdw13, __u32 cdw14, __u32 cdw15,
 		__u32 data_len, void *data, __u32 metadata_len, void *metadata,
@@ -252,7 +252,7 @@ int nvme_admin_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
 
 /**
  * nvme_submit_admin_passthru() - Submit an nvme passthrough admin command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cmd:	The nvme admin command to send
  * @result:	Optional field to return the result from the CQE DW0
  *
@@ -261,12 +261,12 @@ int nvme_admin_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_submit_admin_passthru(int fd, struct nvme_passthru_cmd *cmd,
+int nvme_submit_admin_passthru(struct dev_handle *hdl, struct nvme_passthru_cmd *cmd,
 			       __u32 *result);
 
 /**
  * nvme_admin_passthru() - Submit an nvme passthrough command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
  * @rsvd:	Reserved for future use
@@ -294,7 +294,7 @@ int nvme_submit_admin_passthru(int fd, struct nvme_passthru_cmd *cmd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_admin_passthru(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_admin_passthru(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 		__u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10, __u32 cdw11,
 		__u32 cdw12, __u32 cdw13, __u32 cdw14, __u32 cdw15,
 		__u32 data_len, void *data, __u32 metadata_len, void *metadata,
@@ -302,7 +302,7 @@ int nvme_admin_passthru(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
 
 /**
  * nvme_submit_io_passthru64() - Submit a 64-bit nvme passthrough command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cmd:	The nvme io command to send
  * @result:	Optional field to return the result from the CQE DW0-1
  *
@@ -311,12 +311,12 @@ int nvme_admin_passthru(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_submit_io_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
+int nvme_submit_io_passthru64(struct dev_handle *hdl, struct nvme_passthru_cmd64 *cmd,
 			    __u64 *result);
 
 /**
  * nvme_io_passthru64() - Submit an nvme io passthrough command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
  * @rsvd:	Reserved for future use
@@ -344,7 +344,7 @@ int nvme_submit_io_passthru64(int fd, struct nvme_passthru_cmd64 *cmd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_io_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_io_passthru64(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 		__u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10, __u32 cdw11,
 		__u32 cdw12, __u32 cdw13, __u32 cdw14, __u32 cdw15,
 		__u32 data_len, void *data, __u32 metadata_len, void *metadata,
@@ -352,7 +352,7 @@ int nvme_io_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
 
 /**
  * nvme_submit_io_passthru() - Submit an nvme passthrough command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cmd:	The nvme io command to send
  * @result:	Optional field to return the result from the CQE dword 0
  * @result:	Optional field to return the result from the CQE DW0
@@ -362,12 +362,12 @@ int nvme_io_passthru64(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_submit_io_passthru(int fd, struct nvme_passthru_cmd *cmd,
+int nvme_submit_io_passthru(struct dev_handle *hdl, struct nvme_passthru_cmd *cmd,
 			    __u32 *result);
 
 /**
  * nvme_io_passthru() - Submit an nvme io passthrough command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @opcode:	The nvme io command to send
  * @flags:	NVMe command flags (not used)
  * @rsvd:	Reserved for future use
@@ -395,7 +395,7 @@ int nvme_submit_io_passthru(int fd, struct nvme_passthru_cmd *cmd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_io_passthru(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_io_passthru(struct dev_handle *hdl, __u8 opcode, __u8 flags, __u16 rsvd,
 		__u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10, __u32 cdw11,
 		__u32 cdw12, __u32 cdw13, __u32 cdw14, __u32 cdw15,
 		__u32 data_len, void *data, __u32 metadata_len, void *metadata,
@@ -403,38 +403,38 @@ int nvme_io_passthru(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
 
 /**
  * nvme_subsystem_reset() - Initiate a subsystem reset
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  *
  * This should only be sent to controller handles, not to namespaces.
  *
  * Return: Zero if a subsystem reset was initiated or -1 with errno set
  * otherwise.
  */
-int nvme_subsystem_reset(int fd);
+int nvme_subsystem_reset(struct dev_handle *hdl);
 
 /**
  * nvme_ctrl_reset() - Initiate a controller reset
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  *
  * This should only be sent to controller handles, not to namespaces.
  *
  * Return: 0 if a reset was initiated or -1 with errno set otherwise.
  */
-int nvme_ctrl_reset(int fd);
+int nvme_ctrl_reset(struct dev_handle *hdl);
 
 /**
  * nvme_ns_rescan() - Initiate a controller rescan
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  *
  * This should only be sent to controller handles, not to namespaces.
  *
  * Return: 0 if a rescan was initiated or -1 with errno set otherwise.
  */
-int nvme_ns_rescan(int fd);
+int nvme_ns_rescan(struct dev_handle *hdl);
 
 /**
  * nvme_get_nsid() - Retrieve the NSID from a namespace file descriptor
- * @fd:		File descriptor of nvme namespace
+ * @hdl:		File descriptor of nvme namespace
  * @nsid:	User pointer to namespace id
  *
  * This should only be sent to namespace handles, not to controllers. The
@@ -444,7 +444,7 @@ int nvme_ns_rescan(int fd);
  *
  * Return: 0 if @nsid was set successfully or -1 with errno set otherwise.
  */
-int nvme_get_nsid(int fd, __u32 *nsid);
+int nvme_get_nsid(struct dev_handle *hdl, __u32 *nsid);
 
 /**
  * nvme_identify() - Send the NVMe Identify command
@@ -458,14 +458,15 @@ int nvme_get_nsid(int fd, __u32 *nsid);
  */
 int nvme_identify(struct nvme_identify_args *args);
 
-static inline int nvme_identify_cns_nsid(int fd, enum nvme_identify_cns cns,
+
+static inline int nvme_identify_cns_nsid(struct dev_handle *hdl, enum nvme_identify_cns cns,
 					 __u32 nsid, void *data)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = cns,
 		.csi = NVME_CSI_NVM,
@@ -474,13 +475,12 @@ static inline int nvme_identify_cns_nsid(int fd, enum nvme_identify_cns cns,
 		.cns_specific_id = NVME_CNSSPECID_NONE,
 		.uuidx = NVME_UUID_NONE,
 	};
-
 	return nvme_identify(&args);
 }
 
 /**
  * nvme_identify_ctrl() - Retrieves nvme identify controller
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @id:		User space destination address to transfer the data,
  *
  * Sends nvme identify with CNS value %NVME_IDENTIFY_CNS_CTRL.
@@ -490,15 +490,15 @@ static inline int nvme_identify_cns_nsid(int fd, enum nvme_identify_cns cns,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ctrl(int fd, struct nvme_id_ctrl *id)
+static inline int nvme_identify_ctrl(struct dev_handle *hdl, struct nvme_id_ctrl *id)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_CTRL,
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_CTRL,
 				      NVME_NSID_NONE, id);
 }
 
 /**
  * nvme_identify_ns() - Retrieves nvme identify namespace
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace to identify
  * @ns:		User space destination address to transfer the data
  *
@@ -516,31 +516,31 @@ static inline int nvme_identify_ctrl(int fd, struct nvme_id_ctrl *id)
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ns(int fd, __u32 nsid, struct nvme_id_ns *ns)
+static inline int nvme_identify_ns(struct dev_handle *hdl, __u32 nsid, struct nvme_id_ns *ns)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_NS, nsid, ns);
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_NS, nsid, ns);
 }
 
 /**
  * nvme_identify_allocated_ns() - Same as nvme_identify_ns, but only for
  *				  allocated namespaces
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace to identify
  * @ns:		User space destination address to transfer the data
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_allocated_ns(int fd, __u32 nsid,
+static inline int nvme_identify_allocated_ns(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_id_ns *ns)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_ALLOCATED_NS,
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_ALLOCATED_NS,
 				      nsid, ns);
 }
 
 /**
  * nvme_identify_active_ns_list() - Retrieves active namespaces id list
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Return namespaces greater than this identifier
  * @list:	User space destination address to transfer the data
  *
@@ -553,16 +553,16 @@ static inline int nvme_identify_allocated_ns(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_active_ns_list(int fd, __u32 nsid,
+static inline int nvme_identify_active_ns_list(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_ns_list *list)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_NS_ACTIVE_LIST,
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_NS_ACTIVE_LIST,
 				      nsid, list);
 }
 
 /**
  * nvme_identify_allocated_ns_list() - Retrieves allocated namespace id list
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Return namespaces greater than this identifier
  * @list:	User space destination address to transfer the data
  *
@@ -575,16 +575,16 @@ static inline int nvme_identify_active_ns_list(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_allocated_ns_list(int fd, __u32 nsid,
+static inline int nvme_identify_allocated_ns_list(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_ns_list *list)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST,
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST,
 				      nsid, list);
 }
 
 /**
  * nvme_identify_ctrl_list() - Retrieves identify controller list
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cntid:	Starting CNTLID to return in the list
  * @cntlist:	User space destination address to transfer the data
  *
@@ -597,14 +597,14 @@ static inline int nvme_identify_allocated_ns_list(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ctrl_list(int fd, __u16 cntid,
+static inline int nvme_identify_ctrl_list(struct dev_handle *hdl, __u16 cntid,
 			struct nvme_ctrl_list *cntlist)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = cntlist,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CTRL_LIST,
 		.csi = NVME_CSI_NVM,
@@ -619,7 +619,7 @@ static inline int nvme_identify_ctrl_list(int fd, __u16 cntid,
 
 /**
  * nvme_identify_nsid_ctrl_list() - Retrieves controller list attached to an nsid
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Return controllers that are attached to this nsid
  * @cntid:	Starting CNTLID to return in the list
  * @cntlist:	User space destination address to transfer the data
@@ -633,14 +633,14 @@ static inline int nvme_identify_ctrl_list(int fd, __u16 cntid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1
  */
-static inline int nvme_identify_nsid_ctrl_list(int fd, __u32 nsid, __u16 cntid,
+static inline int nvme_identify_nsid_ctrl_list(struct dev_handle *hdl, __u32 nsid, __u16 cntid,
 			struct nvme_ctrl_list *cntlist)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = cntlist,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_NS_CTRL_LIST,
 		.csi = NVME_CSI_NVM,
@@ -655,7 +655,7 @@ static inline int nvme_identify_nsid_ctrl_list(int fd, __u32 nsid, __u16 cntid,
 
 /**
  * nvme_identify_ns_descs() - Retrieves namespace descriptor list
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	The namespace id to retrieve descriptors
  * @descs:	User space destination address to transfer the data
  *
@@ -670,16 +670,16 @@ static inline int nvme_identify_nsid_ctrl_list(int fd, __u32 nsid, __u16 cntid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ns_descs(int fd, __u32 nsid,
+static inline int nvme_identify_ns_descs(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_ns_id_desc *descs)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_NS_DESC_LIST,
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_NS_DESC_LIST,
 				      nsid, descs);
 }
 
 /**
  * nvme_identify_nvmset_list() - Retrieves NVM Set List
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nvmsetid:	NVM Set Identifier
  * @nvmset:	User space destination address to transfer the data
  *
@@ -693,14 +693,14 @@ static inline int nvme_identify_ns_descs(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_nvmset_list(int fd, __u16 nvmsetid,
+static inline int nvme_identify_nvmset_list(struct dev_handle *hdl, __u16 nvmsetid,
 			struct nvme_id_nvmset_list *nvmset)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = nvmset,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_NVMSET_LIST,
 		.csi = NVME_CSI_NVM,
@@ -716,7 +716,7 @@ static inline int nvme_identify_nvmset_list(int fd, __u16 nvmsetid,
 /**
  * nvme_identify_primary_ctrl() - Retrieve NVMe Primary Controller
  *				  identification
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cntid:	Return controllers starting at this identifier
  * @cap:	User space destination buffer address to transfer the data
  *
@@ -725,14 +725,14 @@ static inline int nvme_identify_nvmset_list(int fd, __u16 nvmsetid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_primary_ctrl(int fd, __u16 cntid,
+static inline int nvme_identify_primary_ctrl(struct dev_handle *hdl, __u16 cntid,
 			struct nvme_primary_ctrl_cap *cap)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = cap,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_PRIMARY_CTRL_CAP,
 		.csi = NVME_CSI_NVM,
@@ -747,7 +747,7 @@ static inline int nvme_identify_primary_ctrl(int fd, __u16 cntid,
 
 /**
  * nvme_identify_secondary_ctrl_list() - Retrieves secondary controller list
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier
  * @cntid:	Return controllers starting at this identifier
  * @sc_list:	User space destination address to transfer the data
@@ -763,14 +763,14 @@ static inline int nvme_identify_primary_ctrl(int fd, __u16 cntid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_secondary_ctrl_list(int fd, __u32 nsid,
+static inline int nvme_identify_secondary_ctrl_list(struct dev_handle *hdl, __u32 nsid,
 			__u16 cntid, struct nvme_secondary_ctrl_list *sc_list)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = sc_list,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_SECONDARY_CTRL_LIST,
 		.csi = NVME_CSI_NVM,
@@ -786,7 +786,7 @@ static inline int nvme_identify_secondary_ctrl_list(int fd, __u32 nsid,
 /**
  * nvme_identify_ns_granularity() - Retrieves namespace granularity
  *				    identification
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @gr_list:	User space destination address to transfer the data
  *
  * If the controller supports reporting of Namespace Granularity, then a
@@ -799,16 +799,16 @@ static inline int nvme_identify_secondary_ctrl_list(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ns_granularity(int fd,
+static inline int nvme_identify_ns_granularity(struct dev_handle *hdl,
 			struct nvme_id_ns_granularity_list *gr_list)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_NS_GRANULARITY,
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_NS_GRANULARITY,
 				      NVME_NSID_NONE, gr_list);
 }
 
 /**
  * nvme_identify_uuid() - Retrieves device's UUIDs
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @uuid_list:	User space destination address to transfer the data
  *
  * Each UUID List entry is either 0h, the NVMe Invalid UUID, or a valid UUID.
@@ -819,15 +819,15 @@ static inline int nvme_identify_ns_granularity(int fd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_uuid(int fd, struct nvme_id_uuid_list *uuid_list)
+static inline int nvme_identify_uuid(struct dev_handle *hdl, struct nvme_id_uuid_list *uuid_list)
 {
-	return nvme_identify_cns_nsid(fd, NVME_IDENTIFY_CNS_UUID_LIST,
+	return nvme_identify_cns_nsid(hdl, NVME_IDENTIFY_CNS_UUID_LIST,
 				      NVME_NSID_NONE, uuid_list);
 }
 
 /**
  * nvme_identify_ns_csi() - I/O command set specific identify namespace data
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace to identify
  * @uuidx:	UUID Index for differentiating vendor specific encoding
  * @csi:	Command Set Identifier
@@ -839,14 +839,14 @@ static inline int nvme_identify_uuid(int fd, struct nvme_id_uuid_list *uuid_list
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ns_csi(int fd, __u32 nsid, __u8 uuidx,
+static inline int nvme_identify_ns_csi(struct dev_handle *hdl, __u32 nsid, __u8 uuidx,
 			enum nvme_csi csi, void *data)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CSI_NS,
 		.csi = csi,
@@ -861,7 +861,7 @@ static inline int nvme_identify_ns_csi(int fd, __u32 nsid, __u8 uuidx,
 
 /**
  * nvme_identify_ctrl_csi() - I/O command set specific Identify Controller data
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @csi:	Command Set Identifier
  * @data:	User space destination address to transfer the data
  *
@@ -872,13 +872,13 @@ static inline int nvme_identify_ns_csi(int fd, __u32 nsid, __u8 uuidx,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ctrl_csi(int fd, enum nvme_csi csi, void *data)
+static inline int nvme_identify_ctrl_csi(struct dev_handle *hdl, enum nvme_csi csi, void *data)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CSI_CTRL,
 		.csi = csi,
@@ -893,7 +893,7 @@ static inline int nvme_identify_ctrl_csi(int fd, enum nvme_csi csi, void *data)
 
 /**
  * nvme_identify_active_ns_list_csi() - Active namespace ID list associated with a specified I/O command set
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Return namespaces greater than this identifier
  * @csi:	Command Set Identifier
  * @ns_list:	User space destination address to transfer the data
@@ -908,14 +908,14 @@ static inline int nvme_identify_ctrl_csi(int fd, enum nvme_csi csi, void *data)
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_active_ns_list_csi(int fd, __u32 nsid,
+static inline int nvme_identify_active_ns_list_csi(struct dev_handle *hdl, __u32 nsid,
 			enum nvme_csi csi, struct nvme_ns_list *ns_list)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = ns_list,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CSI_NS_ACTIVE_LIST,
 		.csi = csi,
@@ -930,7 +930,7 @@ static inline int nvme_identify_active_ns_list_csi(int fd, __u32 nsid,
 
 /**
  * nvme_identify_allocated_ns_list_csi() - Allocated namespace ID list associated with a specified I/O command set
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Return namespaces greater than this identifier
  * @csi:	Command Set Identifier
  * @ns_list:	User space destination address to transfer the data
@@ -945,14 +945,14 @@ static inline int nvme_identify_active_ns_list_csi(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_allocated_ns_list_csi(int fd, __u32 nsid,
+static inline int nvme_identify_allocated_ns_list_csi(struct dev_handle *hdl, __u32 nsid,
 			enum nvme_csi csi, struct nvme_ns_list *ns_list)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = ns_list,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CSI_ALLOCATED_NS_LIST,
 		.csi = csi,
@@ -967,7 +967,7 @@ static inline int nvme_identify_allocated_ns_list_csi(int fd, __u32 nsid,
 
 /**
  * nvme_identify_independent_identify_ns() - I/O command set independent Identify namespace data
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Return namespaces greater than this identifier
  * @ns:		I/O Command Set Independent Identify Namespace data
  *		structure
@@ -978,14 +978,14 @@ static inline int nvme_identify_allocated_ns_list_csi(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_independent_identify_ns(int fd, __u32 nsid,
+static inline int nvme_identify_independent_identify_ns(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_id_independent_id_ns *ns)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = ns,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CSI_INDEPENDENT_ID_NS,
 		.csi = NVME_CSI_NVM,
@@ -1000,7 +1000,7 @@ static inline int nvme_identify_independent_identify_ns(int fd, __u32 nsid,
 
 /**
  * nvme_identify_ns_csi_user_data_format() - Identify namespace user data format
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @user_data_format: Return namespaces capability of identifier
  * @uuidx:	UUID selection, if supported
  * @csi:	Command Set Identifier
@@ -1012,15 +1012,15 @@ static inline int nvme_identify_independent_identify_ns(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_ns_csi_user_data_format(int fd,
+static inline int nvme_identify_ns_csi_user_data_format(struct dev_handle *hdl,
 			__u16 user_data_format, __u8 uuidx,
 			enum nvme_csi csi, void *data)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_NS_USER_DATA_FORMAT,
 		.csi = csi,
@@ -1035,7 +1035,7 @@ static inline int nvme_identify_ns_csi_user_data_format(int fd,
 
 /**
  * nvme_identify_iocs_ns_csi_user_data_format() - Identify I/O command set namespace data structure
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @user_data_format: Return namespaces capability of identifier
  * @uuidx:	UUID selection, if supported
  * @csi:	Command Set Identifier
@@ -1048,15 +1048,15 @@ static inline int nvme_identify_ns_csi_user_data_format(int fd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_iocs_ns_csi_user_data_format(int fd,
+static inline int nvme_identify_iocs_ns_csi_user_data_format(struct dev_handle *hdl,
 			__u16 user_data_format, __u8 uuidx,
 			enum nvme_csi csi, void *data)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CSI_NS_USER_DATA_FORMAT,
 		.csi = csi,
@@ -1071,7 +1071,7 @@ static inline int nvme_identify_iocs_ns_csi_user_data_format(int fd,
 
 /**
  * nvme_nvm_identify_ctrl() - Identify controller data
- * @fd:	File descriptor of nvme device
+ * @hdl:        Device handle to nvme device
  * @id:	User space destination address to transfer the data
  *
  * Return an identify controller data structure to the host of
@@ -1080,14 +1080,14 @@ static inline int nvme_identify_iocs_ns_csi_user_data_format(int fd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_nvm_identify_ctrl(int fd, struct nvme_id_ctrl_nvm *id)
+static inline int nvme_nvm_identify_ctrl(struct dev_handle *hdl, struct nvme_id_ctrl_nvm *id)
 {
-	return nvme_identify_ctrl_csi(fd, NVME_CSI_NVM, id);
+	return nvme_identify_ctrl_csi(hdl, NVME_CSI_NVM, id);
 }
 
 /**
  * nvme_identify_domain_list() - Domain list data
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @domid:	Domain ID
  * @list:	User space destination address to transfer data
  *
@@ -1101,14 +1101,14 @@ static inline int nvme_nvm_identify_ctrl(int fd, struct nvme_id_ctrl_nvm *id)
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_domain_list(int fd, __u16 domid,
+static inline int nvme_identify_domain_list(struct dev_handle *hdl, __u16 domid,
 			struct nvme_id_domain_list *list)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = list,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_DOMAIN_LIST,
 		.csi = NVME_CSI_NVM,
@@ -1123,21 +1123,21 @@ static inline int nvme_identify_domain_list(int fd, __u16 domid,
 
 /**
  * nvme_identify_endurance_group_list() - Endurance group list data
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @endgrp_id:	Endurance group identifier
  * @list:	Array of endurance group identifiers
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_endurance_group_list(int fd, __u16 endgrp_id,
+static inline int nvme_identify_endurance_group_list(struct dev_handle *hdl, __u16 endgrp_id,
 			struct nvme_id_endurance_group_list *list)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = list,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_ENDURANCE_GROUP_ID,
 		.csi = NVME_CSI_NVM,
@@ -1152,7 +1152,7 @@ static inline int nvme_identify_endurance_group_list(int fd, __u16 endgrp_id,
 
 /**
  * nvme_identify_iocs() - I/O command set data structure
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @cntlid:	Controller ID
  * @iocs:	User space destination address to transfer the data
  *
@@ -1162,14 +1162,14 @@ static inline int nvme_identify_endurance_group_list(int fd, __u16 endgrp_id,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_identify_iocs(int fd, __u16 cntlid,
+static inline int nvme_identify_iocs(struct dev_handle *hdl, __u16 cntlid,
 			struct nvme_id_iocs *iocs)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = iocs,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_COMMAND_SET_STRUCTURE,
 		.csi = NVME_CSI_NVM,
@@ -1184,21 +1184,21 @@ static inline int nvme_identify_iocs(int fd, __u16 cntlid,
 
 /**
  * nvme_zns_identify_ns() - ZNS identify namespace data
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace to identify
  * @data:	User space destination address to transfer the data
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_zns_identify_ns(int fd, __u32 nsid,
+static inline int nvme_zns_identify_ns(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_zns_id_ns *data)
 {
 	struct nvme_identify_args args = {
 		.result = NULL,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.cns = NVME_IDENTIFY_CNS_CSI_NS,
 		.csi = NVME_CSI_ZNS,
@@ -1212,15 +1212,15 @@ static inline int nvme_zns_identify_ns(int fd, __u32 nsid,
 
 /**
  * nvme_zns_identify_ctrl() - ZNS identify controller data
- * @fd:	File descriptor of nvme device
+ * @hdl:        Device handle to nvme device
  * @id:	User space destination address to transfer the data
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_zns_identify_ctrl(int fd, struct nvme_zns_id_ctrl *id)
+static inline int nvme_zns_identify_ctrl(struct dev_handle *hdl, struct nvme_zns_id_ctrl *id)
 {
-	return nvme_identify_ctrl_csi(fd, NVME_CSI_ZNS, id);
+	return nvme_identify_ctrl_csi(hdl, NVME_CSI_ZNS, id);
 }
 
 /**
@@ -1234,16 +1234,16 @@ int nvme_get_log(struct nvme_get_log_args *args);
 
 /**
  * nvme_get_log_page() - Get log page data
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @xfer_len:	Max log transfer size per request to split the total.
  * @args:	&struct nvme_get_log_args argument structure
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_log_page(int fd, __u32 xfer_len, struct nvme_get_log_args *args);
+int nvme_get_log_page(struct dev_handle *hdl, __u32 xfer_len, struct nvme_get_log_args *args);
 
-static inline int nvme_get_nsid_log(int fd, bool rae,
+static inline int nvme_get_nsid_log(struct dev_handle *hdl, bool rae,
 			enum nvme_cmd_get_log_lid lid,
 			__u32 nsid, __u32 len, void *log)
 {
@@ -1251,8 +1251,8 @@ static inline int nvme_get_nsid_log(int fd, bool rae,
 		.lpo = 0,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = lid,
 		.len = len,
@@ -1265,34 +1265,34 @@ static inline int nvme_get_nsid_log(int fd, bool rae,
 		.ot = false,
 	};
 
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
-static inline int nvme_get_log_simple(int fd, enum nvme_cmd_get_log_lid lid,
+static inline int nvme_get_log_simple(struct dev_handle *hdl, enum nvme_cmd_get_log_lid lid,
 				      __u32 len, void *log)
 {
-	return nvme_get_nsid_log(fd, false, lid, NVME_NSID_ALL, len, log);
+	return nvme_get_nsid_log(hdl, false, lid, NVME_NSID_ALL, len, log);
 }
 
 /**
  * nvme_get_log_supported_log_pages() - Retrieve nmve supported log pages
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @log:	Array of LID supported and Effects data structures
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_supported_log_pages(int fd, bool rae,
+static inline int nvme_get_log_supported_log_pages(struct dev_handle *hdl, bool rae,
 			struct nvme_supported_log_pages *log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_SUPPORTED_LOG_PAGES,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_SUPPORTED_LOG_PAGES,
 				 NVME_NSID_ALL, sizeof(*log), log);
 }
 
 /**
  * nvme_get_log_error() - Retrieve nvme error log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nr_entries:	Number of error log entries allocated
  * @rae:	Retain asynchronous events
  * @err_log:	Array of error logs of size 'entries'
@@ -1304,17 +1304,17 @@ static inline int nvme_get_log_supported_log_pages(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_error(int fd, unsigned int nr_entries, bool rae,
+static inline int nvme_get_log_error(struct dev_handle *hdl, unsigned int nr_entries, bool rae,
 				     struct nvme_error_log_page *err_log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_ERROR,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_ERROR,
 				 NVME_NSID_ALL, sizeof(*err_log) * nr_entries,
 				 err_log);
 }
 
 /**
  * nvme_get_log_smart() - Retrieve nvme smart log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Optional namespace identifier
  * @rae:	Retain asynchronous events
  * @smart_log:	User address to store the smart log
@@ -1329,16 +1329,16 @@ static inline int nvme_get_log_error(int fd, unsigned int nr_entries, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_smart(int fd, __u32 nsid, bool rae,
+static inline int nvme_get_log_smart(struct dev_handle *hdl, __u32 nsid, bool rae,
 				     struct nvme_smart_log *smart_log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_SMART,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_SMART,
 				 nsid, sizeof(*smart_log), smart_log);
 }
 
 /**
  * nvme_get_log_fw_slot() - Retrieves the controller firmware log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @fw_log:	User address to store the log page
  *
@@ -1349,16 +1349,16 @@ static inline int nvme_get_log_smart(int fd, __u32 nsid, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_fw_slot(int fd, bool rae,
+static inline int nvme_get_log_fw_slot(struct dev_handle *hdl, bool rae,
 			struct nvme_firmware_slot *fw_log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_FW_SLOT,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_FW_SLOT,
 				 NVME_NSID_ALL, sizeof(*fw_log), fw_log);
 }
 
 /**
  * nvme_get_log_changed_ns_list() - Retrieve namespace changed list
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @ns_log:	User address to store the log page
  *
@@ -1369,16 +1369,16 @@ static inline int nvme_get_log_fw_slot(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_changed_ns_list(int fd, bool rae,
+static inline int nvme_get_log_changed_ns_list(struct dev_handle *hdl, bool rae,
 			struct nvme_ns_list *ns_log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_CHANGED_NS,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_CHANGED_NS,
 				 NVME_NSID_ALL, sizeof(*ns_log), ns_log);
 }
 
 /**
  * nvme_get_log_cmd_effects() - Retrieve nvme command effects log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @csi:	Command Set Identifier
  * @effects_log:User address to store the effects log
  *
@@ -1388,15 +1388,15 @@ static inline int nvme_get_log_changed_ns_list(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_cmd_effects(int fd, enum nvme_csi csi,
+static inline int nvme_get_log_cmd_effects(struct dev_handle *hdl, enum nvme_csi csi,
 			struct nvme_cmd_effects_log *effects_log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = effects_log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_CMD_EFFECTS,
 		.len = sizeof(*effects_log),
@@ -1408,12 +1408,12 @@ static inline int nvme_get_log_cmd_effects(int fd, enum nvme_csi csi,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_device_self_test() - Retrieve the device self test log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @log:	Userspace address of the log payload
  *
  * The log page indicates the status of an in progress self test and the
@@ -1423,30 +1423,30 @@ static inline int nvme_get_log_cmd_effects(int fd, enum nvme_csi csi,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_device_self_test(int fd,
+static inline int nvme_get_log_device_self_test(struct dev_handle *hdl,
 			struct nvme_self_test_log *log)
 {
-	return nvme_get_nsid_log(fd, false, NVME_LOG_LID_DEVICE_SELF_TEST,
+	return nvme_get_nsid_log(hdl, false, NVME_LOG_LID_DEVICE_SELF_TEST,
 				 NVME_NSID_ALL, sizeof(*log), log);
 }
 
 /**
  * nvme_get_log_create_telemetry_host() - Create host telemetry log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @log:	Userspace address of the log payload
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_create_telemetry_host(int fd,
+static inline int nvme_get_log_create_telemetry_host(struct dev_handle *hdl,
 			struct nvme_telemetry_log *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_TELEMETRY_HOST,
 		.len = sizeof(*log),
@@ -1458,12 +1458,12 @@ static inline int nvme_get_log_create_telemetry_host(int fd,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_telemetry_host() - Get Telemetry Host-Initiated log page
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @offset:	Offset into the telemetry data
  * @len:	Length of provided user buffer to hold the log data in bytes
  * @log:	User address for log page data
@@ -1474,15 +1474,15 @@ static inline int nvme_get_log_create_telemetry_host(int fd,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_telemetry_host(int fd, __u64 offset,
+static inline int nvme_get_log_telemetry_host(struct dev_handle *hdl, __u64 offset,
 			__u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_TELEMETRY_HOST,
 		.len = len,
@@ -1494,12 +1494,12 @@ static inline int nvme_get_log_telemetry_host(int fd, __u64 offset,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_telemetry_ctrl() - Get Telemetry Controller-Initiated log page
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset into the telemetry data
  * @len:	Length of provided user buffer to hold the log data in bytes
@@ -1511,15 +1511,15 @@ static inline int nvme_get_log_telemetry_host(int fd, __u64 offset,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_telemetry_ctrl(int fd, bool rae,
+static inline int nvme_get_log_telemetry_ctrl(struct dev_handle *hdl, bool rae,
 			__u64 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_TELEMETRY_CTRL,
 		.len = len,
@@ -1531,12 +1531,12 @@ static inline int nvme_get_log_telemetry_ctrl(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_endurance_group() - Get Endurance Group log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @endgid:	Starting group identifier to return in the list
  * @log:	User address to store the endurance log
  *
@@ -1550,15 +1550,15 @@ static inline int nvme_get_log_telemetry_ctrl(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_endurance_group(int fd, __u16 endgid,
+static inline int nvme_get_log_endurance_group(struct dev_handle *hdl, __u16 endgid,
 			struct nvme_endurance_group_log *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_ENDURANCE_GROUP,
 		.len = sizeof(*log),
@@ -1570,27 +1570,27 @@ static inline int nvme_get_log_endurance_group(int fd, __u16 endgid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_predictable_lat_nvmset() - Predictable Latency Per NVM Set
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nvmsetid:	NVM set id
  * @log:	User address to store the predictable latency log
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_predictable_lat_nvmset(int fd, __u16 nvmsetid,
+static inline int nvme_get_log_predictable_lat_nvmset(struct dev_handle *hdl, __u16 nvmsetid,
 			struct nvme_nvmset_predictable_lat_log *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_PREDICTABLE_LAT_NVMSET,
 		.len = sizeof(*log),
@@ -1602,12 +1602,12 @@ static inline int nvme_get_log_predictable_lat_nvmset(int fd, __u16 nvmsetid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_predictable_lat_event() - Retrieve Predictable Latency Event Aggregate Log Page
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset into the predictable latency event
  * @len:	Length of provided user buffer to hold the log data in bytes
@@ -1616,15 +1616,15 @@ static inline int nvme_get_log_predictable_lat_nvmset(int fd, __u16 nvmsetid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_predictable_lat_event(int fd, bool rae,
+static inline int nvme_get_log_predictable_lat_event(struct dev_handle *hdl, bool rae,
 			__u32 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_PREDICTABLE_LAT_AGG,
 		.len = len,
@@ -1636,26 +1636,26 @@ static inline int nvme_get_log_predictable_lat_event(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_fdp_configurations() - Get list of Flexible Data Placement configurations
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @egid:	Endurance group identifier
  * @offset:	Offset into log page
  * @len:	Length (in bytes) of provided user buffer to hold the log data
  * @log:	Log page data buffer
  */
-static inline int nvme_get_log_fdp_configurations(int fd, __u16 egid,
+static inline int nvme_get_log_fdp_configurations(struct dev_handle *hdl, __u16 egid,
 			__u32 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_FDP_CONFIGS,
 		.len = len,
@@ -1671,21 +1671,21 @@ static inline int nvme_get_log_fdp_configurations(int fd, __u16 egid,
 
 /**
  * nvme_get_log_reclaim_unit_handle_usage() - Get reclaim unit handle usage
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @egid:	Endurance group identifier
  * @offset:	Offset into log page
  * @len:	Length (in bytes) of provided user buffer to hold the log data
  * @log:	Log page data buffer
  */
-static inline int nvme_get_log_reclaim_unit_handle_usage(int fd, __u16 egid,
+static inline int nvme_get_log_reclaim_unit_handle_usage(struct dev_handle *hdl, __u16 egid,
 			__u32 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_FDP_RUH_USAGE,
 		.len = len,
@@ -1701,20 +1701,20 @@ static inline int nvme_get_log_reclaim_unit_handle_usage(int fd, __u16 egid,
 
 /**
  * nvme_get_log_fdp_stats() - Get Flexible Data Placement statistics
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @egid:	Endurance group identifier
  * @offset:	Offset into log page
  * @len:	Length (in bytes) of provided user buffer to hold the log data
  * @log:	Log page data buffer
  */
-static inline int nvme_get_log_fdp_stats(int fd, __u16 egid, __u32 offset, __u32 len, void *log)
+static inline int nvme_get_log_fdp_stats(struct dev_handle *hdl, __u16 egid, __u32 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_FDP_STATS,
 		.len = len,
@@ -1730,22 +1730,22 @@ static inline int nvme_get_log_fdp_stats(int fd, __u16 egid, __u32 offset, __u32
 
 /**
  * nvme_get_log_fdp_events() - Get Flexible Data Placement events
- * @fd:			File descriptor of nvme device
+ * @hdl:		Device handle to nvme device
  * @egid:		Endurance group identifier
- * @host_events:	Whether to report host or controller events
+ * @hdlost_events:	Whether to report host or controller events
  * @offset:		Offset into log page
  * @len:		Length (in bytes) of provided user buffer to hold the log data
  * @log:		Log page data buffer
  */
-static inline int nvme_get_log_fdp_events(int fd, __u16 egid, bool host_events, __u32 offset,
+static inline int nvme_get_log_fdp_events(struct dev_handle *hdl, __u16 egid, bool host_events, __u32 offset,
 		__u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_FDP_EVENTS,
 		.len = len,
@@ -1761,7 +1761,7 @@ static inline int nvme_get_log_fdp_events(int fd, __u16 egid, bool host_events, 
 
 /**
  * nvme_get_log_ana() - Retrieve Asymmetric Namespace Access log page
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @lsp:	Log specific, see &enum nvme_get_log_ana_lsp
  * @rae:	Retain asynchronous events
  * @offset:	Offset to the start of the log page
@@ -1777,15 +1777,15 @@ static inline int nvme_get_log_fdp_events(int fd, __u16 egid, bool host_events, 
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_ana(int fd, enum nvme_log_ana_lsp lsp, bool rae,
+static inline int nvme_get_log_ana(struct dev_handle *hdl, enum nvme_log_ana_lsp lsp, bool rae,
 				   __u64 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_ANA,
 		.len = len,
@@ -1797,12 +1797,12 @@ static inline int nvme_get_log_ana(int fd, enum nvme_log_ana_lsp lsp, bool rae,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_ana_groups() - Retrieve Asymmetric Namespace Access groups only log page
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @len:	The allocated length of the log page
  * @log:	User address to store the ana group log
@@ -1812,16 +1812,16 @@ static inline int nvme_get_log_ana(int fd, enum nvme_log_ana_lsp lsp, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_ana_groups(int fd, bool rae, __u32 len,
+static inline int nvme_get_log_ana_groups(struct dev_handle *hdl, bool rae, __u32 len,
 			    struct nvme_ana_group_desc *log)
 {
-	return nvme_get_log_ana(fd, NVME_LOG_ANA_LSP_RGO_GROUPS_ONLY, rae, 0,
+	return nvme_get_log_ana(hdl, NVME_LOG_ANA_LSP_RGO_GROUPS_ONLY, rae, 0,
 				len, log);
 }
 
 /**
  * nvme_get_log_lba_status() - Retrieve LBA Status
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset to the start of the log page
  * @len:	The allocated length of the log page
@@ -1830,15 +1830,15 @@ static inline int nvme_get_log_ana_groups(int fd, bool rae, __u32 len,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_lba_status(int fd, bool rae,
+static inline int nvme_get_log_lba_status(struct dev_handle *hdl, bool rae,
 			__u64 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_LBA_STATUS,
 		.len = len,
@@ -1850,12 +1850,12 @@ static inline int nvme_get_log_lba_status(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_endurance_grp_evt() - Retrieve Rotational Media Information
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset to the start of the log page
  * @len:	The allocated length of the log page
@@ -1864,15 +1864,15 @@ static inline int nvme_get_log_lba_status(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_endurance_grp_evt(int fd, bool rae,
+static inline int nvme_get_log_endurance_grp_evt(struct dev_handle *hdl, bool rae,
 			__u32 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_ENDURANCE_GRP_EVT,
 		.len = len,
@@ -1884,44 +1884,44 @@ static inline int nvme_get_log_endurance_grp_evt(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_fid_supported_effects() - Retrieve Feature Identifiers Supported and Effects
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @log:	FID Supported and Effects data structure
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
  */
-static inline int nvme_get_log_fid_supported_effects(int fd, bool rae,
+static inline int nvme_get_log_fid_supported_effects(struct dev_handle *hdl, bool rae,
 			struct nvme_fid_supported_effects_log *log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_FID_SUPPORTED_EFFECTS,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_FID_SUPPORTED_EFFECTS,
 				 NVME_NSID_NONE, sizeof(*log), log);
 }
 
 /**
  * nvme_get_log_mi_cmd_supported_effects() - displays the MI Commands Supported by the controller
- * @fd:     File descriptor of nvme device
+ * @hdl:     Device handle to nvme device
  * @rae:    Retain asynchronous events
  * @log:    MI Command Supported and Effects data structure
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
  */
-static inline int nvme_get_log_mi_cmd_supported_effects(int fd, bool rae,
+static inline int nvme_get_log_mi_cmd_supported_effects(struct dev_handle *hdl, bool rae,
 			struct nvme_mi_cmd_supported_effects_log *log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_MI_CMD_SUPPORTED_EFFECTS,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_MI_CMD_SUPPORTED_EFFECTS,
 				 NVME_NSID_NONE, sizeof(*log), log);
 }
 
 /**
  * nvme_get_log_boot_partition() - Retrieve Boot Partition
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @lsp:	The log specified field of LID
  * @len:	The allocated size, minimum
@@ -1931,15 +1931,15 @@ static inline int nvme_get_log_mi_cmd_supported_effects(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
  */
-static inline int nvme_get_log_boot_partition(int fd, bool rae,
+static inline int nvme_get_log_boot_partition(struct dev_handle *hdl, bool rae,
 			__u8 lsp, __u32 len, struct nvme_boot_partition *part)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = part,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_BOOT_PARTITION,
 		.len = len,
@@ -1951,12 +1951,12 @@ static inline int nvme_get_log_boot_partition(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_discovery() - Retrieve Discovery log page
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @offset:	Offset of this log to retrieve
  * @len:	The allocated size for this portion of the log
@@ -1968,15 +1968,15 @@ static inline int nvme_get_log_boot_partition(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_discovery(int fd, bool rae,
+static inline int nvme_get_log_discovery(struct dev_handle *hdl, bool rae,
 			__u32 offset, __u32 len, void *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = offset,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_DISCOVER,
 		.len = len,
@@ -1988,27 +1988,27 @@ static inline int nvme_get_log_discovery(int fd, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_media_unit_stat() - Retrieve Media Unit Status
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @domid:	Domain Identifier selection, if supported
  * @mus:	User address to store the Media Unit statistics log
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
  */
-static inline int nvme_get_log_media_unit_stat(int fd, __u16 domid,
+static inline int nvme_get_log_media_unit_stat(struct dev_handle *hdl, __u16 domid,
 			struct nvme_media_unit_stat_log *mus)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = mus,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_MEDIA_UNIT_STATUS,
 		.len = sizeof(*mus),
@@ -2020,27 +2020,27 @@ static inline int nvme_get_log_media_unit_stat(int fd, __u16 domid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_support_cap_config_list() - Retrieve Supported Capacity Configuration List
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @domid:	Domain Identifier selection, if supported
  * @cap:	User address to store supported capabilities config list
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
  */
-static inline int nvme_get_log_support_cap_config_list(int fd, __u16 domid,
+static inline int nvme_get_log_support_cap_config_list(struct dev_handle *hdl, __u16 domid,
 			struct nvme_supported_cap_config_list_log *cap)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = cap,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_SUPPORTED_CAP_CONFIG_LIST,
 		.len = sizeof(*cap),
@@ -2052,28 +2052,28 @@ static inline int nvme_get_log_support_cap_config_list(int fd, __u16 domid,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_reservation() - Retrieve Reservation Notification
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @log:	User address to store the reservation log
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise
  */
-static inline int nvme_get_log_reservation(int fd, bool rae,
+static inline int nvme_get_log_reservation(struct dev_handle *hdl, bool rae,
 			struct nvme_resv_notification_log *log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_RESERVATION,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_RESERVATION,
 				 NVME_NSID_ALL, sizeof(*log), log);
 }
 
 /**
  * nvme_get_log_sanitize() - Retrieve Sanitize Status
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rae:	Retain asynchronous events
  * @log:	User address to store the sanitize log
  *
@@ -2083,16 +2083,16 @@ static inline int nvme_get_log_reservation(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_sanitize(int fd, bool rae,
+static inline int nvme_get_log_sanitize(struct dev_handle *hdl, bool rae,
 			struct nvme_sanitize_log_page *log)
 {
-	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_SANITIZE,
+	return nvme_get_nsid_log(hdl, rae, NVME_LOG_LID_SANITIZE,
 				 NVME_NSID_ALL, sizeof(*log), log);
 }
 
 /**
  * nvme_get_log_zns_changed_zones() - Retrieve list of zones that have changed
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @rae:	Retain asynchronous events
  * @log:	User address to store the changed zone log
@@ -2102,15 +2102,15 @@ static inline int nvme_get_log_sanitize(int fd, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_zns_changed_zones(int fd, __u32 nsid, bool rae,
+static inline int nvme_get_log_zns_changed_zones(struct dev_handle *hdl, __u32 nsid, bool rae,
 			struct nvme_zns_changed_zone_log *log)
 {
 	struct nvme_get_log_args args = {
 		.lpo = 0,
 		.result = NULL,
 		.log = log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_ZNS_CHANGED_ZONES,
 		.len = sizeof(*log),
@@ -2122,12 +2122,12 @@ static inline int nvme_get_log_zns_changed_zones(int fd, __u32 nsid, bool rae,
 		.rae = rae,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
  * nvme_get_log_persistent_event() - Retrieve Persistent Event Log
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @action:	Action the controller should take during processing this command
  * @size:	Size of @pevent_log
  * @pevent_log:	User address to store the persistent event log
@@ -2135,7 +2135,7 @@ static inline int nvme_get_log_zns_changed_zones(int fd, __u32 nsid, bool rae,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_log_persistent_event(int fd,
+static inline int nvme_get_log_persistent_event(struct dev_handle *hdl,
 			enum nvme_pevent_log_action action,
 			__u32 size, void *pevent_log)
 {
@@ -2143,8 +2143,8 @@ static inline int nvme_get_log_persistent_event(int fd,
 		.lpo = 0,
 		.result = NULL,
 		.log = pevent_log,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = NVME_LOG_LID_PERSISTENT_EVENT,
 		.len = size,
@@ -2156,7 +2156,7 @@ static inline int nvme_get_log_persistent_event(int fd,
 		.rae = false,
 		.ot = false,
 	};
-	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+	return nvme_get_log_page(hdl, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
 /**
@@ -2170,7 +2170,7 @@ int nvme_set_features(struct nvme_set_features_args *args);
 
 /**
  * nvme_set_features_data() - Helper function for @nvme_set_features()
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @fid:	Feature identifier
  * @nsid:	Namespace ID, if applicable
  * @cdw11:	Value to set the feature to
@@ -2182,15 +2182,15 @@ int nvme_set_features(struct nvme_set_features_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_set_features_data(int fd, __u8 fid, __u32 nsid,
+static inline int nvme_set_features_data(struct dev_handle *hdl, __u8 fid, __u32 nsid,
 			__u32 cdw11, bool save, __u32 data_len, void *data,
 			__u32 *result)
 {
 	struct nvme_set_features_args args = {
 		.result = result,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.cdw11 = cdw11,
@@ -2207,7 +2207,7 @@ static inline int nvme_set_features_data(int fd, __u8 fid, __u32 nsid,
 
 /**
  * nvme_set_features_simple() - Helper function for @nvme_set_features()
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @fid:	Feature identifier
  * @nsid:	Namespace ID, if applicable
  * @cdw11:	Value to set the feature to
@@ -2217,32 +2217,32 @@ static inline int nvme_set_features_data(int fd, __u8 fid, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_set_features_simple(int fd, __u8 fid, __u32 nsid,
+static inline int nvme_set_features_simple(struct dev_handle *hdl, __u8 fid, __u32 nsid,
 			__u32 cdw11, bool save, __u32 *result)
 {
-	return nvme_set_features_data(fd, fid, nsid, cdw11, save, 0, NULL,
+	return nvme_set_features_data(hdl, fid, nsid, cdw11, save, 0, NULL,
 				 result);
 }
 
 /**
  * nvme_set_features_arbitration() - Set arbitration features
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @ab:		Arbitration Burst
  * @lpw:	Low Priority Weight
  * @mpw:	Medium Priority Weight
- * @hpw:	High Priority Weight
+ * @hdlpw:	High Priority Weight
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_arbitration(int fd, __u8 ab, __u8 lpw, __u8 mpw,
+int nvme_set_features_arbitration(struct dev_handle *hdl, __u8 ab, __u8 lpw, __u8 mpw,
 				  __u8 hpw, bool  save, __u32 *result);
 
 /**
  * nvme_set_features_power_mgmt() - Set power management feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @ps:		Power State
  * @wh:		Workload Hint
  * @save:	Save value across power states
@@ -2251,12 +2251,12 @@ int nvme_set_features_arbitration(int fd, __u8 ab, __u8 lpw, __u8 mpw,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_power_mgmt(int fd, __u8 ps, __u8 wh, bool save,
+int nvme_set_features_power_mgmt(struct dev_handle *hdl, __u8 ps, __u8 wh, bool save,
 				 __u32 *result);
 
 /**
  * nvme_set_features_lba_range() - Set LBA range feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @nr_ranges:	Number of ranges in @data
  * @save:	Save value across power states
@@ -2266,12 +2266,12 @@ int nvme_set_features_power_mgmt(int fd, __u8 ps, __u8 wh, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_lba_range(int fd, __u32 nsid, __u32 nr_ranges, bool save,
+int nvme_set_features_lba_range(struct dev_handle *hdl, __u32 nsid, __u32 nr_ranges, bool save,
 				struct nvme_lba_range_type *data, __u32 *result);
 
 /**
  * nvme_set_features_temp_thresh() - Set temperature threshold feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @tmpth:	Temperature Threshold
  * @tmpsel:	Threshold Temperature Select
  * @thsel:	Threshold Type Select
@@ -2281,13 +2281,13 @@ int nvme_set_features_lba_range(int fd, __u32 nsid, __u32 nr_ranges, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_temp_thresh(int fd, __u16 tmpth, __u8 tmpsel,
+int nvme_set_features_temp_thresh(struct dev_handle *hdl, __u16 tmpth, __u8 tmpsel,
 				  enum nvme_feat_tmpthresh_thsel thsel,
 				  bool save, __u32 *result);
 
 /**
  * nvme_set_features_err_recovery() - Set error recovery feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @tler:	Time-limited error recovery value
  * @dulbe:	Deallocated or Unwritten Logical Block Error Enable
@@ -2297,12 +2297,12 @@ int nvme_set_features_temp_thresh(int fd, __u16 tmpth, __u8 tmpsel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_err_recovery(int fd, __u32 nsid, __u16 tler,
+int nvme_set_features_err_recovery(struct dev_handle *hdl, __u32 nsid, __u16 tler,
 				   bool dulbe, bool save, __u32 *result);
 
 /**
  * nvme_set_features_volatile_wc() - Set volatile write cache feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @wce:	Write cache enable
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2310,12 +2310,12 @@ int nvme_set_features_err_recovery(int fd, __u32 nsid, __u16 tler,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_volatile_wc(int fd, bool wce, bool save,
+int nvme_set_features_volatile_wc(struct dev_handle *hdl, bool wce, bool save,
 				  __u32 *result);
 
 /**
  * nvme_set_features_irq_coalesce() - Set IRQ coalesce feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @thr:	Aggregation Threshold
  * @time:	Aggregation Time
  * @save:	Save value across power states
@@ -2324,12 +2324,12 @@ int nvme_set_features_volatile_wc(int fd, bool wce, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_irq_coalesce(int fd, __u8 thr, __u8 time,
+int nvme_set_features_irq_coalesce(struct dev_handle *hdl, __u8 thr, __u8 time,
 				   bool save, __u32 *result);
 
 /**
  * nvme_set_features_irq_config() - Set IRQ config feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @iv:		Interrupt Vector
  * @cd:		Coalescing Disable
  * @save:	Save value across power states
@@ -2338,12 +2338,12 @@ int nvme_set_features_irq_coalesce(int fd, __u8 thr, __u8 time,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_irq_config(int fd, __u16 iv, bool cd, bool save,
+int nvme_set_features_irq_config(struct dev_handle *hdl, __u16 iv, bool cd, bool save,
 				 __u32 *result);
 
 /**
  * nvme_set_features_write_atomic() - Set write atomic feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @dn:		Disable Normal
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2351,12 +2351,12 @@ int nvme_set_features_irq_config(int fd, __u16 iv, bool cd, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_write_atomic(int fd, bool dn, bool save,
+int nvme_set_features_write_atomic(struct dev_handle *hdl, bool dn, bool save,
 				   __u32 *result);
 
 /**
  * nvme_set_features_async_event() - Set asynchronous event feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @events:	Events to enable
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2364,12 +2364,12 @@ int nvme_set_features_write_atomic(int fd, bool dn, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_async_event(int fd, __u32 events, bool save,
+int nvme_set_features_async_event(struct dev_handle *hdl, __u32 events, bool save,
 				  __u32 *result);
 
 /**
  * nvme_set_features_auto_pst() - Set autonomous power state feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @apste:	Autonomous Power State Transition Enable
  * @apst:	Autonomous Power State Transition
  * @save:	Save value across power states
@@ -2378,24 +2378,24 @@ int nvme_set_features_async_event(int fd, __u32 events, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_auto_pst(int fd, bool apste, bool save,
+int nvme_set_features_auto_pst(struct dev_handle *hdl, bool apste, bool save,
 			       struct nvme_feat_auto_pst *apst,
 			       __u32 *result);
 
 /**
  * nvme_set_features_timestamp() - Set timestamp feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @save:	Save value across power states
  * @timestamp:	The current timestamp value to assign to this feature
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_timestamp(int fd, bool save, __u64 timestamp);
+int nvme_set_features_timestamp(struct dev_handle *hdl, bool save, __u64 timestamp);
 
 /**
  * nvme_set_features_hctm() - Set thermal management feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @tmt2:	Thermal Management Temperature 2
  * @tmt1:	Thermal Management Temperature 1
  * @save:	Save value across power states
@@ -2404,12 +2404,12 @@ int nvme_set_features_timestamp(int fd, bool save, __u64 timestamp);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_hctm(int fd, __u16 tmt2, __u16 tmt1, bool save,
+int nvme_set_features_hctm(struct dev_handle *hdl, __u16 tmt2, __u16 tmt1, bool save,
 			   __u32 *result);
 
 /**
  * nvme_set_features_nopsc() - Set non-operational power state feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @noppme:	Non-Operational Power State Permissive Mode Enable
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2417,11 +2417,11 @@ int nvme_set_features_hctm(int fd, __u16 tmt2, __u16 tmt1, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_nopsc(int fd, bool noppme, bool save, __u32 *result);
+int nvme_set_features_nopsc(struct dev_handle *hdl, bool noppme, bool save, __u32 *result);
 
 /**
  * nvme_set_features_rrl() - Set read recovery level feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @rrl:	Read recovery level setting
  * @nvmsetid:	NVM set id
  * @save:	Save value across power states
@@ -2430,12 +2430,12 @@ int nvme_set_features_nopsc(int fd, bool noppme, bool save, __u32 *result);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_rrl(int fd, __u8 rrl, __u16 nvmsetid, bool save,
+int nvme_set_features_rrl(struct dev_handle *hdl, __u8 rrl, __u16 nvmsetid, bool save,
 			  __u32 *result);
 
 /**
  * nvme_set_features_plm_config() - Set predictable latency feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @enable:	Predictable Latency Enable
  * @nvmsetid:	NVM Set Identifier
  * @save:	Save value across power states
@@ -2445,13 +2445,13 @@ int nvme_set_features_rrl(int fd, __u8 rrl, __u16 nvmsetid, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_plm_config(int fd, bool enable, __u16 nvmsetid,
+int nvme_set_features_plm_config(struct dev_handle *hdl, bool enable, __u16 nvmsetid,
 				 bool save, struct nvme_plm_config *data,
 				 __u32 *result);
 
 /**
  * nvme_set_features_plm_window() - Set window select feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Window Select
  * @nvmsetid:	NVM Set Identifier
  * @save:	Save value across power states
@@ -2460,12 +2460,12 @@ int nvme_set_features_plm_config(int fd, bool enable, __u16 nvmsetid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_plm_window(int fd, enum nvme_feat_plm_window_select sel,
+int nvme_set_features_plm_window(struct dev_handle *hdl, enum nvme_feat_plm_window_select sel,
 				 __u16 nvmsetid, bool save, __u32 *result);
 
 /**
  * nvme_set_features_lba_sts_interval() - Set LBA status information feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @save:	Save value across power states
  * @lsiri:	LBA Status Information Report Interval
  * @lsipi:	LBA Status Information Poll Interval
@@ -2474,24 +2474,24 @@ int nvme_set_features_plm_window(int fd, enum nvme_feat_plm_window_select sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_lba_sts_interval(int fd, __u16 lsiri, __u16 lsipi,
+int nvme_set_features_lba_sts_interval(struct dev_handle *hdl, __u16 lsiri, __u16 lsipi,
 				       bool save, __u32 *result);
 
 /**
  * nvme_set_features_host_behavior() - Set host behavior feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @save:	Save value across power states
  * @data:	Pointer to structure nvme_feat_host_behavior
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_host_behavior(int fd, bool save,
+int nvme_set_features_host_behavior(struct dev_handle *hdl, bool save,
 				    struct nvme_feat_host_behavior *data);
 
 /**
  * nvme_set_features_sanitize() - Set sanitize feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nodrm:	No-Deallocate Response Mode
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2499,11 +2499,11 @@ int nvme_set_features_host_behavior(int fd, bool save,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_sanitize(int fd, bool nodrm, bool save, __u32 *result);
+int nvme_set_features_sanitize(struct dev_handle *hdl, bool nodrm, bool save, __u32 *result);
 
 /**
  * nvme_set_features_endurance_evt_cfg() - Set endurance event config feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @endgid:	Endurance Group Identifier
  * @egwarn:	Flags to enable warning, see &enum nvme_eg_critical_warning_flags
  * @save:	Save value across power states
@@ -2512,12 +2512,12 @@ int nvme_set_features_sanitize(int fd, bool nodrm, bool save, __u32 *result);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_endurance_evt_cfg(int fd, __u16 endgid, __u8 egwarn,
+int nvme_set_features_endurance_evt_cfg(struct dev_handle *hdl, __u16 endgid, __u8 egwarn,
 					bool save, __u32 *result);
 
 /**
  * nvme_set_features_sw_progress() - Set pre-boot software load count feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @pbslc:	Pre-boot Software Load Count
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2525,24 +2525,24 @@ int nvme_set_features_endurance_evt_cfg(int fd, __u16 endgid, __u8 egwarn,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_sw_progress(int fd, __u8 pbslc, bool save,
+int nvme_set_features_sw_progress(struct dev_handle *hdl, __u8 pbslc, bool save,
 				  __u32 *result);
 
 /**
  * nvme_set_features_host_id() - Set enable extended host identifiers feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @exhid:	Enable Extended Host Identifier
  * @save:	Save value across power states
- * @hostid:	Host ID to set
+ * @hdlostid:	Host ID to set
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_host_id(int fd, bool exhid, bool save, __u8 *hostid);
+int nvme_set_features_host_id(struct dev_handle *hdl, bool exhid, bool save, __u8 *hostid);
 
 /**
  * nvme_set_features_resv_mask() - Set reservation notification mask feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @mask:	Reservation Notification Mask Field
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2550,11 +2550,11 @@ int nvme_set_features_host_id(int fd, bool exhid, bool save, __u8 *hostid);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_resv_mask(int fd, __u32 mask, bool save, __u32 *result);
+int nvme_set_features_resv_mask(struct dev_handle *hdl, __u32 mask, bool save, __u32 *result);
 
 /**
  * nvme_set_features_resv_persist() - Set persist through power loss feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @ptpl:	Persist Through Power Loss
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2562,11 +2562,11 @@ int nvme_set_features_resv_mask(int fd, __u32 mask, bool save, __u32 *result);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_resv_persist(int fd, bool ptpl, bool save, __u32 *result);
+int nvme_set_features_resv_persist(struct dev_handle *hdl, bool ptpl, bool save, __u32 *result);
 
 /**
  * nvme_set_features_write_protect() - Set write protect feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @state:	Write Protection State
  * @save:	Save value across power states
  * @result:	The command completion result from CQE dword0
@@ -2574,7 +2574,7 @@ int nvme_set_features_resv_persist(int fd, bool ptpl, bool save, __u32 *result);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_set_features_write_protect(int fd, enum nvme_feat_nswpcfg_state state,
+int nvme_set_features_write_protect(struct dev_handle *hdl, enum nvme_feat_nswpcfg_state state,
 				    bool save, __u32 *result);
 
 /**
@@ -2588,7 +2588,7 @@ int nvme_get_features(struct nvme_get_features_args *args);
 
 /**
  * nvme_get_features_data() - Helper function for @nvme_get_features()
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @fid:	Feature identifier
  * @nsid:	Namespace ID, if applicable
  * @data_len:	Length of feature data, if applicable, in bytes
@@ -2598,14 +2598,14 @@ int nvme_get_features(struct nvme_get_features_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_features_data(int fd, enum nvme_features_id fid,
+static inline int nvme_get_features_data(struct dev_handle *hdl, enum nvme_features_id fid,
 			__u32 nsid, __u32 data_len, void *data, __u32 *result)
 {
 	struct nvme_get_features_args args = {
 		.result = result,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.sel = NVME_GET_FEATURES_SEL_CURRENT,
@@ -2620,7 +2620,7 @@ static inline int nvme_get_features_data(int fd, enum nvme_features_id fid,
 
 /**
  * nvme_get_features_simple() - Helper function for @nvme_get_features()
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @fid:	Feature identifier
  * @nsid:	Namespace ID, if applicable
  * @result:	The command completion result from CQE dword0
@@ -2628,39 +2628,39 @@ static inline int nvme_get_features_data(int fd, enum nvme_features_id fid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_get_features_simple(int fd, enum nvme_features_id fid,
+static inline int nvme_get_features_simple(struct dev_handle *hdl, enum nvme_features_id fid,
 			__u32 nsid, __u32 *result)
 {
-	return nvme_get_features_data(fd, fid, nsid, 0, NULL, result);
+	return nvme_get_features_data(hdl, fid, nsid, 0, NULL, result);
 }
 
 /**
  * nvme_get_features_arbitration() - Get arbitration feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_arbitration(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_arbitration(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
  * nvme_get_features_power_mgmt() - Get power management feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_power_mgmt(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_power_mgmt(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u32 *result);
 
 /**
  * nvme_get_features_lba_range() - Get LBA range feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @data:	User address of feature data, if applicable
  * @result:	The command completion result from CQE dword0
@@ -2668,73 +2668,73 @@ int nvme_get_features_power_mgmt(int fd, enum nvme_get_features_sel sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_lba_range(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_lba_range(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				struct nvme_lba_range_type *data,
 				__u32 *result);
 
 /**
  * nvme_get_features_temp_thresh() - Get temperature threshold feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_temp_thresh(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_temp_thresh(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
  * nvme_get_features_err_recovery() - Get error recovery feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_err_recovery(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_err_recovery(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
  * nvme_get_features_volatile_wc() - Get volatile write cache feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_volatile_wc(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_volatile_wc(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
  * nvme_get_features_num_queues() - Get number of queues feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_num_queues(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_num_queues(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u32 *result);
 
 /**
  * nvme_get_features_irq_coalesce() - Get IRQ coalesce feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_irq_coalesce(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_irq_coalesce(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
  * nvme_get_features_irq_config() - Get IRQ config feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @iv:
  * @result:	The command completion result from CQE dword0
@@ -2742,36 +2742,36 @@ int nvme_get_features_irq_coalesce(int fd, enum nvme_get_features_sel sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_irq_config(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_irq_config(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u16 iv, __u32 *result);
 
 /**
  * nvme_get_features_write_atomic() - Get write atomic feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_write_atomic(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_write_atomic(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
  * nvme_get_features_async_event() - Get asynchronous event feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_async_event(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_async_event(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
  * nvme_get_features_auto_pst() - Get autonomous power state feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @apst:
  * @result:	The command completion result from CQE dword0
@@ -2779,80 +2779,80 @@ int nvme_get_features_async_event(int fd, enum nvme_get_features_sel sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_auto_pst(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_auto_pst(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 			       struct nvme_feat_auto_pst *apst, __u32 *result);
 
 /**
  * nvme_get_features_host_mem_buf() - Get host memory buffer feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_host_mem_buf(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_host_mem_buf(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
  * nvme_get_features_timestamp() - Get timestamp feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @ts:		Current timestamp
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_timestamp(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_timestamp(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				struct nvme_timestamp *ts);
 
 /**
  * nvme_get_features_kato() - Get keep alive timeout feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_kato(int fd, enum nvme_get_features_sel sel, __u32 *result);
+int nvme_get_features_kato(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
  * nvme_get_features_hctm() - Get thermal management feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_hctm(int fd, enum nvme_get_features_sel sel, __u32 *result);
+int nvme_get_features_hctm(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
  * nvme_get_features_nopsc() - Get non-operational power state feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_nopsc(int fd, enum nvme_get_features_sel sel, __u32 *result);
+int nvme_get_features_nopsc(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
  * nvme_get_features_rrl() - Get read recovery level feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_rrl(int fd, enum nvme_get_features_sel sel, __u32 *result);
+int nvme_get_features_rrl(struct dev_handle *hdl, enum nvme_get_features_sel sel, __u32 *result);
 
 /**
  * nvme_get_features_plm_config() - Get predictable latency feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @nvmsetid:	NVM set id
  * @data:
@@ -2861,13 +2861,13 @@ int nvme_get_features_rrl(int fd, enum nvme_get_features_sel sel, __u32 *result)
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_plm_config(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_plm_config(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				 __u16 nvmsetid, struct nvme_plm_config *data,
 				 __u32 *result);
 
 /**
  * nvme_get_features_plm_window() - Get window select feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @nvmsetid:	NVM set id
  * @result:	The command completion result from CQE dword0
@@ -2875,24 +2875,24 @@ int nvme_get_features_plm_config(int fd, enum nvme_get_features_sel sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_plm_window(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_plm_window(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 	__u16 nvmsetid, __u32 *result);
 
 /**
  * nvme_get_features_lba_sts_interval() - Get LBA status information feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_lba_sts_interval(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_lba_sts_interval(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				       __u32 *result);
 
 /**
  * nvme_get_features_host_behavior() - Get host behavior feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @data:	Pointer to structure nvme_feat_host_behavior
  * @result:	The command completion result from CQE dword0
@@ -2900,25 +2900,25 @@ int nvme_get_features_lba_sts_interval(int fd, enum nvme_get_features_sel sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_host_behavior(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_host_behavior(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				    struct nvme_feat_host_behavior *data,
 				    __u32 *result);
 
 /**
  * nvme_get_features_sanitize() - Get sanitize feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_sanitize(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_sanitize(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				__u32 *result);
 
 /**
  * nvme_get_features_endurance_event_cfg() - Get endurance event config feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @endgid:	Endurance Group Identifier
  * @result:	The command completion result from CQE dword0
@@ -2926,62 +2926,62 @@ int nvme_get_features_sanitize(int fd, enum nvme_get_features_sel sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_endurance_event_cfg(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_endurance_event_cfg(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 					  __u16 endgid, __u32 *result);
 
 /**
  * nvme_get_features_sw_progress() - Get software progress feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_sw_progress(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_sw_progress(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				  __u32 *result);
 
 /**
  * nvme_get_features_host_id() - Get host id feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @exhid:	Enable Extended Host Identifier
- * @len:	Length of @hostid
- * @hostid:	Buffer for returned host ID
+ * @len:	Length of @hdlostid
+ * @hdlostid:	Buffer for returned host ID
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_host_id(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_host_id(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 			      bool exhid, __u32 len, __u8 *hostid);
 
 /**
  * nvme_get_features_resv_mask() - Get reservation mask feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_resv_mask(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_resv_mask(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				__u32 *result);
 
 /**
  * nvme_get_features_resv_persist() - Get reservation persist feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_resv_persist(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_resv_persist(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
  * nvme_get_features_write_protect() - Get write protect feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
@@ -2989,20 +2989,20 @@ int nvme_get_features_resv_persist(int fd, enum nvme_get_features_sel sel,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_write_protect(int fd, __u32 nsid,
+int nvme_get_features_write_protect(struct dev_handle *hdl, __u32 nsid,
 				    enum nvme_get_features_sel sel,
 				    __u32 *result);
 
 /**
  * nvme_get_features_iocs_profile() - Get IOCS profile feature
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @sel:	Select which type of attribute to return, see &enum nvme_get_features_sel
  * @result:	The command completion result from CQE dword0
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_features_iocs_profile(int fd, enum nvme_get_features_sel sel,
+int nvme_get_features_iocs_profile(struct dev_handle *hdl, enum nvme_get_features_sel sel,
 				   __u32 *result);
 
 /**
@@ -3030,7 +3030,7 @@ int nvme_ns_mgmt(struct nvme_ns_mgmt_args *args);
 
 /**
  * nvme_ns_mgmt_create() - Create a non attached namespace
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @ns:		Namespace identification that defines ns creation parameters
  * @nsid:		On success, set to the namespace id that was created
  * @timeout:		Override the default timeout to this value in milliseconds;
@@ -3045,15 +3045,15 @@ int nvme_ns_mgmt(struct nvme_ns_mgmt_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_ns_mgmt_create(int fd, struct nvme_id_ns *ns,
+static inline int nvme_ns_mgmt_create(struct dev_handle *hdl, struct nvme_id_ns *ns,
 			__u32 *nsid, __u32 timeout, __u8 csi,
 			struct nvme_ns_mgmt_host_sw_specified *data)
 {
 	struct nvme_ns_mgmt_args args = {
 		.result = nsid,
 		.ns = ns,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = timeout,
 		.nsid = NVME_NSID_NONE,
 		.sel = NVME_NS_MGMT_SEL_CREATE,
@@ -3068,7 +3068,7 @@ static inline int nvme_ns_mgmt_create(int fd, struct nvme_id_ns *ns,
 
 /**
  * nvme_ns_mgmt_delete() - Delete a non attached namespace
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier to delete
  *
  * It is recommended that a namespace being deleted is not attached to any
@@ -3078,13 +3078,13 @@ static inline int nvme_ns_mgmt_create(int fd, struct nvme_id_ns *ns,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_ns_mgmt_delete(int fd, __u32 nsid)
+static inline int nvme_ns_mgmt_delete(struct dev_handle *hdl, __u32 nsid)
 {
 	struct nvme_ns_mgmt_args args = {
 		.result = NULL,
 		.ns = NULL,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = 0,
 		.nsid = nsid,
 		.sel = NVME_NS_MGMT_SEL_DELETE,
@@ -3108,21 +3108,21 @@ int nvme_ns_attach(struct nvme_ns_attach_args *args);
 
 /**
  * nvme_ns_attach_ctrls() - Attach namespace to controllers
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID to attach
  * @ctrlist:	Controller list to modify attachment state of nsid
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_ns_attach_ctrls(int fd, __u32 nsid,
+static inline int nvme_ns_attach_ctrls(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_ctrl_list *ctrlist)
 {
 	struct nvme_ns_attach_args args = {
 		.result = NULL,
 		.ctrlist = ctrlist,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.sel = NVME_NS_ATTACH_SEL_CTRL_ATTACH,
@@ -3133,21 +3133,21 @@ static inline int nvme_ns_attach_ctrls(int fd, __u32 nsid,
 
 /**
  * nvme_ns_detach_ctrls() - Detach namespace from controllers
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID to detach
  * @ctrlist:	Controller list to modify attachment state of nsid
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_ns_detach_ctrls(int fd, __u32 nsid,
+static inline int nvme_ns_detach_ctrls(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_ctrl_list *ctrlist)
 {
 	struct nvme_ns_attach_args args = {
 		.result = NULL,
 		.ctrlist = ctrlist,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.sel = NVME_NS_ATTACH_SEL_CTRL_DEATTACH,
@@ -3248,7 +3248,7 @@ int nvme_directive_send(struct nvme_directive_send_args *args);
 
 /**
  * nvme_directive_send_id_endir() - Directive Send Enable Directive
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace Identifier
  * @endir:	Enable Directive
  * @dtype:	Directive Type
@@ -3257,27 +3257,27 @@ int nvme_directive_send(struct nvme_directive_send_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_directive_send_id_endir(int fd, __u32 nsid, bool endir,
+int nvme_directive_send_id_endir(struct dev_handle *hdl, __u32 nsid, bool endir,
 				 enum nvme_directive_dtype dtype,
 				 struct nvme_id_directives *id);
 
 /**
  * nvme_directive_send_stream_release_identifier() - Directive Send Stream release
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @stream_id:	Stream identifier
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_directive_send_stream_release_identifier(int fd,
+static inline int nvme_directive_send_stream_release_identifier(struct dev_handle *hdl,
 			__u32 nsid, __u16 stream_id)
 {
 	struct nvme_directive_send_args args = {
 		.result = NULL,
 		.data = NULL,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.doper = NVME_DIRECTIVE_SEND_STREAMS_DOPER_RELEASE_IDENTIFIER,
@@ -3292,19 +3292,19 @@ static inline int nvme_directive_send_stream_release_identifier(int fd,
 
 /**
  * nvme_directive_send_stream_release_resource() - Directive Send Stream release resources
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_directive_send_stream_release_resource(int fd, __u32 nsid)
+static inline int nvme_directive_send_stream_release_resource(struct dev_handle *hdl, __u32 nsid)
 {
 	struct nvme_directive_send_args args = {
 		.result = NULL,
 		.data = NULL,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.doper = NVME_DIRECTIVE_SEND_STREAMS_DOPER_RELEASE_RESOURCE,
@@ -3328,21 +3328,21 @@ int nvme_directive_recv(struct nvme_directive_recv_args *args);
 
 /**
  * nvme_directive_recv_identify_parameters() - Directive receive identifier parameters
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @id:		Identify parameters buffer
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_directive_recv_identify_parameters(int fd, __u32 nsid,
+static inline int nvme_directive_recv_identify_parameters(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_id_directives *id)
 {
 	struct nvme_directive_recv_args args = {
 		.result = NULL,
 		.data = id,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.doper = NVME_DIRECTIVE_RECEIVE_IDENTIFY_DOPER_PARAM,
@@ -3357,21 +3357,21 @@ static inline int nvme_directive_recv_identify_parameters(int fd, __u32 nsid,
 
 /**
  * nvme_directive_recv_stream_parameters() - Directive receive stream parameters
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @parms:	Streams directive parameters buffer
  *
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_directive_recv_stream_parameters(int fd, __u32 nsid,
+static inline int nvme_directive_recv_stream_parameters(struct dev_handle *hdl, __u32 nsid,
 			struct nvme_streams_directive_params *parms)
 {
 	struct nvme_directive_recv_args args = {
 		.result = NULL,
 		.data = parms,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.doper = NVME_DIRECTIVE_RECEIVE_STREAMS_DOPER_PARAM,
@@ -3386,7 +3386,7 @@ static inline int nvme_directive_recv_stream_parameters(int fd, __u32 nsid,
 
 /**
  * nvme_directive_recv_stream_status() - Directive receive stream status
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @nr_entries: Number of streams to receive
  * @id:		Stream status buffer
@@ -3394,15 +3394,15 @@ static inline int nvme_directive_recv_stream_parameters(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_directive_recv_stream_status(int fd, __u32 nsid,
+static inline int nvme_directive_recv_stream_status(struct dev_handle *hdl, __u32 nsid,
 			unsigned int nr_entries,
 			struct nvme_streams_directive_status *id)
 {
 	struct nvme_directive_recv_args args = {
 		.result = NULL,
 		.data = id,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.doper = NVME_DIRECTIVE_RECEIVE_STREAMS_DOPER_STATUS,
@@ -3417,7 +3417,7 @@ static inline int nvme_directive_recv_stream_status(int fd, __u32 nsid,
 
 /**
  * nvme_directive_recv_stream_allocate() - Directive receive stream allocate
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace ID
  * @nsr:	Namespace Streams Requested
  * @result:	If successful, the CQE dword0 value
@@ -3425,14 +3425,14 @@ static inline int nvme_directive_recv_stream_status(int fd, __u32 nsid,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_directive_recv_stream_allocate(int fd, __u32 nsid,
+static inline int nvme_directive_recv_stream_allocate(struct dev_handle *hdl, __u32 nsid,
 			__u16 nsr, __u32 *result)
 {
 	struct nvme_directive_recv_args args = {
 		.result = result,
 		.data = NULL,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.nsid = nsid,
 		.doper = NVME_DIRECTIVE_RECEIVE_STREAMS_DOPER_RESOURCE,
@@ -3545,7 +3545,7 @@ int nvme_virtual_mgmt(struct nvme_virtual_mgmt_args *args);
 
 /**
  * nvme_flush() - Send an nvme flush command
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier
  *
  * The Flush command requests that the contents of volatile write cache be made
@@ -3554,14 +3554,14 @@ int nvme_virtual_mgmt(struct nvme_virtual_mgmt_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_flush(int fd, __u32 nsid)
+static inline int nvme_flush(struct dev_handle *hdl, __u32 nsid)
 {
 	struct nvme_passthru_cmd cmd = {};
 
 	cmd.opcode = nvme_cmd_flush;
 	cmd.nsid = nsid;
 
-	return nvme_submit_io_passthru(fd, &cmd, NULL);
+	return nvme_submit_io_passthru(hdl, &cmd, NULL);
 }
 
 /**
@@ -3743,7 +3743,7 @@ int nvme_io_mgmt_recv(struct nvme_io_mgmt_recv_args *args);
 
 /**
  * nvme_fdp_reclaim_unit_handle_status() - Get reclaim unit handle status
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier
  * @data_len:	Length of response buffer
  * @data:	Response buffer
@@ -3751,13 +3751,13 @@ int nvme_io_mgmt_recv(struct nvme_io_mgmt_recv_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_fdp_reclaim_unit_handle_status(int fd, __u32 nsid,
+static inline int nvme_fdp_reclaim_unit_handle_status(struct dev_handle *hdl, __u32 nsid,
 			__u32 data_len, void *data)
 {
 	struct nvme_io_mgmt_recv_args args = {
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.nsid = nsid,
 		.data_len = data_len,
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
@@ -3779,7 +3779,7 @@ int nvme_io_mgmt_send(struct nvme_io_mgmt_send_args *args);
 
 /**
  * nvme_fdp_reclaim_unit_handle_update() - Update a list of reclaim unit handles
- * @fd:		File descriptor of nvme device
+ * @hdl:	Device handle to nvme device
  * @nsid:	Namespace identifier
  * @npids:	Number of placement identifiers
  * @pids:	List of placement identifiers
@@ -3787,13 +3787,13 @@ int nvme_io_mgmt_send(struct nvme_io_mgmt_send_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_fdp_reclaim_unit_handle_update(int fd, __u32 nsid,
+static inline int nvme_fdp_reclaim_unit_handle_update(struct dev_handle *hdl, __u32 nsid,
 			unsigned int npids, __u16 *pids)
 {
 	struct nvme_io_mgmt_send_args args = {
 		.data = (void *)pids,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.nsid = nsid,
 		.data_len = (__u32)(npids * sizeof(__u16)),
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
@@ -3825,7 +3825,7 @@ int nvme_zns_mgmt_recv(struct nvme_zns_mgmt_recv_args *args);
 
 /**
  * nvme_zns_report_zones() - Return the list of zones
- * @fd:		File descriptor of nvme device
+ * @hdl:        Device handle to nvme device
  * @nsid:	Namespace ID
  * @slba:	Starting LBA
  * @opts:	Reporting options
@@ -3839,7 +3839,7 @@ int nvme_zns_mgmt_recv(struct nvme_zns_mgmt_recv_args *args);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-static inline int nvme_zns_report_zones(int fd, __u32 nsid, __u64 slba,
+static inline int nvme_zns_report_zones(struct dev_handle *hdl, __u32 nsid, __u64 slba,
 			  enum nvme_zns_report_options opts,
 			  bool extended, bool partial,
 			  __u32 data_len, void *data,
@@ -3849,8 +3849,8 @@ static inline int nvme_zns_report_zones(int fd, __u32 nsid, __u64 slba,
 		.slba = slba,
 		.result = result,
 		.data = data,
+		.hdl = hdl,
 		.args_size = sizeof(args),
-		.fd = fd,
 		.timeout = timeout,
 		.nsid = nsid,
 		.zra = extended ? NVME_ZNS_ZRA_EXTENDED_REPORT_ZONES :

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -94,13 +94,13 @@ close_fd:
 	return -1;
 }
 
-int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
+int nvme_fw_download_seq(struct dev_handle *hdl, __u32 size, __u32 xfer, __u32 offset,
 			 void *buf)
 {
 	int err = 0;
 	struct nvme_fw_download_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.offset = offset,
 		.data_len = xfer,
 		.data = buf,
@@ -122,7 +122,7 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 	return err;
 }
 
-static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
+static int nvme_get_telemetry_log(struct dev_handle *hdl, bool create, bool ctrl, bool rae,
 				  struct nvme_telemetry_log **buf, enum nvme_telemetry_da da,
 				  size_t *size)
 {
@@ -135,7 +135,7 @@ static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
 	int err;
 	struct nvme_get_log_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.nsid = NVME_NSID_NONE,
 		.lsp = NVME_LOG_LSP_NONE,
 		.lsi = NVME_LOG_LSI_NONE,
@@ -156,14 +156,14 @@ static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
 	}
 
 	if (ctrl) {
-		err = nvme_get_log_telemetry_ctrl(fd, true, 0, xfer, log);
+		err = nvme_get_log_telemetry_ctrl(hdl, true, 0, xfer, log);
 		lid = NVME_LOG_LID_TELEMETRY_CTRL;
 	} else {
 		lid = NVME_LOG_LID_TELEMETRY_HOST;
 		if (create)
-			err = nvme_get_log_create_telemetry_host(fd, log);
+			err = nvme_get_log_create_telemetry_host(hdl, log);
 		else
-			err = nvme_get_log_telemetry_host(fd, 0, xfer, log);
+			err = nvme_get_log_telemetry_host(hdl, 0, xfer, log);
 	}
 
 	if (err)
@@ -184,7 +184,7 @@ static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
 		*size = (le16_to_cpu(telem->dalb3) + 1) * xfer;
 		break;
 	case NVME_TELEMETRY_DA_4:
-		err = nvme_identify_ctrl(fd, &id_ctrl);
+		err = nvme_identify_ctrl(hdl, &id_ctrl);
 		if (err) {
 			perror("identify-ctrl");
 			errno = EINVAL;
@@ -218,7 +218,7 @@ static int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae,
 	args.lid = lid;
 	args.log = log;
 	args.len = *size;
-	err = nvme_get_log_page(fd, 4096, &args);
+	err = nvme_get_log_page(hdl, 4096, &args);
 	if (!err) {
 		*buf = log;
 		return 0;
@@ -228,32 +228,32 @@ free:
 	return err;
 }
 
-int nvme_get_ctrl_telemetry(int fd, bool rae, struct nvme_telemetry_log **log,
+int nvme_get_ctrl_telemetry(struct dev_handle *hdl, bool rae, struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size)
 {
-	return nvme_get_telemetry_log(fd, false, true, rae, log, da, size);
+	return nvme_get_telemetry_log(hdl, false, true, rae, log, da, size);
 }
 
-int nvme_get_host_telemetry(int fd, struct nvme_telemetry_log **log,
+int nvme_get_host_telemetry(struct dev_handle *hdl, struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size)
 {
-	return nvme_get_telemetry_log(fd, false, false, false, log, da, size);
+	return nvme_get_telemetry_log(hdl, false, false, false, log, da, size);
 }
 
-int nvme_get_new_host_telemetry(int fd, struct nvme_telemetry_log **log,
+int nvme_get_new_host_telemetry(struct dev_handle *hdl, struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size)
 {
-	return nvme_get_telemetry_log(fd, true, false, false, log, da, size);
+	return nvme_get_telemetry_log(hdl, true, false, false, log, da, size);
 }
 
-int nvme_get_lba_status_log(int fd, bool rae, struct nvme_lba_status_log **log)
+int nvme_get_lba_status_log(struct dev_handle *hdl, bool rae, struct nvme_lba_status_log **log)
 {
 	__u32 size = sizeof(struct nvme_lba_status_log);
 	void *buf, *tmp;
 	int err;
 	struct nvme_get_log_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.nsid = NVME_NSID_NONE,
 		.lsp = NVME_LOG_LSP_NONE,
 		.lsi = NVME_LOG_LSI_NONE,
@@ -270,7 +270,7 @@ int nvme_get_lba_status_log(int fd, bool rae, struct nvme_lba_status_log **log)
 		return -1;
 
 	*log = buf;
-	err = nvme_get_log_lba_status(fd, true, 0, size, buf);
+	err = nvme_get_log_lba_status(hdl, true, 0, size, buf);
 	if (err)
 		goto free;
 
@@ -289,7 +289,7 @@ int nvme_get_lba_status_log(int fd, bool rae, struct nvme_lba_status_log **log)
 	args.lid = NVME_LOG_LID_LBA_STATUS;
 	args.log = buf;
 	args.len = size;
-	err = nvme_get_log_page(fd, 4096, &args);
+	err = nvme_get_log_page(hdl, 4096, &args);
 	if (!err)
 		return 0;
 
@@ -299,13 +299,13 @@ free:
 	return err;
 }
 
-static int nvme_ns_attachment(int fd, __u32 nsid, __u16 num_ctrls,
+static int nvme_ns_attachment(struct dev_handle *hdl, __u32 nsid, __u16 num_ctrls,
 			      __u16 *ctrlist, bool attach, __u32 timeout)
 {
 	struct nvme_ctrl_list cntlist = { 0 };
 	struct nvme_ns_attach_args args = {
 		.args_size = sizeof(args),
-		.fd = fd,
+		.hdl = hdl,
 		.nsid = nsid,
 		.sel = NVME_NS_ATTACH_SEL_CTRL_DEATTACH,
 		.ctrlist = &cntlist,
@@ -319,26 +319,26 @@ static int nvme_ns_attachment(int fd, __u32 nsid, __u16 num_ctrls,
 	return nvme_ns_attach(&args);
 }
 
-int nvme_namespace_attach_ctrls(int fd, __u32 nsid, __u16 num_ctrls,
+int nvme_namespace_attach_ctrls(struct dev_handle *hdl, __u32 nsid, __u16 num_ctrls,
 				__u16 *ctrlist)
 {
-	return nvme_ns_attachment(fd, nsid, num_ctrls, ctrlist, true,
+	return nvme_ns_attachment(hdl, nsid, num_ctrls, ctrlist, true,
 				  NVME_DEFAULT_IOCTL_TIMEOUT);
 }
 
-int nvme_namespace_detach_ctrls(int fd, __u32 nsid, __u16 num_ctrls,
+int nvme_namespace_detach_ctrls(struct dev_handle *hdl, __u32 nsid, __u16 num_ctrls,
 				__u16 *ctrlist)
 {
-	return nvme_ns_attachment(fd, nsid, num_ctrls, ctrlist, false,
+	return nvme_ns_attachment(hdl, nsid, num_ctrls, ctrlist, false,
 				  NVME_DEFAULT_IOCTL_TIMEOUT);
 }
 
-int nvme_get_ana_log_len(int fd, size_t *analen)
+int nvme_get_ana_log_len(struct dev_handle *hdl, size_t *analen)
 {
 	struct nvme_id_ctrl ctrl;
 	int ret;
 
-	ret = nvme_identify_ctrl(fd, &ctrl);
+	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret)
 		return ret;
 
@@ -348,13 +348,13 @@ int nvme_get_ana_log_len(int fd, size_t *analen)
 	return 0;
 }
 
-int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize)
+int nvme_get_logical_block_size(struct dev_handle *hdl, __u32 nsid, int *blksize)
 {
 	struct nvme_id_ns ns;
 	__u8 flbas;
 	int ret;
 
-	ret = nvme_identify_ns(fd, nsid, &ns);
+	ret = nvme_identify_ns(hdl, nsid, &ns);
 	if (ret)
 		return ret;
 

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -31,7 +31,7 @@
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
+int nvme_fw_download_seq(struct dev_handle *h, __u32 size, __u32 xfer, __u32 offset,
 			 void *buf);
 
 /**
@@ -62,7 +62,7 @@ enum nvme_telemetry_da {
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_ctrl_telemetry(int fd, bool rae, struct nvme_telemetry_log **log,
+int nvme_get_ctrl_telemetry(struct dev_handle *h, bool rae, struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size);
 
 /**
@@ -78,7 +78,7 @@ int nvme_get_ctrl_telemetry(int fd, bool rae, struct nvme_telemetry_log **log,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_host_telemetry(int fd,  struct nvme_telemetry_log **log,
+int nvme_get_host_telemetry(struct dev_handle *h,  struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size);
 
 /**
@@ -94,7 +94,7 @@ int nvme_get_host_telemetry(int fd,  struct nvme_telemetry_log **log,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log,
+int nvme_get_new_host_telemetry(struct dev_handle *h,  struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size);
 
 /**
@@ -105,7 +105,7 @@ int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log,
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_ana_log_len(int fd, size_t *analen);
+int nvme_get_ana_log_len(struct dev_handle *h, size_t *analen);
 
 /**
  * nvme_get_logical_block_size() - Retrieve block size
@@ -116,7 +116,7 @@ int nvme_get_ana_log_len(int fd, size_t *analen);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize);
+int nvme_get_logical_block_size(struct dev_handle *h, __u32 nsid, int *blksize);
 
 /**
  * nvme_get_lba_status_log() - Retrieve the LBA Status log page
@@ -127,7 +127,7 @@ int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_get_lba_status_log(int fd, bool rae, struct nvme_lba_status_log **log);
+int nvme_get_lba_status_log(struct dev_handle *h, bool rae, struct nvme_lba_status_log **log);
 
 /**
  * nvme_namespace_attach_ctrls() - Attach namespace to controller(s)
@@ -139,7 +139,7 @@ int nvme_get_lba_status_log(int fd, bool rae, struct nvme_lba_status_log **log);
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_namespace_attach_ctrls(int fd, __u32 nsid, __u16 num_ctrls, __u16 *ctrlist);
+int nvme_namespace_attach_ctrls(struct dev_handle *h, __u32 nsid, __u16 num_ctrls, __u16 *ctrlist);
 
 /**
  * nvme_namespace_detach_ctrls() - Detach namespace from controller(s)
@@ -151,7 +151,7 @@ int nvme_namespace_attach_ctrls(int fd, __u32 nsid, __u16 num_ctrls, __u16 *ctrl
  * Return: The nvme command status if a response was received (see
  * &enum nvme_status_field) or -1 with errno set otherwise.
  */
-int nvme_namespace_detach_ctrls(int fd, __u32 nsid, __u16 num_ctrls, __u16 *ctrlist);
+int nvme_namespace_detach_ctrls(struct dev_handle *h, __u32 nsid, __u16 num_ctrls, __u16 *ctrlist);
 
 /**
  * nvme_open() - Open an nvme controller or namespace device

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -41,7 +41,7 @@ struct nvme_ns {
 	struct nvme_subsystem *s;
 	struct nvme_ctrl *c;
 
-	int fd;
+	struct dev_handle *hdl;
 	__u32 nsid;
 	char *name;
 	char *generic_name;
@@ -65,7 +65,7 @@ struct nvme_ctrl {
 	struct list_head namespaces;
 	struct nvme_subsystem *s;
 
-	int fd;
+	struct dev_handle *hdl;
 	char *name;
 	char *sysfs_dir;
 	char *address;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -492,7 +492,7 @@ nvme_ns_t nvme_subsystem_next_ns(nvme_subsystem_t s, nvme_ns_t n);
 		p = nvme_namespace_next_path(n, p))
 
 /**
- * nvme_ns_get_fd() - Get associated file descriptor
+ * nvme_ns_get_hdl() - Get handle associated file descriptor
  * @n:	Namespace instance
  *
  * libnvme will open() the file (if not already opened) and keep
@@ -502,9 +502,9 @@ nvme_ns_t nvme_subsystem_next_ns(nvme_subsystem_t s, nvme_ns_t n);
  * remain cached until the ns object is deleted or
  * nvme_ns_release_fd() is called.
  *
- * Return: File descriptor associated with @n or -1
+ * Return: dev_handle associated with @n or -1
  */
-int nvme_ns_get_fd(nvme_ns_t n);
+void* nvme_ns_get_hdl(nvme_ns_t n);
 
 /**
  * nvme_ns_release_fd() - Close fd and clear fd from ns object
@@ -806,7 +806,7 @@ nvme_ns_t nvme_path_get_ns(nvme_path_t p);
  *
  * Return: File descriptor associated with @c or -1
  */
-int nvme_ctrl_get_fd(nvme_ctrl_t c);
+void* nvme_ctrl_get_fd(nvme_ctrl_t c);
 
 /**
  * nvme_ctrl_release_fd() - Close fd and clear fd from controller object

--- a/test/test.c
+++ b/test/test.c
@@ -38,7 +38,8 @@ static int test_ctrl(nvme_ctrl_t c)
 	static __u8 buf[0x1000];
 
 	enum nvme_get_features_sel sel = NVME_GET_FEATURES_SEL_CURRENT;
-	int ret, temp, fd = nvme_ctrl_get_fd(c);
+	int ret, temp; 
+	struct dev_handle *hdl = nvme_ctrl_get_fd(c);
 	struct nvme_error_log_page error[64]; 
 	struct nvme_smart_log smart = { 0 };
 	struct nvme_firmware_slot fw =  { 0 };
@@ -68,7 +69,7 @@ static int test_ctrl(nvme_ctrl_t c)
 		printf("PASSED: Identify controller\n");
 	}
 
-	ret = nvme_get_log_smart(fd, NVME_NSID_ALL, true, &smart);
+	ret = nvme_get_log_smart(hdl, NVME_NSID_ALL, true, &smart);
 	if (ret) {
 		printf("ERROR: no smart log for:%s %#x\n", nvme_ctrl_get_name(c), ret);
 		return ret;
@@ -87,42 +88,42 @@ static int test_ctrl(nvme_ctrl_t c)
 	printf("  sn:%-.20s\n", id.sn);
 	printf("  model:%-.40s\n", id.mn);
 
-	ret = nvme_identify_allocated_ns_list(fd, 0, &ns_list);
+	ret = nvme_identify_allocated_ns_list(hdl, 0, &ns_list);
 	if (!ret)
 		printf("  PASSED: Allocated NS List\n");
 	else
 		printf("  ERROR: Allocated NS List:%x\n", ret);
-	ret = nvme_identify_active_ns_list(fd, 0, &ns_list);
+	ret = nvme_identify_active_ns_list(hdl, 0, &ns_list);
 	if (!ret)
 		printf("  PASSED: Active NS List\n");
 	else
 		printf("  ERROR: Active NS List:%x\n", ret);
-	ret = nvme_identify_ctrl_list(fd, 0, &ctrlist);
+	ret = nvme_identify_ctrl_list(hdl, 0, &ctrlist);
 	if (!ret)
 		printf("  PASSED: Ctrl List\n");
 	else
 		printf("  ERROR: CtrlList:%x\n", ret);
-	ret = nvme_identify_nsid_ctrl_list(fd, 1, 0, &ctrlist);
+	ret = nvme_identify_nsid_ctrl_list(hdl, 1, 0, &ctrlist);
 	if (!ret)
 		printf("  PASSED: NSID Ctrl List\n");
 	else
 		printf("  ERROR: NSID CtrlList:%x\n", ret);
-	ret = nvme_identify_primary_ctrl(fd, 0, &prim);
+	ret = nvme_identify_primary_ctrl(hdl, 0, &prim);
 	if (!ret)
 		printf("  PASSED: Identify Primary\n");
 	else
 		printf("  ERROR: Identify Primary:%x\n", ret);
-	ret = nvme_identify_secondary_ctrl_list(fd, 1, 0, &sec);
+	ret = nvme_identify_secondary_ctrl_list(hdl, 1, 0, &sec);
 	if (!ret)
 		printf("  PASSED: Identify Secondary\n");
 	else
 		printf("  ERROR: Identify Secondary:%x\n", ret);
-	ret = nvme_identify_ns_granularity(fd, &gran);
+	ret = nvme_identify_ns_granularity(hdl, &gran);
 	if (!ret)
 		printf("  PASSED: Identify NS granularity\n");
 	else
 		printf("  ERROR: Identify NS granularity:%x\n", ret);
-	ret = nvme_identify_uuid(fd, &uuid);
+	ret = nvme_identify_uuid(hdl, &uuid);
 	if (!ret)
 		printf("  PASSED: Identify UUID List\n");
 	else
@@ -131,138 +132,138 @@ static int test_ctrl(nvme_ctrl_t c)
 	printf("\nLogs\n");
 	printf("  SMART: Current temperature:%d percent used:%d%%\n", temp,
 		smart.percent_used);
-	ret = nvme_get_log_sanitize(fd, true, &sanlog);
+	ret = nvme_get_log_sanitize(hdl, true, &sanlog);
 	if (!ret)
 		printf("  Sanitize Log:\n");
 	else
 		printf("  ERROR: Sanitize Log:%x\n", ret);
-	ret = nvme_get_log_reservation(fd, true, &resvnotify);
+	ret = nvme_get_log_reservation(hdl, true, &resvnotify);
 	if (!ret)
 		printf("  Reservation Log\n");
 	else
 		printf("  ERROR: Reservation Log:%x\n", ret);
-	ret = nvme_get_log_ana_groups(fd, true, sizeof(buf), analog);
+	ret = nvme_get_log_ana_groups(hdl, true, sizeof(buf), analog);
 	if (!ret)
 		printf("  ANA Groups\n");
 	else
 		printf("  ERROR: ANA Groups:%x\n", ret);
-	ret = nvme_get_log_endurance_group(fd, 0, &eglog);
+	ret = nvme_get_log_endurance_group(hdl, 0, &eglog);
 	if (!ret)
 		printf("  Endurance Group\n");
 	else
 		printf("  ERROR: Endurance Group:%x\n", ret);
-	ret = nvme_get_log_telemetry_ctrl(fd, true, 0, sizeof(buf), telem);
+	ret = nvme_get_log_telemetry_ctrl(hdl, true, 0, sizeof(buf), telem);
 	if (!ret)
 		printf("  Telemetry Controller\n");
 	else
 		printf("  ERROR: Telemetry Controller:%x\n", ret);
-	ret = nvme_get_log_device_self_test(fd, &st);
+	ret = nvme_get_log_device_self_test(hdl, &st);
 	if (!ret)
 		printf("  Device Self Test\n");
 	else
 		printf("  ERROR: Device Self Test:%x\n", ret);
-	ret = nvme_get_log_cmd_effects(fd, NVME_CSI_NVM, &cfx);
+	ret = nvme_get_log_cmd_effects(hdl, NVME_CSI_NVM, &cfx);
 	if (!ret)
 		printf("  Command Effects\n");
 	else
 		printf("  ERROR: Command Effects:%x\n", ret);
-	ret = nvme_get_log_changed_ns_list(fd, true, &ns_list);
+	ret = nvme_get_log_changed_ns_list(hdl, true, &ns_list);
 	if (!ret)
 		printf("  Change NS List\n");
 	else
 		printf("  ERROR: Change NS List:%x\n", ret);
-	ret = nvme_get_log_fw_slot(fd, true, &fw);
+	ret = nvme_get_log_fw_slot(hdl, true, &fw);
 	if (!ret)
 		printf("  FW Slot\n");
 	else
 		printf("  ERROR: FW Slot%x\n", ret);
-	ret = nvme_get_log_error(fd, 64, true, error);
+	ret = nvme_get_log_error(hdl, 64, true, error);
 	if (!ret)
 		printf("  Error Log\n");
 	else
 		printf("  ERROR: Error Log:%x\n", ret);
 	printf("\nFeatures\n");
-	ret = nvme_get_features_arbitration(fd, sel, &result);
+	ret = nvme_get_features_arbitration(hdl, sel, &result);
 	if (!ret)
 		printf("  Arbitration:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Arbitration:%x\n", ret);
-	ret = nvme_get_features_power_mgmt(fd, sel, &result);
+	ret = nvme_get_features_power_mgmt(hdl, sel, &result);
 	if (!ret)
 		printf("  Power Management:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Power Management:%x\n", ret);
-	ret = nvme_get_features_temp_thresh(fd, sel, &result);
+	ret = nvme_get_features_temp_thresh(hdl, sel, &result);
 	if (!ret)
 		printf("  Temperature Threshold:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Temperature Threshold:%x\n", ret);
-	ret = nvme_get_features_err_recovery(fd, sel, &result);
+	ret = nvme_get_features_err_recovery(hdl, sel, &result);
 	if (!ret)
 		printf("  Error Recovery:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Error Recovery:%x\n", ret);
-	ret = nvme_get_features_volatile_wc(fd, sel, &result);
+	ret = nvme_get_features_volatile_wc(hdl, sel, &result);
 	if (!ret)
 		printf("  Volatile Write Cache:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Volatile Write Cache:%x\n", ret);
-	ret = nvme_get_features_num_queues(fd, sel, &result);
+	ret = nvme_get_features_num_queues(hdl, sel, &result);
 	if (!ret)
 		printf("  Number of Queues:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Number of Queues:%x\n", ret);
-	ret = nvme_get_features_irq_coalesce(fd, sel, &result);
+	ret = nvme_get_features_irq_coalesce(hdl, sel, &result);
 	if (!ret)
 		printf("  IRQ Coalescing:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: IRQ Coalescing:%x\n", ret);
-	ret = nvme_get_features_write_atomic(fd, sel, &result);
+	ret = nvme_get_features_write_atomic(hdl, sel, &result);
 	if (!ret)
 		printf("  Write Atomic:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Write Atomic:%x\n", ret);
-	ret = nvme_get_features_async_event(fd, sel, &result);
+	ret = nvme_get_features_async_event(hdl, sel, &result);
 	if (!ret)
 		printf("  Asycn Event Config:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Asycn Event Config:%x\n", ret);
-	ret = nvme_get_features_hctm(fd, sel, &result);
+	ret = nvme_get_features_hctm(hdl, sel, &result);
 	if (!ret)
 		printf("  HCTM:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: HCTM:%x\n", ret);
-	ret = nvme_get_features_nopsc(fd, sel, &result);
+	ret = nvme_get_features_nopsc(hdl, sel, &result);
 	if (!ret)
 		printf("  NOP Power State Config:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: NOP Power State Configrbitration:%x\n", ret);
-	ret = nvme_get_features_rrl(fd, sel, &result);
+	ret = nvme_get_features_rrl(hdl, sel, &result);
 	if (!ret)
 		printf("  Read Recover Levels:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Read Recover Levels:%x\n", ret);
-	ret = nvme_get_features_lba_sts_interval(fd, sel, &result);
+	ret = nvme_get_features_lba_sts_interval(hdl, sel, &result);
 	if (!ret)
 		printf("  LBA Status Interval:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: LBA Status Interval:%x\n", ret);
-	ret = nvme_get_features_sanitize(fd, sel, &result);
+	ret = nvme_get_features_sanitize(hdl, sel, &result);
 	if (!ret)
 		printf("  Sanitize:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: SW Progress Marker:%x\n", ret);
-	ret = nvme_get_features_sw_progress(fd, sel, &result);
+	ret = nvme_get_features_sw_progress(hdl, sel, &result);
 	if (!ret)
 		printf("  SW Progress Marker:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Sanitize:%x\n", ret);
-	ret = nvme_get_features_resv_mask(fd, sel, &result);
+	ret = nvme_get_features_resv_mask(hdl, sel, &result);
 	if (!ret)
 		printf("  Reservation Mask:%x\n", result);
 	else if (ret > 0)
 		printf("  ERROR: Reservation Mask:%x\n", ret);
-	ret = nvme_get_features_resv_persist(fd, sel, &result);
+	ret = nvme_get_features_resv_persist(hdl, sel, &result);
 	if (!ret)
 		printf("  Reservation Persistence:%x\n", result);
 	else if (ret > 0)
@@ -272,7 +273,8 @@ static int test_ctrl(nvme_ctrl_t c)
 
 static int test_namespace(nvme_ns_t n)
 {
-	int ret, nsid = nvme_ns_get_nsid(n), fd = nvme_ns_get_fd(n);
+	int ret, nsid = nvme_ns_get_nsid(n);
+	struct dev_handle *hdl = nvme_ns_get_hdl(n);
 	struct nvme_id_ns ns = { 0 }, allocated = { 0 };
 	struct nvme_ns_id_desc descs = { 0 };
 	__u32 result = 0;
@@ -287,17 +289,17 @@ static int test_namespace(nvme_ns_t n)
 		nvme_ns_get_name(n), le64_to_cpu(ns.nsze),
 		1 << ns.lbaf[flbas].ds);
 
-	ret = nvme_identify_allocated_ns(fd, nsid, &allocated);
+	ret = nvme_identify_allocated_ns(hdl, nsid, &allocated);
 	if (!ret)
 		printf("  Identify allocated ns\n");
 	else
 		printf("  ERROR: Identify allocated ns:%x\n", ret);
-	ret = nvme_identify_ns_descs(fd, nsid,  &descs);
+	ret = nvme_identify_ns_descs(hdl, nsid,  &descs);
 	if (!ret)
 		printf("  Identify NS Descriptors\n");
 	else
 		printf("  ERROR: Identify NS Descriptors:%x\n", ret);
-	ret = nvme_get_features_write_protect(fd, nsid,
+	ret = nvme_get_features_write_protect(hdl, nsid,
 		NVME_GET_FEATURES_SEL_CURRENT, &result);
 	if (!ret)
 		printf("  Write Protect:%x\n", result);

--- a/test/zns.c
+++ b/test/zns.c
@@ -29,7 +29,7 @@ static void show_zns_properties(nvme_ns_t n)
 	if (!zr)
 		return;
 
-	if (nvme_zns_identify_ns(nvme_ns_get_fd(n), nvme_ns_get_nsid(n),
+	if (nvme_zns_identify_ns(nvme_ns_get_hdl(n), nvme_ns_get_nsid(n),
 				 &zns_ns)) {
 		fprintf(stderr, "failed to identify zns ns\n");;
 	}
@@ -38,7 +38,7 @@ static void show_zns_properties(nvme_ns_t n)
 		le16_to_cpu(zns_ns.ozcs), le32_to_cpu(zns_ns.mar),
 		le32_to_cpu(zns_ns.mor));
 
-	if (nvme_zns_identify_ctrl(nvme_ns_get_fd(n), &zns_ctrl)) {
+	if (nvme_zns_identify_ctrl(nvme_ns_get_hdl(n), &zns_ctrl)) {
 		fprintf(stderr, "failed to identify zns ctrl\n");;
 		free(zr);
 		return;
@@ -46,7 +46,7 @@ static void show_zns_properties(nvme_ns_t n)
 
 	printf("zasl:%u\n", zns_ctrl.zasl);
 
-	if (nvme_zns_report_zones(nvme_ns_get_fd(n), nvme_ns_get_nsid(n), 0,
+	if (nvme_zns_report_zones(nvme_ns_get_hdl(n), nvme_ns_get_nsid(n), 0,
 				  NVME_ZNS_ZRAS_REPORT_ALL, false,
 				  true, 0x1000, (void *)zr,
 				  NVME_DEFAULT_IOCTL_TIMEOUT, &result)) {


### PR DESCRIPTION
api: refactor for transport agnostic library backend

Extend the api-types with the following device-handle types:

* struct dev_handle
* enum nvme_dev_type

The 'dev_handle' provides a, possibly opaque, device handle instead of a "fixed" file-descriptor. This allows for non-OS managed device-types such as user-space NVMe-drivers. Additionally, the types allows for library-side dispatch.

This is done in preparation for xNVMe, and thereby, support for
user-space NVMe driver, io_uring_cmd etc.