### PR TITLE
build: remove symbol which doesn't exist in libnvme-mi.so

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -49,7 +49,6 @@ LIBNVME_MI_1_1 {
 		nvme_mi_admin_security_send;
 		nvme_mi_admin_security_recv;
 		nvme_mi_endpoint_desc;
-		nvme_mi_root_close;
 		nvme_mi_first_endpoint;
 		nvme_mi_next_endpoint;
 		nvme_mi_first_ctrl;


### PR DESCRIPTION
Last unused symbol, https://github.com/linux-nvme/libnvme/commit/20a3fa87520af7f615415091fe9da484b0ac3bd2 cleaned up the rest in libnvme.so.

```
clang  -o src/libnvme-mi.so.1.6.0 src/libnvme-mi.so.1.6.0.p/nvme_cleanup.c.o src/libnvme-mi.so.1.6.0.p/nvme_log.c.o src/libnvme-mi.so.1.6.0.p/nvme_mi.c.o src/libnvme-mi.so.1.6.0.p/nvme_mi-mctp.c.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,--start-group -Wl,-soname,libnvme-mi.so.1 -O3 -pipe -march=znver3 -flto=thin -Wl,-O1 -Wl,--as-needed -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 ccan/libccan.a -Wl,--version-script=/var/tmp/portage/sys-libs/libnvme-1.6/work/libnvme-1.6/src/libnvme-mi.map /usr/lib64/libdbus-1.so -Wl,--end-group
ld.lld: error: version script assignment of 'LIBNVME_MI_1_1' to symbol 'nvme_mi_root_close' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

https://github.com/search?q=repo%3Alinux-nvme%2Flibnvme%20nvme_mi_root_close&type=code

Bug: https://bugs.gentoo.org/914635
Signed-off-by: Alfred Wingate <parona@protonmail.com>