### PR TITLE
ioctl: MSB variable-size storage/reference tags

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -1836,33 +1836,35 @@ static int nvme_set_var_size_tags(__u32 *cmd_dw2, __u32 *cmd_dw3, __u32 *cmd_dw1
 		__u8 pif, __u8 sts, __u64 reftag, __u64 storage_tag)
 {
 	__u32 cdw2 = 0, cdw3 = 0, cdw14;
+	beint64_t be_reftag = cpu_to_be64(reftag);
+	beint64_t be_storage_tag = cpu_to_be64(storage_tag);
 
 	switch (pif) {
 	/* 16b Protection Information */
 	case 0:
-		cdw14 = reftag & 0xffffffff;
-		cdw14 |= ((storage_tag << (32 - sts)) & 0xffffffff);
+		cdw14 = be_reftag & 0xffffffff;
+		cdw14 |= ((be_storage_tag << (32 - sts)) & 0xffffffff);
 		break;
 	/* 32b Protection Information */
 	case 1:
-		cdw14 = reftag & 0xffffffff;
-		cdw3 = reftag >> 32;
-		cdw14 |= ((storage_tag << (80 - sts)) & 0xffff0000);
+		cdw14 = be_reftag & 0xffffffff;
+		cdw3 = be_reftag >> 32;
+		cdw14 |= ((be_storage_tag << (80 - sts)) & 0xffff0000);
 		if (sts >= 48)
-			cdw3 |= ((storage_tag >> (sts - 48)) & 0xffffffff);
+			cdw3 |= ((be_storage_tag >> (sts - 48)) & 0xffffffff);
 		else
-			cdw3 |= ((storage_tag << (48 - sts)) & 0xffffffff);
-		cdw2 = (storage_tag >> (sts - 16)) & 0xffff;
+			cdw3 |= ((be_storage_tag << (48 - sts)) & 0xffffffff);
+		cdw2 = (be_storage_tag >> (sts - 16)) & 0xffff;
 		break;
 	/* 64b Protection Information */
 	case 2:
-		cdw14 = reftag & 0xffffffff;
-		cdw3 = (reftag >> 32) & 0xffff;
-		cdw14 |= ((storage_tag << (48 - sts)) & 0xffffffff);
+		cdw14 = be_reftag & 0xffffffff;
+		cdw3 = (be_reftag >> 32) & 0xffff;
+		cdw14 |= ((be_storage_tag << (48 - sts)) & 0xffffffff);
 		if (sts >= 16)
-			cdw3 |= ((storage_tag >> (sts - 16)) & 0xffff);
+			cdw3 |= ((be_storage_tag >> (sts - 16)) & 0xffff);
 		else
-			cdw3 |= ((storage_tag << (16 - sts)) & 0xffff);
+			cdw3 |= ((be_storage_tag << (16 - sts)) & 0xffff);
 		break;
 	default:
 		perror("Unsupported Protection Information Format");


### PR DESCRIPTION
The spec defines these values on a bitwise basis within the shared 80-bit region, stored from MSB to LSB for each tag. Mechanically this can be achieved by setting the values as big-endian using the same logic currently in place.

Reviewed-by: Jeffrey Lien <jeff.lien@wdc.com>

Here's a link to discussion around fixing a similar issue with the copy command: https://github.com/linux-nvme/libnvme/pull/587