### PR TITLE
tree: fix segfault in nvme_scan_subsystem()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -692,7 +692,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name,
 				continue;
 			if (strcmp(_s->name, name))
 				continue;
-			if (!__nvme_scan_subsystem(r, s, f, f_args)) {
+			if (!__nvme_scan_subsystem(r, _s, f, f_args)) {
 				errno = -EINVAL;
 				goto out_free;
 			}


### PR DESCRIPTION
The wrong nvme_subsystem struct was being passed to __nvme_subsystem_scan() which caused it to segfault. Fix it.

Fixes: d08fd10 ("make __nvme_scan_subsystem() returning bool")