### PR TITLE
build: upload artifacts only for upstream repo

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   code-coverage:
+    if: github.repository == 'linux-nvme/libnvme'
     name: code coverage
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -51,7 +51,7 @@ jobs:
   upload_pypi:
     needs: [build_sdist]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linux-nvme/libnvme'
     steps:
       - name: Check if it is a release tag
         id: check-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linux-nvme/libnvme'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Only upload any artifacts to linux-nvme organization if it's NOT a fork.