### PR TITLE
tree: Add 2 new public functions to lookup existing controllers

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 LIBNVME_1_6 {
 	global:
+		nvme_ctrl_config_match;
+		nvme_ctrl_find;
 		nvme_ctrl_get_src_addr;
 		nvme_ctrl_release_fd;
 		nvme_host_release_fds;

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -834,6 +834,7 @@ static const char *lookup_context(nvme_root_t r, nvme_ctrl_t c)
 					       NULL,
 					       NULL,
 					       nvme_ctrl_get_trsvcid(c),
+					       NULL,
 					       NULL))
 				return nvme_subsystem_get_application(s);
 		}
@@ -863,6 +864,7 @@ int nvmf_add_ctrl(nvme_host_t h, nvme_ctrl_t c,
 					nvme_ctrl_get_host_traddr(c),
 					nvme_ctrl_get_host_iface(c),
 					nvme_ctrl_get_trsvcid(c),
+					NULL,
 					NULL);
 		if (fc) {
 			const char *key;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -180,7 +180,7 @@ int json_dump_tree(nvme_root_t r);
 nvme_ctrl_t __nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 			       const char *traddr, const char *host_traddr,
 			       const char *host_iface, const char *trsvcid,
-			       nvme_ctrl_t p);
+			       const char *subsysnqn, nvme_ctrl_t p);
 
 #if (LOG_FUNCNAME == 1)
 #define __nvme_log_func __func__

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -307,6 +307,51 @@ nvme_ctrl_t nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 			     const char *host_iface, const char *trsvcid,
 			     nvme_ctrl_t p);
 
+/**
+ * nvme_ctrl_find() - Locate an existing controller
+ * @s:			&nvme_subsystem_t object
+ * @transport:		Transport name
+ * @traddr:		Transport address
+ * @trsvcid:		Transport service identifier
+ * @subsysnqn:		Subsystem NQN
+ * @host_traddr:	Host transport address
+ * @host_iface:		Host interface name
+ *
+ * Lookup a controller in @s based on @transport, @traddr, @trsvcid,
+ * @subsysnqn, @host_traddr, and @host_iface. @transport must be specified,
+ * other fields may be required depending on the transport. Parameters set
+ * to NULL will be ignored.
+ *
+ * Unlike nvme_lookup_ctrl(), this function does not create a new object if
+ * an existing controller cannot be found.
+ *
+ * Return: Controller instance on success, NULL otherwise.
+ */
+nvme_ctrl_t nvme_ctrl_find(nvme_subsystem_t s, const char *transport,
+			   const char *traddr, const char *trsvcid,
+			   const char *subsysnqn, const char *host_traddr,
+			   const char *host_iface);
+
+/**
+ * nvme_ctrl_config_match() - Check if ctrl @c matches config params
+ * @c:			An existing controller instance
+ * @transport:		Transport name
+ * @traddr:		Transport address
+ * @trsvcid:		Transport service identifier
+ * @subsysnqn:		Subsystem NQN
+ * @host_traddr:	Host transport address
+ * @host_iface:		Host interface name
+ *
+ * Check that controller @c matches parameters: @transport, @traddr,
+ * @trsvcid, @subsysnqn, @host_traddr, and @host_iface. Parameters set
+ * to NULL will be ignored.
+ *
+ * Return: true if there's a match, false otherwise.
+ */
+bool nvme_ctrl_config_match(struct nvme_ctrl *c, const char *transport,
+			    const char *traddr, const char *trsvcid,
+			    const char *subsysnqn, const char *host_traddr,
+			    const char *host_iface);
 
 /**
  * nvme_create_ctrl() - Allocate an unconnected NVMe controller


### PR DESCRIPTION
There is duplicate code between **libnvme** and **nvme-cli**. When trying to instantiate a controller, both libnvme and nvme-cli scan the sysfs looking for an existing controller that can be reused.

This patch adds `nvme_ctrl_find()` and `nvme_ctrl_config_match()`. These functions can be used by nvme-cli to lookup existing controllers. This will allow removing the duplicate code in nvme-cli (separate commit to follow on the nvme-cli GitHub repo).

Note that some of the existing code had to be reorganized to make it possible for the new functions to reuse that existing code.