### PR TITLE
examples: Include sys/stat.h for S_I* constants

### DIFF
--- a/examples/telemetry-listen.c
+++ b/examples/telemetry-listen.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <libnvme.h>
+#include <sys/stat.h>
 
 #include <ccan/endian/endian.h>
 


### PR DESCRIPTION
POSIX says that these constants are defined in sys/stat.h. On Linux with glibc and musl this is also defined in fcntl.h. Other systems define it only in sys/stat.h, so include that as well. The Linux headers ensure that the first of sys/stat.h or fcntl.h define the constant, so it's harmless to include both.

For the latest standard, IEEE Std 1003.1-2017, see https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fcntl.h.html and
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html for details.