### PR TITLE
mi: remove nsid from nvme_mi_admin_identify_secondary_ctrl_list()

### DIFF
--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -1395,7 +1395,6 @@ static inline int nvme_mi_admin_identify_primary_ctrl(nvme_mi_ctrl_t ctrl,
  * nvme_mi_admin_identify_secondary_ctrl_list() - Perform an Admin identify for
  * a secondary controller list.
  * @ctrl: Controller to process identify command
- * @nsid: Namespace ID to specify list start
  * @cntid: Controller ID to specify list start
  * @list: List data to populate
  *
@@ -1412,7 +1411,6 @@ static inline int nvme_mi_admin_identify_primary_ctrl(nvme_mi_ctrl_t ctrl,
  * See: &struct nvme_secondary_ctrl_list
  */
 static inline int nvme_mi_admin_identify_secondary_ctrl_list(nvme_mi_ctrl_t ctrl,
-							     __u32 nsid,
 							     __u16 cntid,
 							     struct nvme_secondary_ctrl_list *list)
 {
@@ -1422,7 +1420,7 @@ static inline int nvme_mi_admin_identify_secondary_ctrl_list(nvme_mi_ctrl_t ctrl
 		.args_size = sizeof(args),
 		.cns = NVME_IDENTIFY_CNS_SECONDARY_CTRL_LIST,
 		.csi = NVME_CSI_NVM,
-		.nsid = nsid,
+		.nsid = NVME_NSID_NONE,
 		.cntid = cntid,
 		.cns_specific_id = NVME_CNSSPECID_NONE,
 		.uuidx = NVME_UUID_NONE,

--- a/test/mi.c
+++ b/test/mi.c
@@ -1245,7 +1245,6 @@ static int test_admin_id_secondary_ctrl_list_cb(struct nvme_mi_ep *ep,
 						void *data)
 {
 	__u16 cns, ctrlid;
-	__u32 nsid;
 	__u8 *hdr;
 
 	hdr = (__u8 *)req->hdr;
@@ -1255,9 +1254,6 @@ static int test_admin_id_secondary_ctrl_list_cb(struct nvme_mi_ep *ep,
 
 	cns = hdr[45] << 8 | hdr[44];
 	assert(cns == NVME_IDENTIFY_CNS_SECONDARY_CTRL_LIST);
-
-	nsid = hdr[11] << 24 | hdr[10] << 16 | hdr[9] << 8 | hdr[8];
-	assert(nsid == 0x01020304);
 
 	ctrlid = hdr[47] << 8 | hdr[46];
 	assert(ctrlid == 5);
@@ -1280,8 +1276,7 @@ static void test_admin_id_secondary_ctrl_list(struct nvme_mi_ep *ep)
 	ctrl = nvme_mi_init_ctrl(ep, 5);
 	assert(ctrl);
 
-	rc = nvme_mi_admin_identify_secondary_ctrl_list(ctrl, 0x01020304,
-							5, &list);
+	rc = nvme_mi_admin_identify_secondary_ctrl_list(ctrl, 5, &list);
 	assert(!rc);
 }
 


### PR DESCRIPTION
According to the NVMe specification, Identify CNS value 15h ("Secondary Controller list of controllers associated with the primary controller processing the command") does not use the NSID field. So remove the "nsid" argument from
nvme_mi_admin_identify_secondary_ctrl_list().

Fixes: 07b63103878 ("ioctl: remove nsid from nvme_identify_secondary_ctrl_list()")

Fixes: https://github.com/linux-nvme/libnvme/issues/700