### PR TITLE
util: Add string constant for ENVME_CONNECT_IGNORED

### DIFF
--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -620,6 +620,7 @@ static const char * const libnvme_status[] = {
 	[ENVME_CONNECT_OPNOTSUPP] = "not supported",
 	[ENVME_CONNECT_CONNREFUSED] = "connection refused",
 	[ENVME_CONNECT_ADDRNOTAVAIL] = "cannot assign requested address",
+	[ENVME_CONNECT_IGNORED] = "connection ignored",
 };
 
 const char *nvme_errno_to_string(int status)


### PR DESCRIPTION
for use through nvme_errno_to_string().