### PR TITLE
tree: Allocate aligned payloads for namespace scan

### DIFF
--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -182,6 +182,8 @@ nvme_ctrl_t __nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 			       const char *host_iface, const char *trsvcid,
 			       const char *subsysnqn, nvme_ctrl_t p);
 
+void *__nvme_alloc(size_t len);
+
 #if (LOG_FUNCNAME == 1)
 #define __nvme_log_func __func__
 #else

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -7,6 +7,7 @@
  * 	    Chaitanya Kulkarni <chaitanya.kulkarni@wdc.com>
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>
@@ -1058,3 +1059,15 @@ bool nvme_iface_primary_addr_matches(const struct ifaddrs *iface_list, const cha
 }
 
 #endif /* HAVE_NETDB */
+
+void *__nvme_alloc(size_t len)
+{
+	size_t _len = round_up(len, 0x1000);
+	void *p;
+
+	if (posix_memalign((void *)&p, getpagesize(), _len))
+		return NULL;
+
+	memset(p, 0, _len);
+	return p;
+}


### PR DESCRIPTION
Related to https://github.com/linux-nvme/nvme-cli/pull/2051, there are a couple more ioctls made during the tree scan inside of libnvme. Last bits to fix the whole story, hopefully.

Noticed by https://bugs.archlinux.org/task/79760#comment222718