### PR TITLE
build: Add vscode directory into ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ compile_commands.json
 
 .build
 .cache
+.vscode/
 
 subprojects/*
 !subprojects/*.wrap


### PR DESCRIPTION
The vscode directory was not in the .gitignore file. So add it. 