### PR TITLE
types: add Host Behavior Support field definitions

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4743,13 +4743,17 @@ struct nvme_plm_config {
 /**
  * struct nvme_feat_host_behavior - Host Behavior Support - Data Structure
  * @acre:	Advanced Command Retry Enable
- * @rsvd1:	Reserved
+ * @etdas:	Extended Telemetry Data Area 4 Supported
+ * @lbafee:	LBA Format Extension Enable
+ * @rsvd3:	Reserved
  * @cdfe:       Copy Descriptor Formats Enable
  * @rsvd6:	Reserved
  */
 struct nvme_feat_host_behavior {
 	__u8 acre;
-        __u8 rsvd1[3];
+	__u8 etdas;
+	__u8 lbafee;
+	__u8 rsvd3;
         __u16 cdfe;
 	__u8 rsvd6[506];
 };


### PR DESCRIPTION
Bytes 1 and 2 are now defined as fields ETDAS and LBAFEE, so update the `struct nvme_feat_host_behavior` definition.