### PR TITLE
mi: fix the rc for nvme_mi_scan_ep

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -638,6 +638,7 @@ int nvme_mi_admin_admin_passthru(nvme_mi_ctrl_t ctrl, __u8 opcode, __u8 flags,
 	struct nvme_mi_admin_req_hdr req_hdr;
 	struct nvme_mi_resp resp;
 	struct nvme_mi_req req;
+	unsigned int timeout_save;
 	int rc;
 	int direction = opcode & 0x3;
 	bool has_write_data = false;
@@ -662,11 +663,6 @@ int nvme_mi_admin_admin_passthru(nvme_mi_ctrl_t ctrl, __u8 opcode, __u8 flags,
 			has_write_data = true;
 		if (direction == NVME_DATA_TFR_CTRL_TO_HOST)
 			has_read_data = true;
-	}
-
-	if (timeout_ms > nvme_mi_ep_get_timeout(ctrl->ep)) {
-		/* Set timeout if user needs a bigger timeout */
-		nvme_mi_ep_set_timeout(ctrl->ep, timeout_ms);
 	}
 
 	nvme_mi_admin_init_req(&req, &req_hdr, ctrl->id, opcode);
@@ -700,7 +696,17 @@ int nvme_mi_admin_admin_passthru(nvme_mi_ctrl_t ctrl, __u8 opcode, __u8 flags,
 		resp.data_len = data_len;
 	}
 
+	/* if the user has specified a custom timeout, save the current
+	 * timeout and override
+	 */
+	if (timeout_ms != 0) {
+		timeout_save = nvme_mi_ep_get_timeout(ctrl->ep);
+		nvme_mi_ep_set_timeout(ctrl->ep, timeout_ms);
+	}
 	rc = nvme_mi_submit(ctrl->ep, &req, &resp);
+	if (timeout_ms != 0)
+		nvme_mi_ep_set_timeout(ctrl->ep, timeout_save);
+
 	if (rc)
 		return rc;
 

--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -327,7 +327,7 @@ int nvme_mi_scan_ep(nvme_mi_ep_t ep, bool force_rescan)
 
 	rc = nvme_mi_mi_read_mi_data_ctrl_list(ep, 0, &list);
 	if (rc)
-		return -1;
+		return rc;
 
 	n_ctrl = le16_to_cpu(list.num);
 	if (n_ctrl > NVME_ID_CTRL_LIST_MAX) {


### PR DESCRIPTION
nvme_mi_scan_ep should return error code of calling function.
This will help the upper layer know the reason of failure. 