### PR TITLE
fabrics: check the read() return value

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1297,6 +1297,8 @@ static int uuid_from_dmi_entries(char *system_uuid)
 			continue;
 		len = read(f, buf, 512);
 		close(f);
+		if (len <= 0)
+			continue;
 
 		if (!is_dmi_uuid_valid(buf, len))
 			continue;


### PR DESCRIPTION
Do not pass to the is_dmi_uuid_valid() function an invalid len value if read() fails.