### PR TITLE
mi: Probe quirks on first command submission

### DIFF
--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -506,8 +506,6 @@ nvme_mi_ep_t nvme_mi_open_mctp(nvme_root_t root, unsigned int netid, __u8 eid)
 	 */
 	ep->timeout = 5000;
 
-	nvme_mi_ep_probe(ep);
-
 	return ep;
 
 err_free_rspbuf:

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -256,6 +256,7 @@ struct nvme_mi_ep {
 	void *transport_data;
 	struct list_node root_entry;
 	struct list_head controllers;
+	bool quirks_probed;
 	bool controllers_scanned;
 	unsigned int timeout;
 	unsigned int mprt_max;


### PR DESCRIPTION
Currently drive quirks are probed when opening a connection to the MI endpoint. The probe itself is the only IO that's required in the process of establishing the connection. We have an opportunity to make connection-establishment non-blocking if we can move the probe IO elsewhere.

We know the user is expecting IO to the endpoint when they issue a command. Given this, exploit the call to nvme_mi_submit() to establish the drive quirks.