### PR TITLE
build: fix coverage report build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -113,17 +113,13 @@ build_meson() {
         -C "${BUILDDIR}"
 }
 
-build_meson_coverage() {
-    ninja -C "${BUILDDIR}" coverage --verbose
-}
-
 test_meson() {
     "${MESON}" test                             \
         -C "${BUILDDIR}"
 }
 
-test_meson_covarage() {
-    true;
+test_meson_coverage() {
+    ninja -C "${BUILDDIR}" coverage --verbose
 }
 
 tools_build_samurai() {


### PR DESCRIPTION
We need to run the build first, before we can run the coverage tool.