### PR TITLE
split logging from root object

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 LIBNVME_1.9 {
 	global:
+		nvme_ctrl_get_cntlid;
 		nvme_export_tls_key;
 		nvme_get_logging_level;
 		nvme_import_tls_key;
 		nvme_read_key;
 		nvme_scan_tls_keys;
-		nvme_submit_passthru;
 		nvme_submit_passthru64;
+		nvme_submit_passthru;
 		nvme_update_key;
-		nvme_ctrl_get_cntlid;
 };
 
 LIBNVME_1_8 {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+LIBNVME_1.10 {
+	global:
+		nvme_init_default_logging;
+};
+
 LIBNVME_1.9 {
 	global:
 		nvme_ctrl_get_cntlid;

--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -633,7 +633,7 @@ int json_dump_tree(nvme_root_t r)
 	}
 	json_object_object_add(json_root, "hosts", host_array);
 
-	ret = json_object_to_fd(fileno(r->fp), json_root, JSON_C_TO_STRING_PRETTY);
+	ret = json_object_to_fd(r->log.fd, json_root, JSON_C_TO_STRING_PRETTY);
 	if (ret < 0) {
 		nvme_msg(r, LOG_ERR, "Failed to write, %s\n",
 			 json_util_get_last_err());

--- a/src/nvme/log.c
+++ b/src/nvme/log.c
@@ -29,7 +29,7 @@
 static nvme_root_t root;
 
 void __attribute__((format(printf, 4, 5)))
-__nvme_msg(nvme_root_t r, int lvl,
+__nvme_msg(nvme_root_t r, int level,
 	   const char *func, const char *format, ...)
 {
 	FILE *fp = stderr;
@@ -56,9 +56,9 @@ __nvme_msg(nvme_root_t r, int lvl,
 	if (r)
 		fp = r->fp;
 
-	if (r && lvl > r->log_level)
+	if (r && level > r->log_level)
 		return;
-	if (!r && lvl > DEFAULT_LOGLEVEL)
+	if (!r && level > DEFAULT_LOGLEVEL)
 		return;
 
 	if (r && r->log_timestamp) {

--- a/src/nvme/log.h
+++ b/src/nvme/log.h
@@ -36,6 +36,18 @@
 void nvme_init_logging(nvme_root_t r, int lvl, bool log_pid, bool log_tstamp);
 
 /**
+ * nvme_init_default_logging() - Initialize default (fallback) logging
+ * @fp:		File descriptor for logging messages
+ * @lvl:	Logging level to set
+ * @log_pid:	Boolean to enable logging of the PID
+ * @log_tstamp:	Boolean to enable logging of the timestamp
+ *
+ * Sets the default logging settings for the library in case the root object
+ * is absent.
+ */
+void nvme_init_default_logging(FILE *fp, int lvl, bool log_pid, bool log_tstamp);
+
+/**
  * nvme_get_logging_level() - Get current logging level
  * @r:		nvme_root_t context
  * @log_pid:	Pointer to store a current value of logging of
@@ -59,24 +71,27 @@ int nvme_get_logging_level(nvme_root_t r, bool *log_pid, bool *log_tstamp);
  * will be set as well. This means the global root object is always pointing to
  * the latest created root object. Note the first @nvme_free_tree call will reset
  * the global root object.
+ *
+ * This function is deprecated. Use nvme_init_default_logging or/and
+ * nvme_init_logging instead.
  */
-void nvme_set_root(nvme_root_t r);
+void nvme_set_root(nvme_root_t r) __attribute__((deprecated));
 
 /**
  * nvme_set_debug - Set NVMe command debugging output
  * @debug:	true to enable or false to disable
  *
- * Don't use it, it's debricated.
+ * This function is deprecated. Use nvme_init_default_logging instead.
  */
-void nvme_set_debug(bool debug);
+void nvme_set_debug(bool debug) __attribute__((deprecated));
 
 /**
  * nvme_get_debug - Get NVMe command debugging output
  *
- * Don't use it, it's debricated.
+ * This function is deprecated. Use nvme_get_logging_level instead.
  *
  * Return: false if disabled or true if enabled.
  */
-bool nvme_get_debug(void);
+bool nvme_get_debug(void) __attribute__((deprecated));
 
 #endif /* _LOG_H */

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -198,14 +198,10 @@ void *__nvme_realloc(void *p, size_t len);
 #endif
 
 void __attribute__((format(printf, 4, 5)))
-__nvme_msg(nvme_root_t r, int lvl, const char *func, const char *format, ...);
+__nvme_msg(nvme_root_t r, int level, const char *func, const char *format, ...);
 
-#define nvme_msg(r, lvl, format, ...)					\
-	do {								\
-		if ((lvl) <= MAX_LOGLEVEL)				\
-			__nvme_msg(r, lvl, __nvme_log_func,		\
-				   format, ##__VA_ARGS__);		\
-	} while (0)
+#define nvme_msg(r, level, format, ...)					\
+	__nvme_msg(r, level, __nvme_log_func, format, ##__VA_ARGS__)
 
 #define root_from_ctrl(c) ((c)->s && (c)->s->h ? (c)->s->h->r : NULL)
 #define root_from_ns(n) ((n)->s && (n)->s->h ? (n)->s->h->r : \

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -160,15 +160,19 @@ struct nvme_fabric_options {
 	bool trsvcid;
 };
 
+struct nvme_log {
+	int fd;
+	int level;
+	bool pid;
+	bool timestamp;
+};
+
 struct nvme_root {
 	char *config_file;
 	char *application;
 	struct list_head hosts;
 	struct list_head endpoints; /* MI endpoints */
-	FILE *fp;
-	int log_level;
-	bool log_pid;
-	bool log_timestamp;
+	struct nvme_log log;
 	bool modified;
 	bool mi_probe_enabled;
 	struct nvme_fabric_options *options;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -187,19 +187,30 @@ int nvme_scan_topology(struct nvme_root *r, nvme_scan_filter_t f, void *f_args)
 
 nvme_root_t nvme_create_root(FILE *fp, int log_level)
 {
-	struct nvme_root *r = calloc(1, sizeof(*r));
+	struct nvme_root *r;
+	int fd;
 
+	r = calloc(1, sizeof(*r));
 	if (!r) {
 		errno = ENOMEM;
 		return NULL;
 	}
-	r->log_level = log_level;
-	r->fp = stderr;
-	if (fp)
-		r->fp = fp;
+
+	if (fp) {
+		fd = fileno(fp);
+		if (fd < 0) {
+			free(r);
+			return NULL;
+		}
+	} else
+		fd = STDERR_FILENO;
+
+	r->log.fd = fd;
+	r->log.level = log_level;
+
 	list_head_init(&r->hosts);
 	list_head_init(&r->endpoints);
-	nvme_set_root(r);
+
 	return r;
 }
 
@@ -368,7 +379,6 @@ void nvme_free_tree(nvme_root_t r)
 		free(r->config_file);
 	if (r->application)
 		free(r->application);
-	nvme_set_root(NULL);
 	free(r);
 }
 


### PR DESCRIPTION
Let's refactor the logging out from the root object and accept the full defeat against no global variables fight.