### PR TITLE
example: fix mi identify failed with error cntid

### DIFF
--- a/examples/mi-mctp.c
+++ b/examples/mi-mctp.c
@@ -184,24 +184,24 @@ int do_identify(nvme_mi_ep_t ep, int argc, char **argv)
 	uint16_t ctrl_id;
 	char buf[41];
 	bool partial;
-	int rc, tmp;
+	int rc;
 
 	if (argc < 2) {
 		fprintf(stderr, "no controller ID specified\n");
 		return -1;
 	}
 
-	tmp = atoi(argv[1]);
-	if (tmp < 0 || tmp > 0xffff) {
+	ctrl_id = atoi(argv[1]);
+	if (ctrl_id < 0 || ctrl_id > 0xffff) {
 		fprintf(stderr, "invalid controller ID\n");
 		return -1;
 	}
 
-	ctrl_id = tmp & 0xffff;
+	ctrl_id = ctrl_id & 0xffff;
 
 	partial = argc > 2 && !strcmp(argv[2], "--partial");
 
-	ctrl = nvme_mi_init_ctrl(ep, tmp);
+	ctrl = nvme_mi_init_ctrl(ep, ctrl_id);
 	if (!ctrl) {
 		warn("can't create controller");
 		return -1;
@@ -211,7 +211,7 @@ int do_identify(nvme_mi_ep_t ep, int argc, char **argv)
 	id_args.args_size = sizeof(id_args);
 	id_args.cns = NVME_IDENTIFY_CNS_CTRL;
 	id_args.nsid = NVME_NSID_NONE;
-	id_args.cntid = ctrl_id;
+	id_args.cntid = 0;
 	id_args.csi = NVME_CSI_NVM;
 
 	/* for this example code, we can either do a full or partial identify;


### PR DESCRIPTION
This command failed when we try to identify a controller that the controller id is 1.

Refer to the `Figure 273: Identify - CNS Values`:
+-----------+-------+
| CNS Value | CNTID |
+-----------+-------+
| 01h       | N     |
+-----------+-------+
When CNS is 01h, the CNTID field is ignored.

See `Figure 270: Identify - Command Dword 10`:
If this field is not used as part of the Identify operation, then
* host software shall clear this field to 0h for backwards compatibility (0h is a valid controller identifier);
* and the controller shall ignore this field.

This filed is set to controller id in the example code, but it should be 0 when CNS is 1.

PS: The NVMe that we are testing does not ignore the CNTID field and returns an error when the CNTID field is not 0.