### PR TITLE
build: use container for coverage build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         compiler: [gcc, clang]
         buildtype: [debug, release]
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.34
+      image: ghcr.io/igaw/linux-nvme/debian:0.35
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -49,7 +49,7 @@ jobs:
       - name: compile and run unit tests
         uses: mosteo-actions/docker-run@v1
         with:
-          image: ghcr.io/igaw/linux-nvme/ubuntu-cross-${{ matrix.arch }}:0.34
+          image: ghcr.io/igaw/linux-nvme/ubuntu-cross-${{ matrix.arch }}:0.35
           guest-dir: /build
           host-dir: ${{ github.workspace }}
           command: |
@@ -68,7 +68,7 @@ jobs:
     name: libdbus
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.34
+      image: ghcr.io/igaw/linux-nvme/debian:0.35
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -89,7 +89,7 @@ jobs:
     name: fallback shared libraries
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.34
+      image: ghcr.io/igaw/linux-nvme/debian:0.35
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
@@ -110,7 +110,7 @@ jobs:
     name: muon minimal static
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.34
+      image: ghcr.io/igaw/linux-nvme/debian:0.35
     steps:
       - uses: actions/checkout@v3
       - name: build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,30 +9,12 @@ jobs:
   code-coverage:
     name: code coverage
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/igaw/linux-nvme/debian.python:0.35
     steps:
-      - name: install libraries
-        run: sudo apt-get install libjson-c-dev libdbus-1-dev lcov
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - uses: BSFishy/meson-build@v1.0.3
-        with:
-          # Can't use 'coverage' here, see
-          # https://github.com/BSFishy/meson-build/issues/4
-          action: test
-          options: --verbose
-          setup-options: >
-            --werror
-            --buildtype=release
-            --wrap-mode=nofallback
-            -Dlibdbus=enabled
-            -Db_coverage=true
-          meson-version: 0.61.2
-      - name: Generate Coverage Report
-        # Can't use meson here, see
-        # https://github.com/mesonbuild/meson/issues/7895
-        run: ninja -C build coverage --verbose
+      - name: build
+        run: |
+          scripts/build.sh coverage
       - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian.python:0.34
+      image: ghcr.io/igaw/linux-nvme/debian.python:0.35
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The coverage build also fails due missing dependency in install step. Let's use a prebuild container here as well.