### PR TITLE
linux: Fix uninitialized variables

### DIFF
--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -296,8 +296,8 @@ int nvme_get_new_host_telemetry(int fd, struct nvme_telemetry_log **log,
 
 int nvme_get_lba_status_log(int fd, bool rae, struct nvme_lba_status_log **log)
 {
+	_cleanup_free_ struct nvme_lba_status_log *buf = NULL;
 	__u32 size;
-	_cleanup_free_ struct nvme_lba_status_log *buf;
 	void *tmp;
 	int err;
 	struct nvme_get_log_args args = {

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -166,7 +166,7 @@ int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae, size_t max_
 
 	struct nvme_telemetry_log *telem;
 	enum nvme_cmd_get_log_lid lid;
-	_cleanup_free_ void *log;
+	_cleanup_free_ void *log = NULL;
 	void *tmp;
 	int err;
 	size_t dalb;

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1591,8 +1591,8 @@ nvme_ctrl_t __nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 			       const char *host_iface, const char *trsvcid,
 			       const char *subsysnqn, nvme_ctrl_t p)
 {
+	_cleanup_candidate_ struct candidate_args candidate = {};
 	struct nvme_ctrl *c, *matching_c = NULL;
-	_cleanup_candidate_ struct candidate_args candidate;
 	ctrl_match_t ctrl_match;
 
 	/* Init candidate and get the matching function to use */
@@ -1615,8 +1615,8 @@ bool nvme_ctrl_config_match(struct nvme_ctrl *c, const char *transport,
 			    const char *subsysnqn, const char *host_traddr,
 			    const char *host_iface)
 {
+	_cleanup_candidate_ struct candidate_args candidate = {};
 	ctrl_match_t ctrl_match;
-	_cleanup_candidate_ struct candidate_args candidate;
 
 	/* Init candidate and get the matching function to use */
 	ctrl_match = _candidate_init(&candidate, transport, traddr, trsvcid,


### PR DESCRIPTION
In file included from ../src/nvme/linux.c:40:
In function ‘freep’,
    inlined from ‘nvme_get_telemetry_log’ at ../src/nvme/linux.c:169:23:
../src/nvme/cleanup.h:24:9: warning: ‘log’ may be used uninitialized [-Wmaybe-uninitialized]
   24 |         free(*(void **)p);
      |         ^~~~~~~~~~~~~~~~~
../src/nvme/linux.c: In function ‘nvme_get_telemetry_log’:
../src/nvme/linux.c:169:30: note: ‘log’ was declared here
  169 |         _cleanup_free_ void *log;
      |                              ^~~