### PR TITLE
build: checkout repo in coverage build

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ jobs:
     container:
       image: ghcr.io/igaw/linux-nvme/debian.python:0.35
     steps:
+      - uses: actions/checkout@v3
       - name: build
         run: |
           scripts/build.sh coverage


### PR DESCRIPTION
The previous commit removed accidentally the checkout step. Add it back.