### PR TITLE
ANA log page fixes, round 2

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,3 +1,8 @@
+LIBNVME_MI_1_10 {
+	global:
+		nvme_mi_admin_get_ana_log_atomic;
+};
+
 LIBNVME_MI_1_5 {
 	global:
 		nvme_mi_ctrl_id;

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -3,6 +3,7 @@ LIBNVME_1.10 {
 	global:
 		nvme_free_uri;
 		nvme_get_ana_log_atomic;
+		nvme_get_ana_log_len_from_id_ctrl;
 		nvme_init_default_logging;
 		nvme_parse_uri;
 		nvme_root_skip_namespaces;

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -129,6 +129,16 @@ int nvme_get_new_host_telemetry(int fd,  struct nvme_telemetry_log **log,
 		enum nvme_telemetry_da da, size_t *size);
 
 /**
+ * nvme_get_ana_log_len_from_id_ctrl() - Retrieve maximum possible ANA log size
+ * @id_ctrl:	Controller identify data
+ * @rgo:	If true, return maximum log page size without NSIDs
+ *
+ * Return: A byte limit on the size of the controller's ANA log page
+ */
+size_t nvme_get_ana_log_len_from_id_ctrl(const struct nvme_id_ctrl *id_ctrl,
+					 bool rgo);
+
+/**
  * nvme_get_ana_log_len() - Retrieve size of the current ANA log
  * @fd:		File descriptor of nvme device
  * @analen:	Pointer to where the length will be set on success


### PR DESCRIPTION
A couple last changes required on top of #841 to allow `nvme-cli` to use this functionality