### PR TITLE
Make ASAN work with tests mocking libc functions and fix several errors caught by UBSAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,5 @@ Note that when using the sanitize feature, the library `libasan.so` must be avai
 ```
 meson setup .build -Db_sanitize=address && LD_PRELOAD=/lib64/libasan.so.6 ninja -C .build test
 ```
+
+It's also possible to enable the undefined behavior sanitizer with `-Db_sanitize=undefined`. To enable both, use `-Db_sanitize=address,undefined`.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ To enable address sanitizer (advanced debugging of memory issues):
 meson setup .build -Db_sanitize=address
 ```
 
-This option adds `-fsanitize=address` to the gcc options. Note that when using the sanitize feature, the library `libasan.so` must be available and must be the very first library loaded when running an executable. Ensuring that `libasan.so` gets loaded first can be achieved with the `LD_PRELOAD` environment variable as follows: 
+This option adds `-fsanitize=address` to the gcc options. The tests can then be run normally (`meson test -C .build`).
+
+Note that when using the sanitize feature, the library `libasan.so` must be available and must be the very first library loaded when running an executable. If experiencing linking issues, you can ensure that `libasan.so` gets loaded first with the `LD_PRELOAD` environment variable as follows:
 
 ```
 meson setup .build -Db_sanitize=address && LD_PRELOAD=/lib64/libasan.so.6 ninja -C .build test

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -1048,7 +1048,7 @@ int nvme_mi_admin_set_features(nvme_mi_ctrl_t ctrl,
 			       nvme_admin_set_features);
 
 	req_hdr.cdw1 = cpu_to_le32(args->nsid);
