### PR TITLE
tree: fix lba_count size calculation

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2442,11 +2442,12 @@ static int nvme_ns_init(const char *path, struct nvme_ns *ns)
 {
 	_cleanup_free_ char *attr = NULL;
 	struct stat sb;
+	uint64_t size;
 	int ret;
 
 	struct sysfs_attr_table base[] = {
 		{ &ns->nsid,      nvme_strtou32,  true, "nsid" },
-		{ &ns->lba_count, nvme_strtou64,  true, "size" },
+		{ &size,          nvme_strtou64,  true, "size" },
 		{ &ns->lba_size,  nvme_strtou64,  true, "queue/logical_block_size" },
 		{ ns->eui64,      nvme_strtoeuid, false, "eui" },
 		{ ns->nguid,      nvme_strtouuid, false, "nguid" },
@@ -2458,6 +2459,11 @@ static int nvme_ns_init(const char *path, struct nvme_ns *ns)
 		return ret;
 
 	ns->lba_shift = GETSHIFT(ns->lba_size);
+	/*
+	 * size is in 512 bytes units and lba_count is in lba_size which are not
+	 * necessarily the same.
+	 */
+	ns->lba_count = size >> (ns->lba_shift - 9);
 
 	if (asprintf(&attr, "%s/csi", path) < 0)
 		return -errno;


### PR DESCRIPTION
The kernel reports the size in 512 byte units, which is might not match with lba_size.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/2260