### PR TITLE
types: fix regression for vendor-specific field in nvme_id_ns

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -1799,7 +1799,6 @@ enum nvme_lbaf_rp {
  *	      remains fixed throughout the life of the namespace and is
  *	      preserved across namespace and controller operations
  * @lbaf:     LBA Format, see &struct nvme_lbaf.
- * @lbstm:    Logical Block Storage Tag Mask for end-to-end protection
  * @vs:	      Vendor Specific
  */
 struct nvme_id_ns {
@@ -1843,8 +1842,7 @@ struct nvme_id_ns {
 	__u8			nguid[16];
 	__u8			eui64[8];
 	struct nvme_lbaf	lbaf[64];
-	__le64			lbstm;
-	__u8			vs[3704];
+	__u8			vs[3712];
 };
 
 /**


### PR DESCRIPTION
Recent versions of nvme-cli have started reading vs from offset 392 instead of 384. Previous PRs coupled the use of nvme_id_ns for use in namespace management (create_ns).  However, the NVMe spec has a different structure for namespace management, with only a subset of the fields allowed/shared and some additional fields.

To fix this, remove lbstm and restore the proper length for vs from nvme_id_ns.

I expect that create_ns() should fully switch over to the nvme_ns_mgmt_host_sw_specified struct which seems aligned with the spec (though has some newer fields than what is available in the latest NVMe Command Set Specification Revision 1.0c). This will have to be addressed separately in nvme-cli.

https://github.com/linux-nvme/libnvme/pull/307
https://github.com/linux-nvme/nvme-cli/pull/1452