### PR TITLE
Fix memory corruption in tree.c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         compiler: [gcc, clang]
         buildtype: [debug, release]
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:latest
+      image: ghcr.io/igaw/linux-nvme/debian.python:latest
     steps:
       - uses: actions/checkout@v4
       - name: build

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -67,16 +67,16 @@ if build_python_bindings
     test_env.append('PYTHONMALLOC', 'malloc')
 
     # Test section
-    test('[Python] import libnvme', python3, args: ['-c', 'from libnvme import nvme'], env: test_env, depends: pynvme_clib)
+    test('python-import-libnvme', python3, args: ['-c', 'from libnvme import nvme'], env: test_env, depends: pynvme_clib)
 
     py_tests = [ 
-        [ 'create ctrl object', [ files('tests/create-ctrl-obj.py'), ] ],
-        [ 'SIGSEGV during gc', [ files('tests/gc.py'), ] ],
-        [ 'Read NBFT file', [ files('tests/test-nbft.py'), '--filename', join_paths(meson.current_source_dir(), 'tests', 'NBFT') ] ],
+        [ 'create-ctrl-object', [ files('tests/create-ctrl-obj.py'), ] ],
+        [ 'sigsegv-during-gc', [ files('tests/gc.py'), ] ],
+        [ 'read-nbft-file', [ files('tests/test-nbft.py'), '--filename', join_paths(meson.current_source_dir(), 'tests', 'NBFT') ] ],
     ]
     foreach test: py_tests
         description = test[0]
         args = test[1]
-        test('[Python] ' + description, python3, args: args, env: test_env, depends: pynvme_clib)
+        test('python-' + description, python3, args: args, env: test_env, depends: pynvme_clib)
     endforeach
 endif

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2473,7 +2473,7 @@ static int nvme_ns_init(const char *path, struct nvme_ns *ns)
 
 		ret = nvme_ns_identify(ns, id);
 		if (ret)
-			free(ns);
+			return ret;
 
 		nvme_id_ns_flbas_to_lbaf_inuse(id->flbas, &flbas);
 		ns->lba_count = le64_to_cpu(id->nsze);

--- a/test/meson.build
+++ b/test/meson.build
@@ -92,7 +92,7 @@ if conf.get('HAVE_NETDB')
         ['test-util.c'],
         include_directories: [incdir, internal_incdir]
     )
-    test('Test util.c', test_util)
+    test('util', test_util)
 endif
 
 subdir('ioctl')


### PR DESCRIPTION
- enable python build again
- fix memory corruption

Fixes: #762 