### PR TITLE
build: do not setup python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,6 @@ jobs:
       image: ghcr.io/igaw/linux-nvme/debian:latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
       - name: build
         run: |
           scripts/build.sh -b ${{ matrix.buildtype }} -c ${{ matrix.compiler }}
@@ -71,9 +68,6 @@ jobs:
       image: ghcr.io/igaw/linux-nvme/debian:latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
       - name: build
         run: |
           scripts/build.sh -b release -c gcc libdbus
@@ -93,9 +87,6 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
       - name: build
         run: |
           scripts/build.sh -b release -c gcc fallback


### PR DESCRIPTION
The build container already ships the Python toolchain, so there is no need to map the toolchain from the base container.