### PR TITLE
Change commit order on release

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -12,9 +12,6 @@ copyright = '2020, Keith Busch'
 author = 'Keith Busch <kbusch@kernel.org>'
 master_doc = 'index'
 
-release = '@VERSION@'
-
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
Let's reorder the release commits, so that the last commit is actually the version string update. The only reason for the previous order was the version string was used in the documentation. Though there are none, only the date is used.

Fixes: #832