### PR TITLE
CI, Build: Fix GitHub "build" workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: "install/update dependencies"
+        run: |
+          apt update
+          apt-get install --yes --quiet python3-pip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade meson ninja
       - name: build
         run: |
           scripts/build.sh -b ${{ matrix.buildtype }} -c ${{ matrix.compiler }}
@@ -74,6 +80,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: "install/update dependencies"
+        run: |
+          apt update
+          apt-get install --yes --quiet python3-pip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade meson ninja
       - name: build
         run: |
           scripts/build.sh -b release -c gcc libdbus
@@ -96,6 +108,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: "install/update dependencies"
+        run: |
+          apt update
+          apt-get install --yes --quiet python3-pip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade meson ninja
       - name: build
         run: |
           scripts/build.sh -b release -c gcc fallback


### PR DESCRIPTION
GitHub Workflows are now being run with Python 3.12. The Python package "`distutils`" has been deprecated in Python 3.12. This means that older versions of `meson`, which rely on `distutils`, will fail when run with Python 3.12. This patch fixes the GitHub workflow by updating to the latest version of `meson`.