### PR TITLE
libnvme: add missing symbol nvme_scan_tls_keys

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -5,6 +5,7 @@ LIBNVME_1.9 {
 		nvme_get_logging_level;
 		nvme_import_tls_key;
 		nvme_read_key;
+		nvme_scan_tls_keys;
 		nvme_submit_passthru;
 		nvme_submit_passthru64;
 		nvme_update_key;


### PR DESCRIPTION
Missing from the list of exports.

Signed-off-by: Hannes Reinecke <hare@suse.de>