### PR TITLE
tree: fix mem leak in nvme_ns_init()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2488,7 +2488,7 @@ static int nvme_ns_init(const char *path, struct nvme_ns *ns)
 		if (ret)
 			return ret;
 	} else {
-		struct nvme_id_ns *id;
+		_cleanup_free_ struct nvme_id_ns *id = NULL;
 		uint8_t flbas;
 
 		id = __nvme_alloc(sizeof(*ns));


### PR DESCRIPTION
Valgrind revealed a mem leak in nvme_ns_init() invoked by several nvme commands such as connect-all, list, disconnect-all, etc. Leak traced to the nvme_ns_id pointer not getting freed after use. Fix the same.