### PR TITLE
Implement version 1 TLS identities as specified in TP8018

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -3,6 +3,7 @@ LIBNVME_1_7 {
 	global:
 		nvme_init_copy_range_f2;
 		nvme_init_copy_range_f3;
+		nvme_insert_tls_key_versioned;
 };
 
 LIBNVME_1_6 {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -4,6 +4,7 @@ LIBNVME_1_7 {
 		nvme_init_copy_range_f2;
 		nvme_init_copy_range_f3;
 		nvme_insert_tls_key_versioned;
+		nvme_generate_tls_key_identity;
 };
 
 LIBNVME_1_6 {

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ sources = [
     'nvme/log.c',
     'nvme/tree.c',
     'nvme/util.c',
+    'nvme/base64.c'
 ]
 
 mi_sources = [

--- a/src/nvme/base64.c
+++ b/src/nvme/base64.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * base64.c - RFC4648-compliant base64 encoding
+ *
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * Author: Hannes Reinecke <hare@suse.de>
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+
+static const char base64_table[65] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * base64_encode() - base64-encode some bytes
+ * @src: the bytes to encode
+ * @srclen: number of bytes to encode
+ * @dst: (output) the base64-encoded string.  Not NUL-terminated.
+ *
+ * Encodes the input string using characters from the set [A-Za-z0-9+,].
+ * The encoded string is roughly 4/3 times the size of the input string.
+ *
+ * Return: length of the encoded string
+ */
+int base64_encode(const unsigned char *src, int srclen, char *dst)
+{
+	int i, bits = 0;
+	u_int32_t ac = 0;
+	char *cp = dst;
+
+	for (i = 0; i < srclen; i++) {
+		ac = (ac << 8) | src[i];
+		bits += 8;
+		do {
+			bits -= 6;
+			*cp++ = base64_table[(ac >> bits) & 0x3f];
+		} while (bits >= 6);
+	}
+	if (bits) {
+		*cp++ = base64_table[(ac << (6 - bits)) & 0x3f];
+		bits -= 6;
+	}
+	while (bits < 0) {
+		*cp++ = '=';
+		bits += 2;
+	}
+
+	return cp - dst;
+}
+
+/**
+ * base64_decode() - base64-decode some bytes
+ * @src: the base64-encoded string to decode
+ * @len: number of bytes to decode
+ * @dst: (output) the decoded bytes.
+ *
+ * Decodes the base64-encoded bytes @src according to RFC 4648.
+ *
+ * Return: number of decoded bytes
+ */
+int base64_decode(const char *src, int srclen, unsigned char *dst)
+{
+	u_int32_t ac = 0;
+	int i, bits = 0;
+	unsigned char *bp = dst;
+
+	for (i = 0; i < srclen; i++) {
+		const char *p = strchr(base64_table, src[i]);
+
+		if (src[i] == '=') {
+			ac = (ac << 6);
+			bits += 6;
+			if (bits >= 8)
+				bits -= 8;
+			continue;
+		}
+		if (!p || !src[i])
+			return -EINVAL;
+		ac = (ac << 6) | (p - base64_table);
+		bits += 6;
+		if (bits >= 8) {
+			bits -= 8;
+			*bp++ = (unsigned char)(ac >> bits);
+		}
+	}
+	if (ac && ((1 << bits) - 1))
+		return -EAGAIN;
+
+	return bp - dst;
+}

--- a/src/nvme/base64.h
+++ b/src/nvme/base64.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef _BASE64_H
+#define _BASE64_H
+
+int base64_encode(const unsigned char *src, int len, char *dst);
+int base64_decode(const char *src, int len, unsigned char *dst);
+
+#endif /* _BASE64_H */

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -316,4 +316,23 @@ long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
 				   int version, int hmac,
 				   unsigned char *configured_key, int key_len);
 
+/**
+ * nvme_generate_tls_key_identity() - Generate the TLS key identity
+ * @hostnqn:	Host NVMe Qualified Name
+ * @subsysnqn:	Subsystem NVMe Qualified Name
+ * @version:	Key version to use
+ * @hmac:	HMAC algorithm
+ * @configured_key:	Configured key data to derive the key from
+ * @key_len:	Length of @configured_key
+ *
+ * Derives a 'retained' TLS key as specified in NVMe TCP and
+ * generate the corresponding TLs identity.
+ *
+ * Return: The string containing the TLS identity. It is the responsibility
+ * of the caller to free the returned string.
+ */
+char *nvme_generate_tls_key_identity(const char *hostnqn, const char *subsysnqn,
+				     int version, int hmac,
+				     unsigned char *configured_key, int key_len);
+
 #endif /* _LIBNVME_LINUX_H */

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -293,4 +293,27 @@ long nvme_insert_tls_key(const char *keyring, const char *key_type,
 			 const char *hostnqn, const char *subsysnqn, int hmac,
 			 unsigned char *configured_key, int key_len);
 
+/**
+ * nvme_insert_tls_key_versioned() - Derive and insert TLS key
+ * @keyring:    Keyring to use
+ * @key_type:	Type of the resulting key
+ * @hostnqn:	Host NVMe Qualified Name
+ * @subsysnqn:	Subsystem NVMe Qualified Name
+ * @version:	Key version to use
+ * @hmac:	HMAC algorithm
+ * @configured_key:	Configured key data to derive the key from
+ * @key_len:	Length of @configured_key
+ *
+ * Derives a 'retained' TLS key as specified in NVMe TCP 1.0a (if
+ * @version s set to '0') or NVMe TP8028 (if @version is set to '1) and
+ * stores it as type @key_type in the keyring specified by @keyring.
+ *
+ * Return: The key serial number if the key could be inserted into
+ * the keyring or 0 with errno otherwise.
+ */
+long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
+				   const char *hostnqn, const char *subsysnqn,
+				   int version, int hmac,
+				   unsigned char *configured_key, int key_len);
+
 #endif /* _LIBNVME_LINUX_H */


### PR DESCRIPTION
TP8018 specified a new version 1 for TLS identifiers, where the original (version 0) identifiers are suffixed with a PSK hash.
That allows for key rotation as the new identifiers will change whenever the key changes, thus allowing the client to request the correct key after a key rotation.