### PR TITLE
meson: Don't hard-code path to "internal/config.h"

### DIFF
--- a/internal/meson.build
+++ b/internal/meson.build
@@ -19,3 +19,10 @@ internal_incdir = include_directories('.')
 config_dep = declare_dependency(
   include_directories : internal_incdir,
   sources: config_h)
+
+add_project_arguments(
+    [
+        '-include', '@0@'.format(config_h),
+    ],
+    language : 'c',
+)

--- a/meson.build
+++ b/meson.build
@@ -253,7 +253,6 @@ add_project_arguments(
     [
         '-fomit-frame-pointer',
         '-D_GNU_SOURCE',
-        '-include', 'internal/config.h',
     ],
     language : 'c',
 )


### PR DESCRIPTION
When building libnvme as a subproject of another project (e.g. nvme-stas), the hard-coded absolute path to config.h, i.e. "-include internal/config.h" does not resolve properly and fails to build. Instead, use the real path calculated by meson and saved to variable "config_h".