### PR TITLE
fabrics: add 'concat' option

### DIFF
--- a/doc/config-schema.json.in
+++ b/doc/config-schema.json.in
@@ -169,6 +169,11 @@
 		    "type": "boolean",
 		    "default": false
 		},
+		"concat": {
+		    "description": "Enable secure concatenation",
+		    "type": "boolean",
+		    "default": false
+		},
 		"persistent": {
 		    "description": "Create persistent discovery connection",
 		    "type": "boolean"

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -260,6 +260,7 @@ static struct nvme_fabrics_config *merge_config(nvme_ctrl_t c,
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, data_digest, false);
 	MERGE_CFG_OPTION(ctrl_cfg, cfg, tls, false);
+	MERGE_CFG_OPTION(ctrl_cfg, cfg, concat, false);
 
 	return ctrl_cfg;
 }
@@ -289,6 +290,7 @@ void nvmf_update_config(nvme_ctrl_t c, const struct nvme_fabrics_config *cfg)
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, hdr_digest, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, data_digest, false);
 	UPDATE_CFG_OPTION(ctrl_cfg, cfg, tls, false);
+	UPDATE_CFG_OPTION(ctrl_cfg, cfg, concat, false);
 }
 
 static int __add_bool_argument(char **argstr, char *tok, bool arg)
@@ -637,7 +639,9 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 	    (!strcmp(transport, "tcp") &&
 	     add_bool_argument(r, argstr, data_digest, cfg->data_digest)) ||
 	    (!strcmp(transport, "tcp") &&
-	     add_bool_argument(r, argstr, tls, cfg->tls))) {
+	     add_bool_argument(r, argstr, tls, cfg->tls)) ||
+	    (!strcmp(transport, "tcp") &&
+	     add_bool_argument(r, argstr, concat, cfg->concat))) {
 		free(*argstr);
 		return -1;
 	}
@@ -705,6 +709,7 @@ static  int __nvmf_supported_options(nvme_root_t r)
 		nvme_msg(r, LOG_DEBUG, "%s ", v);
 
 		parse_option(r, v, cntlid);
+		parse_option(r, v, concat);
 		parse_option(r, v, ctrl_loss_tmo);
 		parse_option(r, v, data_digest);
 		parse_option(r, v, dhchap_ctrl_secret);

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -42,6 +42,7 @@
  * @hdr_digest:		Generate/verify header digest (TCP)
  * @data_digest:	Generate/verify data digest (TCP)
  * @tls:		Start TLS on the connection (TCP)
+ * @concat:		Enable secure concatenation (TCP)
  */
 struct nvme_fabrics_config {
 	char *host_traddr;
@@ -63,6 +64,7 @@ struct nvme_fabrics_config {
 	bool hdr_digest;
 	bool data_digest;
 	bool tls;
+	bool concat;
 };
 
 /**

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -60,6 +60,8 @@ static void json_update_attributes(nvme_ctrl_t c,
 					data_digest, val_obj);
 		JSON_UPDATE_BOOL_OPTION(cfg, key_str,
 					tls, val_obj);
+		JSON_UPDATE_BOOL_OPTION(cfg, key_str,
+					concat, val_obj);
 		if (!strcmp("persistent", key_str) &&
 		    !nvme_ctrl_is_persistent(c))
 			nvme_ctrl_set_persistent(c, true);
@@ -325,6 +327,7 @@ static void json_update_port(struct json_object *ctrl_array, nvme_ctrl_t c)
 	JSON_BOOL_OPTION(cfg, port_obj, hdr_digest);
 	JSON_BOOL_OPTION(cfg, port_obj, data_digest);
 	JSON_BOOL_OPTION(cfg, port_obj, tls);
+	JSON_BOOL_OPTION(cfg, port_obj, concat);
 	if (nvme_ctrl_is_persistent(c))
 		json_object_object_add(port_obj, "persistent",
 				       json_object_new_boolean(true));
@@ -501,6 +504,7 @@ static void json_dump_ctrl(struct json_object *ctrl_array, nvme_ctrl_t c)
 	JSON_BOOL_OPTION(cfg, ctrl_obj, hdr_digest);
 	JSON_BOOL_OPTION(cfg, ctrl_obj, data_digest);
 	JSON_BOOL_OPTION(cfg, ctrl_obj, tls);
+	JSON_BOOL_OPTION(cfg, ctrl_obj, concat);
 	if (nvme_ctrl_is_persistent(c))
 		json_object_object_add(ctrl_obj, "persistent",
 				       json_object_new_boolean(true));

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -125,6 +125,7 @@ struct nvme_host {
 
 struct nvme_fabric_options {
 	bool cntlid;
+	bool concat;
 	bool ctrl_loss_tmo;
 	bool data_digest;
 	bool dhchap_ctrl_secret;


### PR DESCRIPTION
Add an option 'concat' to enable secure concatenation for TCP.