### PR TITLE
make: add checkpatch to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,19 @@ rpm: ${BUILD-DIR}
 	tar rf libnvme.tar ${BUILD-DIR}/libnvme.spec
 	gzip -f -9 libnvme.tar
 	rpmbuild -ta libnvme.tar.gz -v
+
+# Retrieve and Invoke Linux kernel's checkpatch script on modified source files
+ifeq (checkpatch,$(strip $(filter $(MAKECMDGOALS),checkpatch)))
+  MODIFIED-FILES := $(strip $(shell ./scripts/get-modified-src-files.py))
+endif
+
+${BUILD-DIR}/checkpatch.pl: ${BUILD-DIR}
+	wget "https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl" -O $@
+	chmod +x $@
+
+.PHONY: checkpatch
+checkpatch: ${BUILD-DIR}/checkpatch.pl
+ifneq (,${MODIFIED-FILES})
+	${BUILD-DIR}/checkpatch.pl -no-tree ${MODIFIED-FILES}
+endif
+

--- a/scripts/get-modified-src-files.py
+++ b/scripts/get-modified-src-files.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is part of libnvme.
+# Copyright (c) 2023 Dell Inc.
+#
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+
+"""List source files in current git repo that have been modified or are new (untracked)"""
+
+import shutil
+import subprocess
+
+GIT = shutil.which("git")
+SRC_FILES = (".c", ".h", ".cpp", ".cc")
+
+cmd = f"{GIT} ls-files --modified --others --exclude-standard"
+p = subprocess.run(
+    cmd, stdout=subprocess.PIPE, check=True, universal_newlines=True, shell=True
+)
+
+modified_files = p.stdout.splitlines()
+modified_src_files = [fname for fname in modified_files if fname.endswith(SRC_FILES)]
+
+print(" ".join(modified_src_files))


### PR DESCRIPTION
@igaw - Hi Daniel. I noticed that you are asking people to run the `checkpatch.pl` script to make sure the code follows the same coding style as the kernel. To make it easier for developers to check their code, I added a new command to the `Makefile` (i.e. `make checkpatch`). Hopefully you will find this useful. Otherwise, please ignore.

This automatically retrieves the `checkpatch.pl` script from the Linux kernel repo and runs it to check the modified or untracked source files in the current repo.

The command can be invoked with:
```
$ make checkpatch
```