### PR TITLE
Add quirks framework to libnvme

### DIFF
--- a/src/libnvme.h
+++ b/src/libnvme.h
@@ -23,6 +23,7 @@ extern "C" {
 #include "nvme/tree.h"
 #include "nvme/util.h"
 #include "nvme/log.h"
+#include "nvme/quirks.h"
 
 #ifdef __cplusplus
 }

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -5,6 +5,7 @@ LIBNVME_1_6 {
 		nvme_ctrl_release_fd;
 		nvme_host_release_fds;
 		nvme_ns_release_fd;
+		nvme_quirks_get;
 		nvme_root_release_fds;
 		nvme_subsystem_get_iopolicy;
 		nvme_subsystem_release_fds;

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,8 +26,10 @@ mi_sources = [
 
 if json_c_dep.found()
     sources += 'nvme/json.c'
+    sources += 'nvme/quirks.c'
 else
     sources += 'nvme/no-json.c'
+    sources += 'nvme/no-quirks.c'
 endif
 
 deps = [

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -189,7 +189,7 @@ static void json_parse_host(nvme_root_t r, struct json_object *host_obj)
 	}
 }
 
-static struct json_object *parse_json(nvme_root_t r, int fd)
+struct json_object *parse_json(nvme_root_t r, int fd)
 {
 	char buf[JSON_FILE_BUF_SIZE];
 	struct json_object *obj = NULL;
@@ -219,7 +219,7 @@ static struct json_object *parse_json(nvme_root_t r, int fd)
 	tok->flags = JSON_TOKENER_STRICT;
 
 	obj = json_tokener_parse_ex(tok, str, len);
-	if (!obj)
+	if (!obj && r)
 		nvme_msg(r, LOG_DEBUG, "JSON parsing failed: %s\n",
 			 json_util_get_last_err());
 out:

--- a/src/nvme/no-quirks.c
+++ b/src/nvme/no-quirks.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include "quirks.h"
+
+unsigned int nvme_quirks_get(__u16 vid, __u16 did)
+{
+	return 0;
+}

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -90,6 +90,7 @@ struct nvme_ctrl {
 	bool discovered;
 	bool persistent;
 	struct nvme_fabrics_config cfg;
+	unsigned int quirk_flags;
 };
 
 struct nvme_subsystem {

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -169,7 +169,16 @@ struct nvme_root {
 	struct nvme_fabric_options *options;
 };
 
+struct nvme_quirk {
+	__u16 vid;
+	__u16 did;
+	unsigned int flags;
+};
+
 int nvme_set_attr(const char *dir, const char *attr, const char *value);
+
+struct json_object;
+struct json_object *parse_json(nvme_root_t r, int fd);
 
 int json_read_config(nvme_root_t r, const char *config_file);
 

--- a/src/nvme/quirks.c
+++ b/src/nvme/quirks.c
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <json.h>
+
+#include "private.h"
+#include "quirks.h"
+
+static struct nvme_quirk *quirk_table;
+static unsigned int quirk_table_length;
+
+unsigned int nvme_quirks_get(__u16 vid, __u16 did)
+{
+	struct nvme_quirk *q;
+	int i;
+
+	if (!quirk_table)
+		return 0;
+
+	for (i = 0; i < quirk_table_length; i++) {
+		q = &quirk_table[i];
+
+		if (q->vid == vid && q->did == did)
+			return q->flags;
+	}
+
+	return 0;
+}
+
+static void quirks_parse_entry(struct json_object *entry, __u16 *vid, __u16 *did,
+			       unsigned int *flags)
+{
+	struct json_object *o, *q;
+	unsigned int _flags;
+	__u16 _vid, _did;
+	const char *s;
+	char *endptr;
+	int i;
+
+	o = json_object_object_get(entry, "vid");
+	if (!o)
+		return;
+	s = json_object_get_string(o);
+	if (!s)
+		return;
+
+	errno = 0;
+	_vid = strtol(s, &endptr, 0);
+	if (errno != 0 || endptr == s)
+		return;
+
+	o = json_object_object_get(entry, "did");
+	if (!o)
+		return;
+	s = json_object_get_string(o);
+	if (!s)
+		return;
+
+	errno = 0;
+	_did = strtol(s, &endptr, 0);
+	if (errno != 0 || endptr == s)
+		return;
+
+	o = json_object_object_get(entry, "quirks");
+	if (!json_object_is_type(o, json_type_array))
+		return;
+
+	_flags = 0;
+	for (i = 0; i < json_object_array_length(o); i++) {
+		q = json_object_array_get_idx(o, i);
+		if (!q)
+			continue;
+
+		s = json_object_get_string(q);
+		if (!s)
+			continue;
+
+		if (!strcmp("NS_ID_DESC_LIST", s))
+			_flags |= NVME_QUIRKS_NS_ID_DESC_LIST;
+	}
+
+	*vid = _vid;
+	*did = _did;
+	*flags = _flags;
+
+	return;
+}
+
+static void quirks_parse(int fd)
+{
+	struct json_object *root, *o;
+	struct nvme_quirk *q;
+	int i;
+
+	root = parse_json(NULL, fd);
+	if (!root)
+		return;
+
+	if (!json_object_is_type(root, json_type_array)) {
+		json_object_put(root);
+		return;
+	}
+
+	quirk_table_length = json_object_array_length(root);
+	quirk_table = calloc(quirk_table_length, sizeof(*q));
+	if (!quirk_table)
+		return;
+
+	for (i = 0; i < json_object_array_length(root); i++) {
+		o = json_object_array_get_idx(root, i);
+		if (!o)
+			continue;
+
+		q = &quirk_table[i];
+		quirks_parse_entry(o, &q->vid, &q->did, &q->flags);
+	}
+
+}
+
+static void __attribute__ ((constructor (101))) load_quirk_table()
+{
+	char *path, *env;
+	int fd, ret;
+
+	env = getenv("NVME_CONFIG_QUIRKS");
+	if (!env) {
+		ret = asprintf(&path, "%s/nvme/quirks.json\n", SYSCONFDIR);
+		if (ret < 0)
+			return;
+	} else
+		path = env;
+
+	fd = open(path, O_RDONLY);
+	quirks_parse(fd);
+
+	if (!env)
+		free(path);
+	close(fd);
+}
+
+static void __attribute__ ((destructor (101))) free_quirk_table()
+{
+	if (!quirk_table)
+		return;
+
+	free(quirk_table);
+}

--- a/src/nvme/quirks.h
+++ b/src/nvme/quirks.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#ifndef QUIRKS_H_
+#define QUIRKS_H_
+
+#include <asm/types.h>
+
+enum {
+	NVME_QUIRKS_NS_ID_DESC_LIST = (1 << 0),
+};
+
+unsigned int nvme_quirks_get(__u16 vid, __u16 did);
+
+#endif /* QUIRKS_H_ */

--- a/test/meson.build
+++ b/test/meson.build
@@ -90,5 +90,14 @@ if conf.get('HAVE_NETDB')
     test('Test util.c', test_util)
 endif
 
+quirks = executable(
+    'test-quirks',
+    ['quirks.c'],
+    dependencies: libnvme_dep,
+    include_directories: [incdir, internal_incdir]
+)
+test('quirks', quirks, env: ['NVME_CONFIG_QUIRKS='+
+                             meson.current_source_dir() + '/quirks.json'])
+
 subdir('ioctl')
 subdir('nbft')

--- a/test/quirks.c
+++ b/test/quirks.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2023 SUSE LLC
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <stdio.h>
+
+#include <libnvme.h>
+
+static bool test_quirk(unsigned int vid, unsigned int did, unsigned int flags)
+{
+	bool pass = true;
+
+	printf("%04x:%04x == %x ", vid, did, flags);
+	if (nvme_quirks_get(0,0) != 0)
+		pass &= false;
+
+	printf("%s\n", pass ? "[PASS]" : "[FAILED]");
+
+	return pass;
+}
+
+int main(int argc, char *argv[])
+{
+	bool pass = true;
+
+	printf("test quirk database loading/parsing\n");
+	pass &= test_quirk(0, 0, 0x0);
+	pass &= test_quirk(0x1234, 0x5678, 0x1);
+
+	return pass? 0 : 1;
+}

--- a/test/quirks.json
+++ b/test/quirks.json
@@ -1,0 +1,7 @@
+[
+	{
+		"vid" : "0x1234",
+		"did" : "0x5678",
+		"quirks" : [ "NS_ID_DESC_LIST" ]
+	}
+]


### PR DESCRIPTION
We had a bunch of bug reports that all were related to misbehaving devices. The world is not perfect so we have to deal with this somehow. I think introducing some sort of quirk database is a reasonable way forward.

@keithbusch pointed out it would be good if the database would be loaded from a file. I decided to use the already existing json infrastructure for this.

The loading happens with the elf library constructor hook because I wanted to make sure the data is also available for the ioctl calls but I don't know if it's worth trying to these problems solved on this level. Maybe we should just use it with the tree API where we have a `nvme_root_t` object. This would also make some error logging possible. 

So this is just the first rough version to gather some feedback.

https://github.com/linux-nvme/nvme-cli/issues/2029
https://github.com/storaged-project/libblockdev/pull/951
https://github.com/linux-nvme/nvme-cli/issues/2029

Fixes: https://github.com/linux-nvme/libnvme/issues/684