### PR TITLE
log: Introduce nvme_get_logging_level()

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+LIBNVME_1_9 {
+	global:
+		nvme_get_logging_level;
+};
+
 LIBNVME_1_8 {
 	global:
 		nvme_uuid_find;

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -58,6 +58,8 @@ __nvme_msg(nvme_root_t r, int lvl,
 
 	if (r && lvl > r->log_level)
 		return;
+	if (!r && lvl > DEFAULT_LOGLEVEL)
+		return;
 
 	if (r && r->log_timestamp) {
 		struct timespec now;

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -99,6 +99,19 @@ void nvme_init_logging(nvme_root_t r, int lvl, bool log_pid, bool log_tstamp)
 	r->log_timestamp = log_tstamp;
 }
 
+int nvme_get_logging_level(nvme_root_t r, bool *log_pid, bool *log_tstamp)
+{
+	if (!r)
+		r = root;
+	if (!r)
+		return DEFAULT_LOGLEVEL;
+	if (log_pid)
+		*log_pid = r->log_pid;
+	if (log_tstamp)
+		*log_tstamp = r->log_timestamp;
+	return r->log_level;
+}
+
 void nvme_set_root(nvme_root_t r)
 {
 	root = r;

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -36,6 +36,20 @@
 void nvme_init_logging(nvme_root_t r, int lvl, bool log_pid, bool log_tstamp);
 
 /**
+ * nvme_get_logging_level() - Get current logging level
+ * @r:		nvme_root_t context
+ * @log_pid:	Pointer to store a current value of logging of
+ * 		the PID flag at (optional).
+ * @log_tstamp:	Pointer to store a current value of logging of
+ * 		the timestamp flag at (optional).
+ *
+ * Retrieves current values of logging variables.
+ *
+ * Return: current log level value or DEFAULT_LOGLEVEL if not initialized.
+ */
+int nvme_get_logging_level(nvme_root_t r, bool *log_pid, bool *log_tstamp);
+
+/**
  * nvme_set_root() - Set nvme_root_t context
  * @r:		nvme_root_t context
  *


### PR DESCRIPTION
This is essentially a getter for `nvme_init_logging()` since `nvme_root_t` is an opaque struct. Takes optional pointer to bool args to retrieve PID and timestamp logging values.