### PR TITLE
build: add CFLAGS back when building with muon

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -170,7 +170,8 @@ tools_build_muon() {
 }
 
 config_muon_default() {
-    CC="${CC}" ninja="${SAMU}" "${MUON}" setup          \
+    CC="${CC}" CFLAGS="${CFLAGS}" ninja="${SAMU}"       \
+        "${MUON}" setup                                 \
         -Ddefault_library=static                        \
         -Dc_link_args="-static"                         \
         -Djson-c=disabled                               \


### PR DESCRIPTION
Previous commit dropped the CLFAGS from the muon
configuration step. Add it back.