-	req_hdr.cdw10 = cpu_to_le32((args->save ? 1 : 0) << 31 |
+	req_hdr.cdw10 = cpu_to_le32((__u32)!!args->save << 31 |
 				    (args->fid & 0xff));
 	req_hdr.cdw14 = cpu_to_le32(args->uuidx & 0x7f);
 	req_hdr.cdw11 = cpu_to_le32(args->cdw11);
@@ -1220,7 +1220,7 @@ int nvme_mi_admin_fw_commit(nvme_mi_ctrl_t ctrl,
 	nvme_mi_admin_init_req(&req, &req_hdr, ctrl->id,
 			       nvme_admin_fw_commit);
 
-	req_hdr.cdw10 = cpu_to_le32(((args->bpid & 0x1) << 31) |
+	req_hdr.cdw10 = cpu_to_le32(((__u32)(args->bpid & 0x1) << 31) |
 				    ((args->action & 0x7) << 3) |
 				    ((args->slot & 0x7) << 0));
 

--- a/src/nvme/nbft.c
+++ b/src/nvme/nbft.c
@@ -33,17 +33,15 @@ static __u8 csum(const __u8 *buffer, ssize_t length)
 
 static void format_ip_addr(char *buf, size_t buflen, __u8 *addr)
 {
-	struct in6_addr *addr_ipv6;
+	struct in6_addr addr_ipv6;
 
-	addr_ipv6 = (struct in6_addr *)addr;
-	if (addr_ipv6->s6_addr32[0] == 0 &&
-	    addr_ipv6->s6_addr32[1] == 0 &&
-	    ntohl(addr_ipv6->s6_addr32[2]) == 0xffff)
+	memcpy(&addr_ipv6, addr, sizeof(addr_ipv6));
+	if (IN6_IS_ADDR_V4MAPPED(&addr_ipv6))
 		/* ipv4 */
-		inet_ntop(AF_INET, &(addr_ipv6->s6_addr32[3]), buf, buflen);
+		inet_ntop(AF_INET, &addr_ipv6.s6_addr32[3], buf, buflen);
 	else
 		/* ipv6 */
-		inet_ntop(AF_INET6, addr_ipv6, buf, buflen);
+		inet_ntop(AF_INET6, &addr_ipv6, buf, buflen);
 }
 
 static bool in_heap(struct nbft_header *header, struct nbft_heap_obj obj)

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -43,7 +43,7 @@
  * Returns: The 'name' field from 'value'
  */
 #define NVME_SET(value, name) \
-	(((value) & NVME_##name##_MASK) << NVME_##name##_SHIFT)
+	(((__u32)(value) & NVME_##name##_MASK) << NVME_##name##_SHIFT)
 
 /**
  * enum nvme_constants - A place to stash various constant nvme values

--- a/test/ioctl/features.c
+++ b/test/ioctl/features.c
@@ -46,7 +46,7 @@ static void test_set_features(void)
 		.nsid = TEST_NSID,
 		.in_data = data,
 		.data_len = sizeof(data),
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | TEST_FID,
 		.cdw11 = TEST_CDW11,
 		.cdw12 = TEST_CDW12,
@@ -163,7 +163,7 @@ static void test_set_features_simple(void)
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
 		.nsid = TEST_NSID,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | TEST_FID,
 		.cdw11 = TEST_CDW11,
 		.result = TEST_RESULT,
@@ -205,7 +205,7 @@ static void test_set_arbitration(void)
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
 		.cdw10 = NVME_FEAT_FID_ARBITRATION,
-		.cdw11 = HPW << 24 | MPW << 16 | LPW << 8 | AB,
+		.cdw11 = (uint32_t)HPW << 24 | MPW << 16 | LPW << 8 | AB,
 		.result = TEST_RESULT,
 	};
 	uint32_t result = 0;
@@ -243,7 +243,7 @@ static void test_set_power_mgmt(void)
 	uint8_t PS = 0b10101, WH = 0b101;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_POWER_MGMT,
 		.cdw11 = WH << 5 | PS,
 		.result = TEST_RESULT,
@@ -337,7 +337,7 @@ static void test_set_temp_thresh(void)
 		NVME_FEATURE_TEMPTHRESH_THSEL_UNDER;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_TEMP_THRESH,
 		.cdw11 = THSEL << 20 | TMPSEL << 16 | TMPTH,
 		.result = TEST_RESULT,
@@ -424,7 +424,7 @@ static void test_set_volatile_wc(void)
 {
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_VOLATILE_WC,
 		.cdw11 = 1 << 0, /* WCE */
 		.result = TEST_RESULT,
@@ -521,7 +521,7 @@ static void test_set_irq_config(void)
 	uint16_t IV = 0x1234;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_IRQ_CONFIG,
 		.cdw11 = 1 << 16 /* CD */
 		       | IV,
@@ -600,7 +600,7 @@ static void test_set_async_event(void)
 	uint32_t EVENTS = 0x87654321;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_ASYNC_EVENT,
 		.cdw11 = EVENTS,
 		.result = TEST_RESULT,
@@ -717,7 +717,7 @@ static void test_set_timestamp(void)
 		.opcode = nvme_admin_set_features,
 		.in_data = &ts,
 		.data_len = sizeof(ts),
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_TIMESTAMP,
 	};
 	int err;
@@ -771,7 +771,7 @@ static void test_set_hctm(void)
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
 		.cdw10 = NVME_FEAT_FID_HCTM,
-		.cdw11 = TMT1 << 16 | TMT2,
+		.cdw11 = (uint32_t)TMT1 << 16 | TMT2,
 		.result = TEST_RESULT,
 	};
 	uint32_t result = 0;
@@ -807,7 +807,7 @@ static void test_set_nopsc(void)
 {
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_NOPSC,
 		.cdw11 = 1 << 0 /* NOPPME */,
 		.result = TEST_RESULT,
@@ -890,7 +890,7 @@ static void test_set_plm_config(void)
 		.opcode = nvme_admin_set_features,
 		.in_data = &config,
 		.data_len = sizeof(config),
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_PLM_CONFIG,
 		.cdw11 = NVMSETID,
 		.cdw12 = 1 << 0 /* Predictable Latency Enable */,
@@ -984,7 +984,7 @@ static void test_set_lba_sts_interval(void)
 	uint16_t LSIRI = 0x1234, LSIPI = 0x5678;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_LBA_STS_INTERVAL,
 		.cdw11 = LSIPI << 16 | LSIRI,
 		.result = TEST_RESULT,
@@ -1105,7 +1105,7 @@ static void test_set_endurance_evt_cfg(void)
 	uint8_t EGWARN = 0xCD;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_ENDURANCE_EVT_CFG,
 		.cdw11 = EGWARN << 16 | ENDGID,
 		.result = TEST_RESULT,
@@ -1182,7 +1182,7 @@ static void test_set_sw_progress(void)
 	uint8_t PBSLC = 0xBA;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_SW_PROGRESS,
 		.cdw11 = PBSLC,
 		.result = TEST_RESULT,
@@ -1223,7 +1223,7 @@ static void test_set_host_id(void)
 		.opcode = nvme_admin_set_features,
 		.in_data = hostid,
 		.data_len = sizeof(hostid),
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_HOST_ID,
 		.result = TEST_RESULT,
 	};
@@ -1305,7 +1305,7 @@ static void test_set_resv_mask(void)
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
 		.nsid = TEST_NSID,
-		.cdw10 = 1 << 31 /* SAVE */
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
 		       | NVME_FEAT_FID_RESV_MASK,
 		.cdw11 = MASK,
 		.result = TEST_RESULT,

--- a/test/ioctl/meson.build
+++ b/test/ioctl/meson.build
@@ -3,6 +3,16 @@ mock_ioctl = library(
     ['mock.c', 'util.c'],
 )
 
+# Add mock-ioctl to the LD_PRELOAD path so it overrides libc.
+# Append to LD_PRELOAD so existing libraries, e.g. libasan, are kept.
+# If libasan isn't specified in the LD_PRELOAD path, ASAN warns about mock-ioctl
+# being loaded first because its memory allocations might not get intercepted.
+# But it appears this isn't a problem; ASAN errors in mock-ioctl are reported.
+# This is likely because the executable still links with libasan before libc.
+mock_ioctl_env = environment()
+mock_ioctl_env.append('LD_PRELOAD', mock_ioctl.full_path())
+mock_ioctl_env.set('ASAN_OPTIONS', 'verify_asan_link_order=0')
+
 discovery = executable(
     'test-discovery',
     'discovery.c',
@@ -11,7 +21,7 @@ discovery = executable(
     link_with: mock_ioctl,
 )
 
-test('discovery', discovery, env: ['LD_PRELOAD=' + mock_ioctl.full_path()])
+test('discovery', discovery, env: mock_ioctl_env)
 
 features = executable(
     'test-features',
@@ -20,7 +30,7 @@ features = executable(
     link_with: mock_ioctl,
 )
 
-test('features', features, env: ['LD_PRELOAD=' + mock_ioctl.full_path()])
+test('features', features, env: mock_ioctl_env)
 
 identify = executable(
     'test-identify',
@@ -29,4 +39,4 @@ identify = executable(
     link_with: mock_ioctl,
 )
 
-test('identify', identify, env: ['LD_PRELOAD=' + mock_ioctl.full_path()])
+test('identify', identify, env: mock_ioctl_env)

--- a/test/ioctl/mock.c
+++ b/test/ioctl/mock.c
@@ -75,10 +75,12 @@ void end_mock_cmds(void)
 	check((cmd)->metadata_len == (mock_cmd)->metadata_len, \
 	      "got metadata_len %" PRIu32 ", expected %" PRIu32, \
 	      (cmd)->metadata_len, (mock_cmd)->metadata_len); \
-	cmp((void const *)(uintptr_t)(cmd)->metadata, \
-	    (mock_cmd)->metadata, \
-	    (cmd)->metadata_len, \
-	    "incorrect metadata"); \
+	if ((cmd)->metadata_len) { \
+		cmp((void const *)(uintptr_t)(cmd)->metadata, \
+		    (mock_cmd)->metadata, \
+		    (cmd)->metadata_len, \
+		    "incorrect metadata"); \
+	} \
 	__u32 data_len = (cmd)->data_len; \
 	check(data_len == (mock_cmd)->data_len, \
 	      "got data_len %" PRIu32 ", expected %" PRIu32, \

--- a/test/meson.build
+++ b/test/meson.build
@@ -72,6 +72,11 @@ if conf.get('HAVE_NETDB')
         ['mock-ifaddrs.c', ],
     )
 
+    # See comment in test/ioctl/meson.build explaining how LD_PRELOAD is used
+    mock_ifaddrs_env = environment()
+    mock_ifaddrs_env.append('LD_PRELOAD', mock_ifaddrs.full_path())
+    mock_ifaddrs_env.set('ASAN_OPTIONS', 'verify_asan_link_order=0')
+
     tree = executable(
         'tree',
         ['tree.c'],
@@ -80,7 +85,7 @@ if conf.get('HAVE_NETDB')
         link_with: mock_ifaddrs,
     )
 
-    test('tree', tree, env: ['LD_PRELOAD=' + mock_ifaddrs.full_path()])
+    test('tree', tree, env: mock_ifaddrs_env)
 
     test_util = executable(
         'test-util',

--- a/test/mi-mctp.c
+++ b/test/mi-mctp.c
@@ -83,12 +83,14 @@ static void test_set_tx_mic(struct test_peer *peer)
 {
 	extern __u32 nvme_mi_crc32_update(__u32 crc, void *data, size_t len);
 	__u32 crc = 0xffffffff;
+	__le32 crc_le;
 
-	assert(peer->tx_buf_len + sizeof(crc) <= MAX_BUFSIZ);
+	assert(peer->tx_buf_len + sizeof(crc_le) <= MAX_BUFSIZ);
 
 	crc = nvme_mi_crc32_update(crc, peer->tx_buf, peer->tx_buf_len);
-	*(uint32_t *)(peer->tx_buf + peer->tx_buf_len) = cpu_to_le32(~crc);
-	peer->tx_buf_len += sizeof(crc);
+	crc_le = cpu_to_le32(~crc);
+	memcpy(peer->tx_buf + peer->tx_buf_len, &crc_le, sizeof(crc_le));
+	peer->tx_buf_len += sizeof(crc_le);
 }
 
 int __wrap_socket(int family, int type, int protocol)

--- a/test/mi.c
+++ b/test/mi.c
@@ -44,7 +44,8 @@ static int test_transport_submit(struct nvme_mi_ep *ep,
 
 	/* start from a minimal response: zeroed data, nmp to match request */
 	memset(resp->hdr, 0, resp->hdr_len);
-	memset(resp->data, 0, resp->data_len);
+	if (resp->data_len)
+		memset(resp->data, 0, resp->data_len);
 	resp->hdr->type = NVME_MI_MSGTYPE_NVME;
 	resp->hdr->nmp = req->hdr->nmp | (NVME_MI_ROR_RSP << 7);
 

--- a/test/mi.c
+++ b/test/mi.c
@@ -1647,7 +1647,10 @@ static int test_admin_format_nvm_cb(struct nvme_mi_ep *ep,
 
 	assert(rq_hdr[4] == nvme_admin_format_nvm);
 
-	nsid = rq_hdr[11] << 24 | rq_hdr[10] << 16 | rq_hdr[9] << 8 | rq_hdr[8];
+	nsid = (__u32)rq_hdr[11] << 24
+	     | rq_hdr[10] << 16
+	     | rq_hdr[9] << 8
+	     | rq_hdr[8];
 	assert(nsid == args->nsid);
 
 	assert(((rq_hdr[44] >> 0) & 0xf) == args->lbaf);
@@ -1722,7 +1725,7 @@ static int test_admin_sanitize_nvm_cb(struct nvme_mi_ep *ep,
 	assert(((rq_hdr[45] >> 0) & 0x1) == args->oipbp);
 	assert(((rq_hdr[45] >> 1) & 0x1) == args->nodas);
 
-	ovrpat = rq_hdr[51] << 24 | rq_hdr[50] << 16 |
+	ovrpat = (__u32)rq_hdr[51] << 24 | rq_hdr[50] << 16 |
 		rq_hdr[49] << 8 | rq_hdr[48];
 	assert(ovrpat == args->ovrpat);
 


### PR DESCRIPTION
Testing out ASAN revealed that the new tests using `LD_PRELOAD` with a shared library containing mocks for libc functions cause ASAN to abort at startup. Suppress this check because ASAN seems to have no problems catching memory issues in `libnvme`, the tests, or the mocks.
Also fix several issues caught by enabling UBSAN in the unit tests:
- Passing NULL pointers to `memcmp()` and `memset()`
- Dereferencing unaligned pointers
- Overflow from bit shifts on `int` values that should be `u32`s