### PR TITLE
build: construct path to config.h manually

### DIFF
--- a/internal/meson.build
+++ b/internal/meson.build
@@ -20,9 +20,11 @@ config_dep = declare_dependency(
   include_directories : internal_incdir,
   sources: config_h)
 
+config_h_path = meson.current_build_dir() / 'config.h'
+
 add_project_arguments(
     [
-        '-include', '@0@'.format(config_h),
+        '-include', config_h_path,
     ],
     language : 'c',
 )


### PR DESCRIPTION
meson reports:

  internal/meson.build:25: DEPRECATION: Project uses feature that was
  always broken, and is now deprecated since '1.3.0': str.format: Value
  other than strings, integers, bools, options, dictionaries and lists
  thereof.

Thus just hardcode the config file path