### PR TITLE
tree: do not issue an error when subsys lookup fails during scanning

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2010,7 +2010,7 @@ nvme_ctrl_t nvme_scan_ctrl(nvme_root_t r, const char *name)
 	}
 	subsysname = nvme_ctrl_lookup_subsystem_name(r, name);
 	if (!subsysname) {
-		nvme_msg(r, LOG_ERR,
+		nvme_msg(r, LOG_DEBUG,
 			 "failed to lookup subsystem for controller %s\n",
 			 name);
 		errno = ENXIO;


### PR DESCRIPTION
The scan operation is not atomically done and the sysfs might change while we are iterating over it. Thus, it's possible that we find a controller but when we try to lookup the corresponding subsystem it might already destroyed and removed.

This error makes blktests fail because it finds controllers controller which are not under control of blktests, instead they are created and destroyed by the udev auto connect rules.

These resources appear and disappear while the test runs but when we scan sysfs we issue errors for unrelated resources. Thus just do not issue a error, turn this into debug log message.

Anyway, we already do just return error codes for other reason in this function anyway without logging.