### PR TITLE
sysfs: Export NVMe controller sysfs directory return function

### DIFF
--- a/src/libnvme.h
+++ b/src/libnvme.h
@@ -23,6 +23,7 @@ extern "C" {
 #include "nvme/tree.h"
 #include "nvme/util.h"
 #include "nvme/log.h"
+#include "nvme/sysfs.h"
 
 #ifdef __cplusplus
 }

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -9,6 +9,7 @@ LIBNVME_1.9 {
 		nvme_submit_passthru;
 		nvme_submit_passthru64;
 		nvme_update_key;
+		nvme_ctrl_sysfs_dir;
 };
 
 LIBNVME_1_8 {

--- a/src/meson.build
+++ b/src/meson.build
@@ -132,6 +132,7 @@ install_headers([
         'nvme/types.h',
         'nvme/util.h',
         'nvme/mi.h',
+        'nvme/sysfs.h',
     ],
     subdir: 'nvme',
     install_mode: mode,

--- a/src/nvme/filters.c
+++ b/src/nvme/filters.c
@@ -11,6 +11,7 @@
 #include <dirent.h>
 
 #include "filters.h"
+#include "sysfs.h"
 #include "private.h"
 
 int nvme_namespace_filter(const struct dirent *d)

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -16,9 +16,7 @@
 #include "fabrics.h"
 #include "mi.h"
 
-
 const char *nvme_subsys_sysfs_dir(void);
-const char *nvme_ctrl_sysfs_dir(void);
 const char *nvme_ns_sysfs_dir(void);
 const char *nvme_slots_sysfs_dir(void);
 const char *nvme_uuid_ibm_filename(void);

--- a/src/nvme/sysfs.h
+++ b/src/nvme/sysfs.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libnvme.
+ */
+
+#ifndef _LIBNVME_SYSFS_H
+#define _LIBNVME_SYSFS_H
+
+/**
+ * DOC: sysfs.h
+ *
+ * libnvme sysfs directory
+ */
+
+/**
+ * nvme_ctrl_sysfs_dir() - Return for a NVMe controller sysfs directory
+ *
+ * Return: NVMe controller sysfs directory
+ */
+const char *nvme_ctrl_sysfs_dir(void);
+
+#endif /* _LIBNVME_SYSFS_H */

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -34,6 +34,7 @@
 #include "util.h"
 #include "fabrics.h"
 #include "log.h"
+#include "sysfs.h"
 #include "private.h"
 
 /**


### PR DESCRIPTION
The path is returned with the controller name by the nvme scan. To return the path without the nvme scan nvme identify namespace.