### PR TITLE
linux: avoid segfault in check-tls-key due to null hostnqn/subsysnqn

### DIFF
--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1104,6 +1104,11 @@ static size_t nvme_identity_len(int hmac, int version, const char *hostnqn,
 {
 	size_t len;
 
+	if (!hostnqn || !subsysnqn) {
+		errno = EINVAL;
+		return -1;
+	}
+
 	len = strlen(hostnqn) + strlen(subsysnqn) + 12;
 	if (version == 1) {
 		len += 66;


### PR DESCRIPTION
Running nvme check-tls-key hits a segfault as seen below:

nvme check-tls-key
-d NVMeTLSkey-1:01:bB7soUnpHfxVg53sCY21KY3nLbqLit2RcIO8Rbdf3mKhcKaM:

Segmentation fault (core dumped)

This is because the strlen check on subsysnqn or hostnqn crashes at src/nvme/linux.c due to either of them being null. Avoid this segfault by checking these strings before running a strlen on them.