### PR TITLE
test: handle POSIX ioctl prototype

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -273,7 +273,9 @@ subdir('internal')
 subdir('ccan')
 subdir('src')
 subdir('libnvme')
-subdir('test')
+if get_option('tests')
+    subdir('test')
+endif
 subdir('examples')
 subdir('doc')
 

--- a/meson.build
+++ b/meson.build
@@ -230,6 +230,16 @@ conf.set(
     ),
     description: 'Is network address and service translation available'
 )
+conf.set(
+    'HAVE_GLIBC_IOCTL',
+    cc.compiles(
+        '''#include <sys/ioctl.h>
+        int ioctl(int fd, unsigned long request, ...);
+        ''',
+        name: 'ioctl has glibc-style prototype'
+    ),
+    description: 'Is ioctl the glibc interface (rather than POSIX)'
+)
 
 if cc.has_function_attribute('fallthrough')
   conf.set('fallthrough', '__attribute__((__fallthrough__))')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('rstdir', type : 'string', value : '', description : 'directory for ReST 
 
 option('docs', type : 'combo', choices : ['false', 'html', 'man', 'rst', 'all'], description : 'install documentation')
 option('docs-build', type : 'boolean', value : false,  description : 'build documentation')
+option('tests', type : 'boolean', value : true, description : 'build tests')
 
 option('python', type : 'feature', value: 'auto', description : 'Generate libnvme python bindings')
 option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL support')

--- a/test/ioctl/mock.c
+++ b/test/ioctl/mock.c
@@ -114,7 +114,11 @@ void end_mock_cmds(void)
 	} \
 })
 
+#ifdef HAVE_GLIBC_IOCTL
 int ioctl(int fd, unsigned long request, ...)
+#else
+int ioctl(int fd, int request, ...)
+#endif
 {
 	struct mock_cmds *mock_cmds;
 	bool result64;
@@ -141,7 +145,7 @@ int ioctl(int fd, unsigned long request, ...)
 		result64 = true;
 		break;
 	default:
-		fail("unexpected %s %lu", __func__, request);
+		fail("unexpected %s %lu", __func__, (unsigned long) request);
 	}
 	check(mock_cmds->remaining_cmds,
 	      "unexpected %s command", mock_cmds->name);


### PR DESCRIPTION
glibc has the following prototype for ioctl: int ioctl(int fd, unsigned long request, ...)
POSIX (inc. musl) has the following for ioctl: int ioctl(int fd, int request, ...)

Check which prototype is used in <sys/ioctl.h> to avoid a conflict and conditionally
define the right one for the system.

Bug: https://bugs.gentoo.org/914921
Signed-off-by: Sam James <sam@gentoo.org>