### PR TITLE
Account for discovery log page entry space stripping and simplify space stripping code

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1166,30 +1166,10 @@ out_free_log:
 	return NULL;
 }
 
-static void sanitize_discovery_log_entry(struct nvmf_disc_log_entry  *e)
+static void sanitize_discovery_log_entry(struct nvmf_disc_log_entry *e)
 {
-	switch (e->trtype) {
-	case NVMF_TRTYPE_RDMA:
-	case NVMF_TRTYPE_TCP:
-		switch (e->adrfam) {
-		case NVMF_ADDR_FAMILY_IP4:
-		case NVMF_ADDR_FAMILY_IP6:
-			strchomp(e->traddr, NVMF_TRADDR_SIZE);
-			strchomp(e->trsvcid, NVMF_TRSVCID_SIZE);
-			break;
-		}
-		break;
-        case NVMF_TRTYPE_FC:
-		switch (e->adrfam) {
-		case NVMF_ADDR_FAMILY_FC:
-			strchomp(e->traddr, NVMF_TRADDR_SIZE);
-			break;
-		}
-		break;
-	case NVMF_TRTYPE_LOOP:
-		strchomp(e->traddr, NVMF_TRADDR_SIZE);
-		break;
-	}
+	strchomp(e->trsvcid, sizeof(e->trsvcid));
+	strchomp(e->traddr, sizeof(e->traddr));
 }
 
 int nvmf_get_discovery_log(nvme_ctrl_t c, struct nvmf_discovery_log **logp,

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -47,7 +47,7 @@
 const char *nvmf_dev = "/dev/nvme-fabrics";
 
 /**
- * strchomp() - Strip trailing white space
+ * strchomp() - Strip trailing spaces
  * @str: String to strip
  * @max: Maximum length of string
  */
@@ -55,11 +55,8 @@ static void strchomp(char *str, int max)
 {
 	int i;
 
-	for (i = max - 1; i >= 0; i--) {
-		if (str[i] != '\0' && str[i] != ' ')
-			return;
-		else
-			str[i] = '\0';
+	for (i = max - 1; i >= 0 && str[i] == ' '; i--) {
+		str[i] = '\0';
 	}
 }
 

--- a/test/ioctl/discovery.c
+++ b/test/ioctl/discovery.c
@@ -14,6 +14,46 @@
 
 #define TEST_FD 0xFD
 
+static void arbitrary_ascii_string(size_t max_len, char *str, char *log_str)
+{
+	size_t len;
+	size_t i;
+
+	len = arbitrary_range(max_len + 1);
+	for (i = 0; i < len; i++) {
+		/*
+		 * ASCII strings shall contain only code values 20h through 7Eh.
+		 * Exclude 20h (space) because it ends the string.
+		 */
+		str[i] = log_str[i] = arbitrary_range(0x7E - 0x20) + 0x20 + 1;
+	}
+	for (i = len; i < max_len; i++) {
+		str[i] = '\0';
+		log_str[i] = ' ';
+	}
+}
+
+static void arbitrary_entry(struct nvmf_disc_log_entry *entry,
+                            struct nvmf_disc_log_entry *log_entry)
+{
+	arbitrary(entry, sizeof(*entry));
+	memcpy(log_entry, entry, sizeof(*entry));
+	arbitrary_ascii_string(
+		sizeof(entry->trsvcid), entry->trsvcid, log_entry->trsvcid);
+	arbitrary_ascii_string(
+		sizeof(entry->traddr), entry->traddr, log_entry->traddr);
+}
+
+static void arbitrary_entries(size_t len,
+                              struct nvmf_disc_log_entry *entries,
+                              struct nvmf_disc_log_entry *log_entries)
+{
+	size_t i;
+
+	for (i = 0; i < len; i++)
+		arbitrary_entry(&entries[i], &log_entries[i]);
+}
+
 static void test_no_entries(nvme_ctrl_t c)
 {
 	struct nvmf_discovery_log header = {};
@@ -39,10 +79,10 @@ static void test_no_entries(nvme_ctrl_t c)
 
 static void test_four_entries(nvme_ctrl_t c)
 {
-	struct nvmf_disc_log_entry entries[4];
-	struct nvmf_discovery_log header = {
-		.numrec = cpu_to_le64(ARRAY_SIZE(entries)),
-	};
+	size_t num_entries = 4;
+	struct nvmf_disc_log_entry entries[num_entries];
+	struct nvmf_disc_log_entry log_entries[num_entries];
+	struct nvmf_discovery_log header = {.numrec = cpu_to_le64(num_entries)};
 	/*
 	 * All 4 entries should be fetched at once
 	 * followed by the header again (to ensure genctr hasn't changed)
@@ -63,7 +103,7 @@ static void test_four_entries(nvme_ctrl_t c)
 			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header), /* LPOL */
-			.out_data = entries,
+			.out_data = log_entries,
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
@@ -75,7 +115,7 @@ static void test_four_entries(nvme_ctrl_t c)
 	};
 	struct nvmf_discovery_log *log = NULL;
 
-	arbitrary(entries, sizeof(entries));
+	arbitrary_entries(num_entries, entries, log_entries);
 	set_mock_admin_cmds(mock_admin_cmds, ARRAY_SIZE(mock_admin_cmds));
 	check(nvmf_get_discovery_log(c, &log, 1) == 0, "discovery failed: %m");
 	end_mock_cmds();
@@ -86,14 +126,14 @@ static void test_four_entries(nvme_ctrl_t c)
 
 static void test_five_entries(nvme_ctrl_t c)
 {
-	struct nvmf_disc_log_entry entries[5];
+	size_t num_entries = 5;
+	struct nvmf_disc_log_entry entries[num_entries];
+	struct nvmf_disc_log_entry log_entries[num_entries];
 	size_t first_entries = 4;
 	size_t first_data_len = first_entries * sizeof(*entries);
-	size_t second_entries = ARRAY_SIZE(entries) - first_entries;
+	size_t second_entries = num_entries - first_entries;
 	size_t second_data_len = second_entries * sizeof(*entries);
-	struct nvmf_discovery_log header = {
-		.numrec = cpu_to_le64(ARRAY_SIZE(entries)),
-	};
+	struct nvmf_discovery_log header = {.numrec = cpu_to_le64(num_entries)};
 	/*
 	 * The first 4 entries (4 KB) are fetched together,
 	 * followed by last entry separately.
@@ -115,7 +155,7 @@ static void test_five_entries(nvme_ctrl_t c)
 			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header), /* LPOL */
-			.out_data = entries,
+			.out_data = log_entries,
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
@@ -124,7 +164,7 @@ static void test_five_entries(nvme_ctrl_t c)
 			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header) + first_data_len, /* LPOL */
-			.out_data = entries + first_entries,
+			.out_data = log_entries + first_entries,
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
@@ -136,7 +176,7 @@ static void test_five_entries(nvme_ctrl_t c)
 	};
 	struct nvmf_discovery_log *log = NULL;
 
-	arbitrary(entries, sizeof(entries));
+	arbitrary_entries(num_entries, entries, log_entries);
 	set_mock_admin_cmds(mock_admin_cmds, ARRAY_SIZE(mock_admin_cmds));
 	check(nvmf_get_discovery_log(c, &log, 1) == 0, "discovery failed: %m");
 	end_mock_cmds();
@@ -151,10 +191,12 @@ static void test_genctr_change(nvme_ctrl_t c)
 	struct nvmf_discovery_log header1 = {
 		.numrec = cpu_to_le64(ARRAY_SIZE(entries1)),
 	};
-	struct nvmf_disc_log_entry entries2[2];
+	size_t num_entries2 = 2;
+	struct nvmf_disc_log_entry entries2[num_entries2];
+	struct nvmf_disc_log_entry log_entries2[num_entries2];
 	struct nvmf_discovery_log header2 = {
 		.genctr = cpu_to_le64(1),
-		.numrec = cpu_to_le64(ARRAY_SIZE(entries2)),
+		.numrec = cpu_to_le64(num_entries2),
 	};
 	/*
 	 * genctr changes after the entries are fetched the first time,
@@ -200,7 +242,7 @@ static void test_genctr_change(nvme_ctrl_t c)
 			       | 1 << 15 /* RAE */
 			       | NVME_LOG_LID_DISCOVER, /* LID */
 			.cdw12 = sizeof(header2), /* LPOL */
-			.out_data = entries2,
+			.out_data = log_entries2,
 		},
 		{
 			.opcode = nvme_admin_get_log_page,
@@ -213,7 +255,7 @@ static void test_genctr_change(nvme_ctrl_t c)
 	struct nvmf_discovery_log *log = NULL;
 
 	arbitrary(entries1, sizeof(entries1));
-	arbitrary(entries2, sizeof(entries2));
+	arbitrary_entries(num_entries2, entries2, log_entries2);
 	set_mock_admin_cmds(mock_admin_cmds, ARRAY_SIZE(mock_admin_cmds));
 	check(nvmf_get_discovery_log(c, &log, 2) == 0, "discovery failed: %m");
 	end_mock_cmds();

--- a/test/ioctl/util.c
+++ b/test/ioctl/util.c
@@ -56,3 +56,10 @@ void arbitrary(void *buf_, size_t len)
 	while (len--)
 		*(buf++) = rand();
 }
+
+size_t arbitrary_range(size_t max)
+{
+	size_t value;
+	arbitrary(&value, sizeof(value));
+	return value % max;
+}

--- a/test/ioctl/util.h
+++ b/test/ioctl/util.h
@@ -14,4 +14,6 @@ void cmp(const void *actual, const void *expected, size_t len, const char *msg);
 
 void arbitrary(void *buf, size_t len);
 
+size_t arbitrary_range(size_t max);
+
 #endif /* #ifndef _LIBNVME_TEST_IOCTL_UTIL_H */


### PR DESCRIPTION
`strchomp()` is only needed to strip trailing spaces from a string.
There is no need to replace `NUL` characters with `NUL` characters.
So simplify the check for "NUL or space" to just "space".
Update the function description as well,
as it doesn't strip all whitespace, just spaces.

The NVMe base specification defines fields TRSVCID and TRADDR
as "ASCII strings", meaning they are space-padded.
Therefore, whether spaces need to be stripped from them
doesn't depend on the transport or address family.
Some combinations already appear to be missing,
such as RDMA using IB addresses.
And if new transports are added in the future,
`sanitize_discovery_log_entry()` would need to be updated.
So strip spaces from these fields regardless of the entry's
transport type or address family.

The discovery log page tests incorrectly assumed the log page
`nvmf_get_discovery_log()` returns exactly matches what was fetched.
This failed to account for the trailing space trimming
of the TRSVCID and TRADDR fields.
If the arbitrary entries happened to contain trailing spaces
for these fields, the test cases would fail.
Generate arbitrary entries with space-padded strings for the log page
and corresponding expected entries with `NUL`-padded strings.