### PR TITLE
mi: set correct rc and errno when crc mismatch

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -433,7 +433,8 @@ int nvme_mi_submit(nvme_mi_ep_t ep, struct nvme_mi_req *req,
 		rc = nvme_mi_verify_resp_mic(resp);
 		if (rc) {
 			nvme_msg(ep->root, LOG_WARNING, "crc mismatch\n");
-			return rc;
+			errno = EBADMSG;
+			return -1;
 		}
 	}
 

--- a/test/mi.c
+++ b/test/mi.c
@@ -306,7 +306,7 @@ static void test_invalid_crc(nvme_mi_ep_t ep)
 
 	test_set_transport_callback(ep, test_invalid_crc_cb, NULL);
 	rc = nvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	assert(rc < 0);
 }
 
 /* test: test that the controller list populates the endpoint's list of


### PR DESCRIPTION
Before the fix, when we meet crc mismatch response, the errno is 0 and rc is 1. This combination will be mistaken as Admin Generic Command Status code value 0x1 (Invalid Command Opcode):
  $ nvme id-ctrl mctp:1,20
  crc mismatch
  NVMe status: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field(0x1

After the fix, the rc is -1, and errno is set to Bad message.
  $ nvme id-ctrl mctp:1,20
  crc mismatch
  identify controller: Bad message