### PR TITLE
build: Switch default meson buildtype to 'debugoptimized'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ project(
     default_options: [
         'c_std=gnu99',
         'warning_level=1',
-        'buildtype=debug',
+        'buildtype=debugoptimized',
         'prefix=/usr/local',
         'sysconfdir=etc',
         'wrap_mode=nofallback'


### PR DESCRIPTION
The meson 'debug' buildtype defaults to '-O0 -g' which misses some important compiler warnings (as of gcc-13). While there's no universal solution, the 'debugoptimized' buildtype supplies '-O2 -g' that appears to be a reasonable compromise for having important compiler warnings by default.