### PR TITLE
tree: use logical block size for lba

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2437,7 +2437,7 @@ static int nvme_ns_init(const char *path, struct nvme_ns *ns)
 	struct sysfs_attr_table base[] = {
 		{ &ns->nsid,      nvme_strtou32,  true, "nsid" },
 		{ &ns->lba_count, nvme_strtou64,  true, "size" },
-		{ &ns->lba_size,  nvme_strtou64,  true, "queue/physical_block_size" },
+		{ &ns->lba_size,  nvme_strtou64,  true, "queue/logical_block_size" },
 		{ ns->eui64,      nvme_strtoeuid, false, "eui" },
 		{ ns->nguid,      nvme_strtouuid, false, "nguid" },
 		{ ns->uuid,       nvme_strtouuid, false, "uuid" }


### PR DESCRIPTION
The kernel export the LBA size via the logical_block_size sysfs entry not the physical_block_size.

Fixes: 7959f52960fd ("tree: read all attributes from sysfs when available")
Fixes: https://github.com/linux-nvme/nvme-cli/issues/2173