### PR TITLE
Persistent TLS keys take #2

### DIFF
--- a/doc/config-schema.json.in
+++ b/doc/config-schema.json.in
@@ -98,6 +98,14 @@
 		    "description": "Controller DH-HMAC-CHAP key",
 		    "type": "string"
 		},
+		"keyring": {
+		    "description": "Keyring for TLS key lookup",
+		    "type": "string"
+		},
+		"tls_key": {
+		    "description": "TLS key for the connection",
+		    "type": "string"
+		},
 		"nr_io_queues": {
 		    "description": "Number of I/O queues",
 		    "type": "integer"
@@ -155,14 +163,6 @@
 		    "description": "Enable data digest",
 		    "type": "boolean",
 		    "default": false
-		},
-		"keyring": {
-		    "description": "Keyring for TLS key lookup",
-		    "type": "integer"
-		},
-		"tls_key": {
-		    "description": "TLS key for the connection",
-		    "type": "integer"
 		},
 		"tls": {
 		    "description": "Enable TLS encryption",

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 LIBNVME_1.9 {
 	global:
+		nvme_export_tls_key;
 		nvme_get_logging_level;
 		nvme_read_key;
 		nvme_submit_passthru;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -2,6 +2,7 @@
 LIBNVME_1.9 {
 	global:
 		nvme_get_logging_level;
+		nvme_read_key;
 		nvme_submit_passthru;
 		nvme_submit_passthru64;
 };

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -5,6 +5,7 @@ LIBNVME_1.9 {
 		nvme_read_key;
 		nvme_submit_passthru;
 		nvme_submit_passthru64;
+		nvme_update_key;
 };
 
 LIBNVME_1_8 {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -3,6 +3,7 @@ LIBNVME_1.9 {
 	global:
 		nvme_export_tls_key;
 		nvme_get_logging_level;
+		nvme_import_tls_key;
 		nvme_read_key;
 		nvme_submit_passthru;
 		nvme_submit_passthru64;

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,8 @@ sources = [
     'nvme/log.c',
     'nvme/tree.c',
     'nvme/util.c',
-    'nvme/base64.c'
+    'nvme/base64.c',
+    'nvme/crc32.c'
 ]
 
 mi_sources = [

--- a/src/nvme/crc32.c
+++ b/src/nvme/crc32.c
@@ -1,0 +1,111 @@
+/*
+ *  COPYRIGHT (C) 1986 Gary S. Brown.  You may use this program, or
+ *  code or tables extracted from it, as desired without restriction.
+ */
+
+/*
+ *  First, the polynomial itself and its table of feedback terms.  The
+ *  polynomial is
+ *  X^32+X^26+X^23+X^22+X^16+X^12+X^11+X^10+X^8+X^7+X^5+X^4+X^2+X^1+X^0
+ *
+ *  Note that we take it "backwards" and put the highest-order term in
+ *  the lowest-order bit.  The X^32 term is "implied"; the LSB is the
+ *  X^31 term, etc.  The X^0 term (usually shown as "+1") results in
+ *  the MSB being 1
+ *
+ *  Note that the usual hardware shift register implementation, which
+ *  is what we're using (we're merely optimizing it by doing eight-bit
+ *  chunks at a time) shifts bits into the lowest-order term.  In our
+ *  implementation, that means shifting towards the right.  Why do we
+ *  do it this way?  Because the calculated CRC must be transmitted in
+ *  order from highest-order term to lowest-order term.  UARTs transmit
+ *  characters in order from LSB to MSB.  By storing the CRC this way
+ *  we hand it to the UART in the order low-byte to high-byte; the UART
+ *  sends each low-bit to hight-bit; and the result is transmission bit
+ *  by bit from highest- to lowest-order term without requiring any bit
+ *  shuffling on our part.  Reception works similarly
+ *
+ *  The feedback terms table consists of 256, 32-bit entries.  Notes
+ *
+ *      The table can be generated at runtime if desired; code to do so
+ *      is shown later.  It might not be obvious, but the feedback
+ *      terms simply represent the results of eight shift/xor opera
+ *      tions for all combinations of data and CRC register values
+ *
+ *      The values must be right-shifted by eight bits by the "updcrc
+ *      logic; the shift must be unsigned (bring in zeroes).  On some
+ *      hardware you could probably optimize the shift in assembler by
+ *      using byte-swap instructions
+ *      polynomial $edb88320
+ *
+ *
+ * CRC32 code derived from work by Gary S. Brown.
+ */
+
+/* https://web.mit.edu/freebsd/head/sys/libkern/crc32.c */
+
+#include "crc32.h"
+
+const uint32_t crc32_tab[] = {
+	0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
+	0xe963a535, 0x9e6495a3,	0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+	0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
+	0xf3b97148, 0x84be41de,	0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+	0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec,	0x14015c4f, 0x63066cd9,
+	0xfa0f3d63, 0x8d080df5,	0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+	0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,	0x35b5a8fa, 0x42b2986c,
+	0xdbbbc9d6, 0xacbcf940,	0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+	0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
+	0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+	0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d,	0x76dc4190, 0x01db7106,
+	0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+	0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
+	0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+	0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+	0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+	0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
+	0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+	0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
+	0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+	0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
+	0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+	0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
+	0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+	0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
+	0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+	0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
+	0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+	0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
+	0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+	0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
+	0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+	0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
+	0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+	0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
+	0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+	0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
+	0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+	0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
+	0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+	0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
+	0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+	0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+};
+
+/*
+ * A function that calculates the CRC-32 based on the table above is
+ * given below for documentation purposes. An equivalent implementation
+ * of this function that's actually used in the kernel can be found
+ * in sys/libkern.h, where it can be inlined.
+ */
+
+uint32_t
+crc32(uint32_t crc, const void *buf, size_t size)
+{
+	const uint8_t *p = buf;
+
+	crc = ~crc;
+	while (size--)
+		crc = crc32_tab[(crc ^ *p++) & 0xFF] ^ (crc >> 8);
+	return ~crc;
+}

--- a/src/nvme/crc32.h
+++ b/src/nvme/crc32.h
@@ -1,0 +1,9 @@
+#ifndef crc32_H
+#define crc32_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+uint32_t crc32(uint32_t crc, const void *buf, size_t len);
+
+#endif

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -56,7 +56,7 @@ struct nvme_fabrics_config {
 	int nr_write_queues;
 	int nr_poll_queues;
 	int tos;
-	int keyring;
+	long keyring;
 	long tls_key;
 
 	bool duplicate_connect;

--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -57,7 +57,7 @@ struct nvme_fabrics_config {
 	int nr_poll_queues;
 	int tos;
 	int keyring;
-	int tls_key;
+	long tls_key;
 
 	bool duplicate_connect;
 	bool disable_sqflow;

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -554,7 +554,13 @@ static void json_dump_ctrl(struct json_object *ctrl_array, nvme_ctrl_t c)
 	JSON_BOOL_OPTION(cfg, ctrl_obj, disable_sqflow);
 	JSON_BOOL_OPTION(cfg, ctrl_obj, hdr_digest);
 	JSON_BOOL_OPTION(cfg, ctrl_obj, data_digest);
-	JSON_BOOL_OPTION(cfg, ctrl_obj, tls);
+	if (!strcmp(transport, "tcp")) {
+		JSON_BOOL_OPTION(cfg, ctrl_obj, tls);
+
+		if (cfg->tls_key)
+			json_export_nvme_tls_key(cfg->keyring, cfg->tls_key,
+						 ctrl_obj);
+	}
 	JSON_BOOL_OPTION(cfg, ctrl_obj, concat);
 	if (nvme_ctrl_is_persistent(c))
 		json_object_object_add(ctrl_obj, "persistent",

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -25,6 +25,40 @@
 #define JSON_UPDATE_BOOL_OPTION(c, k, a, o)				\
 	if (!strcmp(# a, k ) && !c->a) c->a = json_object_get_boolean(o);
 
+static void json_import_nvme_tls_key(nvme_ctrl_t c, const char *keyring_str,
+				     const char *encoded_key)
+{
+	struct nvme_fabrics_config *cfg = nvme_ctrl_get_config(c);
+	const char *hostnqn = nvme_host_get_hostnqn(c->s->h);
+	const char *subsysnqn = nvme_ctrl_get_subsysnqn(c);
+	int key_len;
+	unsigned int hmac;
+	long key_id;
+	_cleanup_free_ unsigned char *key_data;
+
+	if (!hostnqn || !subsysnqn) {
+		nvme_msg(NULL, LOG_ERR, "Invalid NQNs (%s, %s)\n",
+			 hostnqn, subsysnqn);
+		return;
+	}
+	key_data = nvme_import_tls_key(encoded_key, &key_len, &hmac);
+	if (!key_data) {
+		nvme_msg(NULL, LOG_ERR, "Failed to decode TLS Key '%s'\n",
+			encoded_key);
+		return;
+	}
+	key_id = nvme_insert_tls_key_versioned(keyring_str, "psk",
+					       hostnqn, subsysnqn,
+					       0, hmac, key_data, key_len);
+	if (key_id <= 0)
+		nvme_msg(NULL, LOG_ERR, "Failed to insert TLS KEY, error %d\n",
+			 errno);
+	else {
+		cfg->tls_key = key_id;
+		cfg->tls = true;
+	}
+}
+
 static void json_export_nvme_tls_key(long keyring_id, long tls_key,
 				     struct json_object *obj)
 {
@@ -46,6 +80,7 @@ static void json_update_attributes(nvme_ctrl_t c,
 				   struct json_object *ctrl_obj)
 {
 	struct nvme_fabrics_config *cfg = nvme_ctrl_get_config(c);
+	const char *keyring_str = NULL, *encoded_key = NULL;
 
 	json_object_object_foreach(ctrl_obj, key_str, val_obj) {
 		JSON_UPDATE_INT_OPTION(cfg, key_str,
@@ -92,21 +127,24 @@ static void json_update_attributes(nvme_ctrl_t c,
 		if (!strcmp("keyring", key_str) && cfg->keyring == 0) {
 			long keyring;
 
-			keyring = nvme_lookup_keyring(json_object_get_string(val_obj));
+			keyring_str = json_object_get_string(val_obj);
+			keyring = nvme_lookup_keyring(keyring_str);
 			if (keyring) {
 				cfg->keyring = keyring;
 				nvme_set_keyring(cfg->keyring);
 			}
 		}
-		if (!strcmp("tls_key", key_str) && cfg->tls_key == 0) {
-			long key;
-
-			key = nvme_lookup_key("psk",
-					      json_object_get_string(val_obj));
-			if (key)
-				cfg->tls_key = key;
-		}
+		if (!strcmp("tls_key", key_str) && cfg->tls_key == 0)
+			encoded_key = json_object_get_string(val_obj);
 	}
+
+	/*
+	 * We might need the keyring information from the above loop,
+	 * so we can only import the TLS key once all entries are
+	 * processed.
+	 */
+	if (encoded_key)
+		json_import_nvme_tls_key(c, keyring_str, encoded_key);
 }
 
 static void json_parse_port(nvme_subsystem_t s, struct json_object *port_obj)

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -31,6 +31,8 @@
 
 #ifdef CONFIG_KEYUTILS
 #include <keyutils.h>
+
+#define NVME_TLS_DEFAULT_KEYRING ".nvme"
 #endif
 
 #include <ccan/endian/endian.h>
@@ -1158,6 +1160,8 @@ long nvme_lookup_keyring(const char *keyring)
 {
 	key_serial_t keyring_id;
 
+	if (!keyring)
+		keyring = NVME_TLS_DEFAULT_KEYRING;
 	keyring_id = find_key_by_type_and_desc("keyring", keyring, 0);
 	if (keyring_id < 0)
 		return 0;

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -274,6 +274,22 @@ long nvme_lookup_key(const char *type, const char *identity);
 int nvme_set_keyring(long keyring_id);
 
 /**
+ * nvme_read_key() - Read key raw data
+ * @keyring_id:     Id of the keyring holding %key_id
+ * @key_id:      Key id
+ * @len:         Length of the returned data
+ *
+ * Links the keyring specified by @keyring_id into the session
+ * keyring and reads the payload of the key specified by @key_id.
+ * @len holds the size of the returned buffer.
+ * If @keyring is 0 the default keyring '.nvme' is used.
+ *
+ * Return: Pointer to the payload on success,
+ * or NULL with errno set otherwise.
+ */
+unsigned char *nvme_read_key(long keyring_id, long key_id, int *len);
+
+/**
  * nvme_insert_tls_key() - Derive and insert TLS key
  * @keyring:    Keyring to use
  * @key_type:	Type of the resulting key

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -290,6 +290,25 @@ int nvme_set_keyring(long keyring_id);
 unsigned char *nvme_read_key(long keyring_id, long key_id, int *len);
 
 /**
+ * nvme_update_key() - Update key raw data
+ * @keyring_id:  Id of the keyring holding %key_id
+ * @key_type:    Type of the key to insert
+ * @identity:    Key identity string
+ * @key_data:    Raw data of the key
+ * @key_len:     Length of @key_data
+ *
+ * Links the keyring specified by @keyring_id into the session
+ * keyring and updates the key reference by @identity with @key_data.
+ * The old key with identity @identity will be revoked to make it
+ * inaccessible.
+ *
+ * Return: Key id of the new key or 0 with errno set otherwise.
+ */
+long nvme_update_key(long keyring_id, const char *key_type,
+		     const char *identity, unsigned char *key_data,
+		     int key_len);
+
+/**
  * nvme_insert_tls_key() - Derive and insert TLS key
  * @keyring:    Keyring to use
  * @key_type:	Type of the resulting key

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -371,6 +371,20 @@ char *nvme_generate_tls_key_identity(const char *hostnqn, const char *subsysnqn,
 				     unsigned char *configured_key, int key_len);
 
 /**
+ * nvme_export_tls_key() - Export a TLS key
+ * @key_data:	Raw data of the key
+ * @key_len:	Length of @key_data
+ *
+ * Returns @key_data in the PSK Interchange format as defined in section
+ * 3.6.1.5 of the NVMe TCP Transport specification.
+ *
+ * Return: The string containing the TLS identity or NULL with errno set
+ * on error. It is the responsibility of the caller to free the returned
+ * string.
+ */
+char *nvme_export_tls_key(const unsigned char *key_data, int key_len);
+
+/**
  * nvme_submit_passthru - Low level ioctl wrapper for passthru commands
  * @fd:		File descriptor of the nvme device
  * @ioctl_cmd:	IOCTL command id

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -309,6 +309,37 @@ long nvme_update_key(long keyring_id, const char *key_type,
 		     int key_len);
 
 /**
+ * typedef nvme_scan_tls_keys_cb_t - Callback for iterating TLS keys
+ * @keyring:	Keyring which has been iterated
+ * @key:	Key for which the callback has been invoked
+ * @desc:	Description of the key
+ * @desc_len:	Length of @desc
+ * @data:	Pointer for caller data
+ *
+ * Called for each TLS PSK in the keyring.
+ */
+typedef void (*nvme_scan_tls_keys_cb_t)(long keyring, long key,
+					char *desc, int desc_len, void *data);
+
+/**
+ * nvme_scan_tls_keys() - Iterate over TLS keys in a keyring
+ * @keyring:	Keyring holding TLS keys
+ * @cb:		Callback function
+ * @data:	Pointer for data to be passed to @cb
+ *
+ * Iterates @keyring and call @cb for each TLS key. When @keyring is NULL
+ * the default '.nvme' keyring is used.
+ * A TLS key must be of type 'psk' and the description must be of the
+ * form 'NVMe<0|1><R|G>0<1|2> <identity>', otherwise it will be skipped
+ * during iteration.
+ *
+ * Return: Number of keys for which @cb was called, or -1 with errno set
+ * on error.
+ */
+int nvme_scan_tls_keys(const char *keyring, nvme_scan_tls_keys_cb_t cb,
+		       void *data);
+
+/**
  * nvme_insert_tls_key() - Derive and insert TLS key
  * @keyring:    Keyring to use
  * @key_type:	Type of the resulting key

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -385,6 +385,21 @@ char *nvme_generate_tls_key_identity(const char *hostnqn, const char *subsysnqn,
 char *nvme_export_tls_key(const unsigned char *key_data, int key_len);
 
 /**
+ * nvme_import_tls_key() - Import a TLS key
+ * @encoded_key:	TLS key in PSK interchange format
+ * @key_len:		Length of the resulting key data
+ * @hmac:		HMAC algorithm
+ *
+ * Imports @key_data in the PSK Interchange format as defined in section
+ * 3.6.1.5 of the NVMe TCP Transport specification.
+ *
+ * Return: The raw data of the PSK or NULL with errno set on error. It is
+ * the responsibility of the caller to free the returned string.
+ */
+unsigned char *nvme_import_tls_key(const char *encoded_key, int *key_len,
+				   unsigned int *hmac);
+
+/**
  * nvme_submit_passthru - Low level ioctl wrapper for passthru commands
  * @fd:		File descriptor of the nvme device
  * @ioctl_cmd:	IOCTL command id

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1772,7 +1772,7 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 			       const char *name)
 {
 	DIR *d;
-	char *host_key;
+	char *host_key, *tls_psk;
 
 	d = opendir(path);
 	if (!d) {
@@ -1806,6 +1806,16 @@ static int nvme_configure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	if (c->dhchap_ctrl_key && !strcmp(c->dhchap_ctrl_key, "none")) {
 		free(c->dhchap_ctrl_key);
 		c->dhchap_ctrl_key = NULL;
+	}
+	tls_psk = nvme_get_ctrl_attr(c, "tls_key");
+	if (tls_psk) {
+		char *endptr;
+		long key_id = strtol(tls_psk, &endptr, 16);
+
+		if (endptr != tls_psk) {
+			c->cfg.tls_key = key_id;
+			c->cfg.tls = true;
+		}
 	}
 	c->cntrltype = nvme_get_ctrl_attr(c, "cntrltype");
 	c->dctype = nvme_get_ctrl_attr(c, "dctype");


### PR DESCRIPTION
Hey all,

this is my next attempt to implement persistent TLS key handling. The original idea of storing the key serial number in the JSON configuration file doesn't really work out as the key serial number is ephemeral, and might change whenever a key is updated/revoked or somesuch. So after a reboot the key won't be present, the we won't be able to load the keys at all.
With the pull request we now store the TLS keys in 'PSK interchange format' as mandated in the NVMe TCP transport specification, which then contains the actual key data. And, obviously, the parser has been updated to read the TLS keys
from the PSK interchange format, too.
The original pull request https://github.com/linux-nvme/libnvme/pull/783 would export all keys via the configuration file, thereby losing the distinction between keys selected from the user (ie via the '--tls_key' option) and keys auto-selected during TLS handshake (when only '--tls' was specified. To fix this this PR now also adds the functions nvme_scan_tls_keys() such that nvme-cli can add an 'export' and 'import' functionality for TLS keys.