### PR TITLE
json: Fix uninitialized variables

### DIFF
--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -34,7 +34,7 @@ static void json_import_nvme_tls_key(nvme_ctrl_t c, const char *keyring_str,
 	int key_len;
 	unsigned int hmac;
 	long key_id;
-	_cleanup_free_ unsigned char *key_data;
+	_cleanup_free_ unsigned char *key_data = NULL;
 
 	if (!hostnqn || !subsysnqn) {
 		nvme_msg(NULL, LOG_ERR, "Invalid NQNs (%s, %s)\n",
@@ -63,11 +63,11 @@ static void json_export_nvme_tls_key(long keyring_id, long tls_key,
 				     struct json_object *obj)
 {
 	int key_len;
-	_cleanup_free_ unsigned char *key_data;
+	_cleanup_free_ unsigned char *key_data = NULL;
 
 	key_data = nvme_read_key(keyring_id, tls_key, &key_len);
 	if (key_data) {
-		_cleanup_free_ char *tls_str;
+		_cleanup_free_ char *tls_str = NULL;
 
 		tls_str = nvme_export_tls_key(key_data, key_len);
 		if (tls_str)


### PR DESCRIPTION
```
In file included from ../src/nvme/json.c:17:
In function ‘freep’,
    inlined from ‘json_export_nvme_tls_key’ at ../src/nvme/json.c:70:24:
../src/nvme/cleanup.h:24:9: warning: ‘tls_str’ may be used uninitialized [-Wmaybe-uninitialized]
   24 |         free(*(void **)p);
      |         ^~~~~~~~~~~~~~~~~
../src/nvme/json.c: In function ‘json_export_nvme_tls_key’:
../src/nvme/json.c:70:38: note: ‘tls_str’ was declared here
   70 |                 _cleanup_free_ char *tls_str;
      |                                      ^~~~~~~

In function ‘freep’,
    inlined from ‘json_export_nvme_tls_key’ at ../src/nvme/json.c:66:32:
../src/nvme/cleanup.h:24:9: warning: ‘key_data’ may be used uninitialized [-Wmaybe-uninitialized]
   24 |         free(*(void **)p);
      |         ^~~~~~~~~~~~~~~~~
../src/nvme/json.c: In function ‘json_export_nvme_tls_key’:
../src/nvme/json.c:66:39: note: ‘key_data’ was declared here
   66 |         _cleanup_free_ unsigned char *key_data;
      |                                       ^~~~~~~~

In function ‘freep’,
    inlined from ‘json_import_nvme_tls_key’ at ../src/nvme/json.c:37:32,
    inlined from ‘json_update_attributes’ at ../src/nvme/json.c:147:3,
    inlined from ‘json_parse_port’ at ../src/nvme/json.c:177:2,
    inlined from ‘json_parse_subsys’ at ../src/nvme/json.c:212:4,
    inlined from ‘json_parse_host’ at ../src/nvme/json.c:246:4,
    inlined from ‘json_read_config’ at ../src/nvme/json.c:316:4:
../src/nvme/cleanup.h:24:9: warning: ‘key_data’ may be used uninitialized [-Wmaybe-uninitialized]
   24 |         free(*(void **)p);
      |         ^~~~~~~~~~~~~~~~~
../src/nvme/json.c: In function ‘json_read_config’:
../src/nvme/json.c:37:39: note: ‘key_data’ was declared here
   37 |         _cleanup_free_ unsigned char *key_data;
      |                                       ^~~~~~~~
```