### PR TITLE
tree: Fix unaligned access UBSan error.

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2356,7 +2356,7 @@ static int nvme_strtou64(const char *str, void *res)
 		return -EINVAL;
 	}
 
-	*(__u64 *)res = v;
+	memcpy(res, &v, sizeof(__u64));
 	return 0;
 }
 


### PR DESCRIPTION
If libnvme is built with `-fsanitize=undefined` then `make test` produces the following error during test/sysfs/sysfs.c execution:
`../src/nvme/tree.c:2359:16: runtime error: store to misaligned address ... for type '__u64', which requires 8 byte alignment`.

Full stacktrace:
    #0 0x7bb4cd722084 in nvme_strtou64 ../src/nvme/tree.c:2359
    #1 0x7bb4cd7221c6 in parse_attrs ../src/nvme/tree.c:2439
    #2 0x7bb4cd734b96 in nvme_ns_init ../src/nvme/tree.c:2464
    #3 0x7bb4cd735ba0 in nvme_ns_open ../src/nvme/tree.c:2540
    #4 0x7bb4cd735ba0 in __nvme_scan_namespace ../src/nvme/tree.c:2599
    #5 0x7bb4cd737f29 in nvme_ctrl_scan_namespace ../src/nvme/tree.c:2626
    #6 0x7bb4cd737f29 in nvme_ctrl_scan_namespaces ../src/nvme/tree.c:1686
    #7 0x7bb4cd73974e in nvme_scan_ctrl ../src/nvme/tree.c:2028
    #8 0x7bb4cd73a34f in nvme_scan_topology ../src/nvme/tree.c:155
    #9 0x57544bb0414c in main ../test/sysfs/sysfs.c:18
    #10 0x7bb4cd491ccf  (/usr/lib/libc.so.6+0x25ccf) (BuildId: 6542915cee3354fbcf2b3ac5542201faec43b5c9)
    #11 0x7bb4cd491d89 in __libc_start_main (/usr/lib/libc.so.6+0x25d89) (BuildId: 6542915cee3354fbcf2b3ac5542201faec43b5c9)
    #12 0x57544bb04244 in _start (/work/libnvme/.build/test/sysfs/sysfs-tree-print+0x1244) (BuildId: 82824fda0809196e9e4bdc1563a1a52d72e06c41)
