### PR TITLE
tree: Add nvme_root identify flag to scan NVMe topology

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -281,6 +281,7 @@ LIBNVME_1_0 {
 		nvme_resv_report;
 		nvme_sanitize_nvm;
 		nvme_scan;
+		nvme_scan_no_id;
 		nvme_scan_ctrl;
 		nvme_scan_ctrls;
 		nvme_scan_ctrl_namespace_paths;

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -168,6 +168,7 @@ struct nvme_root {
 	bool modified;
 	bool mi_probe_enabled;
 	struct nvme_fabric_options *options;
+	bool identify;
 };
 
 int nvme_set_attr(const char *dir, const char *attr, const char *value);

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1304,6 +1304,14 @@ void nvme_free_host(nvme_host_t h);
 nvme_root_t nvme_scan(const char *config_file);
 
 /**
+ * nvme_scan_no_id() - Scan NVMe topology without nvme identify namespace
+ * @config_file:	Configuration file
+ *
+ * Return: nvme_root_t object of found elements
+ */
+nvme_root_t nvme_scan_no_id(const char *config_file);
+
+/**
  * nvme_read_config() - Read NVMe JSON configuration file
  * @r:			nvme_root_t object
  * @config_file:	JSON configuration file


### PR DESCRIPTION
This is to avoid nvme identify namespace to scan NVMe topology.