### PR TITLE
mi.h: Use ccan/endian/endian.h instead of endian.h

### DIFF
--- a/ccan/ccan/endian/endian.h
+++ b/ccan/ccan/endian/endian.h
@@ -104,8 +104,10 @@ static inline uint64_t bswap_64(uint64_t val)
 #endif
 
 /* Needed for Glibc like endiness check */
+#ifndef __LITTLE_ENDIAN
 #define	__LITTLE_ENDIAN	1234
 #define	__BIG_ENDIAN	4321
+#endif
 
 /* Sanity check the defines.  We don't handle weird endianness. */
 #if !HAVE_LITTLE_ENDIAN && !HAVE_BIG_ENDIAN


### PR DESCRIPTION
[[ edited ]]
When both endian.h and ccan/endian/endian.h are included, we can have
__{BIG,LITTLE}_ENDIAN redefined when compiling with clang on FreeBSD.
Clang and gcc have moved to a predefine for endian orders. glibc defines
these the same as they are defied here, but that's an unsafe assumption
to make. Instead, only define them when __LITTLE_ENDIAN not defined as a
fallback to when the host does not define them in the standard system
headers.