### PR TITLE
Get LBA Status does not specify data_len; returning no data

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -1568,6 +1568,7 @@ int nvme_get_lba_status(struct nvme_get_lba_status_args *args)
 		.opcode =  nvme_admin_get_lba_status,
 		.nsid = args->nsid,
 		.addr = (__u64)(uintptr_t)args->lbas,
+		.data_len = (args->mndw + 1) << 2,
 		.cdw10 = cdw10,
 		.cdw11 = cdw11,
 		.cdw12 = cdw12,


### PR DESCRIPTION
Current `nvme_get_lba_status()` function does specify any `data_len` in the admin command, resulting in zero data being returned. Of the possible implementations described in #753 , this is the least intrusive change as it requires no update to nvme-cli.

If an alternative approach is preferred, please comment.

Closes #753 