### PR TITLE
Use C99 types for uint32_t

### DIFF
--- a/src/nvme/base64.c
+++ b/src/nvme/base64.c
@@ -7,6 +7,7 @@
  * Author: Hannes Reinecke <hare@suse.de>
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -29,7 +30,7 @@ static const char base64_table[65] =
 int base64_encode(const unsigned char *src, int srclen, char *dst)
 {
 	int i, bits = 0;
-	u_int32_t ac = 0;
+	uint32_t ac = 0;
 	char *cp = dst;
 
 	for (i = 0; i < srclen; i++) {
@@ -64,7 +65,7 @@ int base64_encode(const unsigned char *src, int srclen, char *dst)
  */
 int base64_decode(const char *src, int srclen, unsigned char *dst)
 {
-	u_int32_t ac = 0;
+	uint32_t ac = 0;
 	int i, bits = 0;
 	unsigned char *bp = dst;
 

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1513,10 +1513,10 @@ unsigned char *nvme_import_tls_key(const char *encoded_key, int *key_len,
 		return NULL;
 	}
 	crc = crc32(crc, decoded_key, decoded_len);
-	key_crc = ((u_int32_t)decoded_key[decoded_len]) |
-		((u_int32_t)decoded_key[decoded_len + 1] << 8) |
-		((u_int32_t)decoded_key[decoded_len + 2] << 16) |
-		((u_int32_t)decoded_key[decoded_len + 3] << 24);
+	key_crc = ((uint32_t)decoded_key[decoded_len]) |
+		((uint32_t)decoded_key[decoded_len + 1] << 8) |
+		((uint32_t)decoded_key[decoded_len + 2] << 16) |
+		((uint32_t)decoded_key[decoded_len + 3] << 24);
 	if (key_crc != crc) {
 		nvme_msg(NULL, LOG_ERR, "CRC mismatch (key %08x, crc %08x)",
 			 key_crc, crc);


### PR DESCRIPTION
<stdint.h> provides `uint32_t`, while `u_int_32` is an unofficial/internal typedef that glibc happens to provide. This fixes the build on musl.

Bug: https://bugs.gentoo.org/931194