### PR TITLE
cleanup: Explicitly initialize auto-cleanup variables

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -740,7 +740,7 @@ static  int __nvmf_supported_options(nvme_root_t r)
 
 static int __nvmf_add_ctrl(nvme_root_t r, const char *argstr)
 {
-	_cleanup_fd_ int fd;
+	_cleanup_fd_ int fd = -1;
 	int ret, len = strlen(argstr);
 	char buf[0x1000], *options, *p;
 
@@ -1186,7 +1186,7 @@ struct nvmf_discovery_log *nvmf_get_discovery_wargs(struct nvme_get_discovery_ar
 static int uuid_from_device_tree(char *system_uuid)
 {
 	ssize_t len;
-	_cleanup_fd_ int f;
+	_cleanup_fd_ int f = -1;
 
 	f = open(PATH_UUID_IBM, O_RDONLY);
 	if (f < 0)
@@ -1230,7 +1230,7 @@ static bool is_dmi_uuid_valid(const char *buf, size_t len)
 static int uuid_from_dmi_entries(char *system_uuid)
 {
 	int f;
-	_cleanup_dir_ DIR *d;
+	_cleanup_dir_ DIR *d = NULL;
 	struct dirent *de;
 	char buf[512] = {0};
 
@@ -1294,7 +1294,7 @@ static int uuid_from_dmi_entries(char *system_uuid)
  */
 static int uuid_from_product_uuid(char *system_uuid)
 {
-	_cleanup_file_ FILE *stream;
+	_cleanup_file_ FILE *stream = NULL;
 	ssize_t nread;
 	_cleanup_free_ char *line = NULL;
 	size_t len = 0;
@@ -1364,7 +1364,7 @@ char *nvmf_hostnqn_generate()
 static char *nvmf_read_file(const char *f, int len)
 {
 	char buf[len];
-	_cleanup_fd_ int fd;
+	_cleanup_fd_ int fd = -1;
 	int ret;
 
 	fd = open(f, O_RDONLY);
@@ -1637,7 +1637,7 @@ static const char *dctype_str[] = {
  */
 static int nvme_fetch_cntrltype_dctype_from_id(nvme_ctrl_t c)
 {
-	_cleanup_free_ struct nvme_id_ctrl *id;
+	_cleanup_free_ struct nvme_id_ctrl *id = NULL;
 	int ret;
 
 	id = __nvme_alloc(sizeof(*id));

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -124,7 +124,7 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 
 int nvme_get_telemetry_max(int fd, enum nvme_telemetry_da *da, size_t *data_tx)
 {
-	_cleanup_free_ struct nvme_id_ctrl *id_ctrl;
+	_cleanup_free_ struct nvme_id_ctrl *id_ctrl = NULL;
 	int err;
 
 	id_ctrl = __nvme_alloc(sizeof(*id_ctrl));
@@ -385,7 +385,7 @@ int nvme_namespace_detach_ctrls(int fd, __u32 nsid, __u16 num_ctrls,
 
 int nvme_get_ana_log_len(int fd, size_t *analen)
 {
-	_cleanup_free_ struct nvme_id_ctrl *ctrl;
+	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
 	int ret;
 
 	ctrl = __nvme_alloc(sizeof(*ctrl));
@@ -405,7 +405,7 @@ int nvme_get_ana_log_len(int fd, size_t *analen)
 
 int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize)
 {
-	_cleanup_free_ struct nvme_id_ns *ns;
+	_cleanup_free_ struct nvme_id_ns *ns = NULL;
 	__u8 flbas;
 	int ret;
 
@@ -426,7 +426,7 @@ int nvme_get_logical_block_size(int fd, __u32 nsid, int *blksize)
 
 static int __nvme_set_attr(const char *path, const char *value)
 {
-	_cleanup_fd_ int fd;
+	_cleanup_fd_ int fd = -1;
 
 	fd = open(path, O_WRONLY);
 	if (fd < 0) {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -122,7 +122,8 @@ static void cleanup_dirents(struct dirents *ents)
 nvme_host_t nvme_default_host(nvme_root_t r)
 {
 	struct nvme_host *h;
-	_cleanup_free_ char *hostnqn, *hostid;
+	_cleanup_free_ char *hostnqn = NULL;
+	_cleanup_free_ char *hostid = NULL;
 
 	hostnqn = nvmf_hostnqn_from_file();
 	if (!hostnqn)
@@ -1853,7 +1854,7 @@ static nvme_ctrl_t nvme_ctrl_alloc(nvme_root_t r, nvme_subsystem_t s,
 	nvme_ctrl_t c, p;
 	_cleanup_free_ char *addr = NULL, *address = NULL;
 	char *a, *e;
-	_cleanup_free_ char *transport;
+	_cleanup_free_ char *transport = NULL;
 	char *traddr = NULL, *trsvcid = NULL;
 	char *host_traddr = NULL, *host_iface = NULL;
 	int ret;

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -757,7 +757,7 @@ char *kv_keymatch(const char *kv, const char *key)
 static size_t read_file(const char * fname, char *buffer, size_t *bufsz)
 {
 	char   *p;
-	_cleanup_file_ FILE *file;
+	_cleanup_file_ FILE *file = NULL;
 	size_t len;
 
 	file = fopen(fname, "re");
@@ -806,7 +806,7 @@ size_t get_entity_name(char *buffer, size_t bufsz)
 
 size_t get_entity_version(char *buffer, size_t bufsz)
 {
-	_cleanup_file_ FILE *file;
+	_cleanup_file_ FILE *file = NULL;
 	size_t  num_bytes = 0;
 
 	/* /proc/sys/kernel/ostype typically contains the string "Linux" */
@@ -928,7 +928,7 @@ int nvme_uuid_from_string(const char *str, unsigned char uuid[NVME_UUID_LEN])
 
 int nvme_uuid_random(unsigned char uuid[NVME_UUID_LEN])
 {
-	_cleanup_fd_ int f;
+	_cleanup_fd_ int f = -1;
 	ssize_t n;
 
 	f = open("/dev/urandom", O_RDONLY);


### PR DESCRIPTION
Using the default, slightly hardened CFLAGS in Fedora I was getting a bunch of warnings like
```
In file included from ../src/nvme/linux.c:38:
In function ‘cleanup_fd’,
    inlined from ‘__nvme_set_attr’ at ../src/nvme/linux.c:429:19,
    inlined from ‘nvme_set_attr’ at ../src/nvme/linux.c:451:9:
../src/nvme/cleanup.h:37:17: warning: ‘fd’ may be used uninitialized [-Wmaybe-uninitialized]
   37 |                 close(*fd);
      |                 ^~~~~~~~~~
../src/nvme/linux.c: In function ‘nvme_set_attr’:
../src/nvme/linux.c:429:26: note: ‘fd’ was declared here
  429 |         _cleanup_fd_ int fd ;
      |                          ^~
```

With a default meson build, these are not reported, despite that the project sets `warning_level=1`, i.e. `-Wall`. Stripping the CFLAGS down it turned out the two `-O2 -fexceptions` together will magically turn some extra warnings on. This is with `gcc version 13.2.1 20231011`.