### PR TITLE
build: run tests before coverage tool

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -119,6 +119,8 @@ test_meson() {
 }
 
 test_meson_coverage() {
+    "${MESON}" test                             \
+        -C "${BUILDDIR}"
     ninja -C "${BUILDDIR}" coverage --verbose
 }
 


### PR DESCRIPTION
Obviously, we need to run the tests before the coverage tool.