### PR TITLE
linux: avoid potential null pointer dereference

### DIFF
--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -1144,7 +1144,7 @@ void *__nvme_realloc(void *p, size_t len)
 
 	void *result = __nvme_alloc(len);
 
-	if (p) {
+	if (p && result) {
 		memcpy(result, p, min(old_len, len));
 		free(p);
 	}


### PR DESCRIPTION
if the "result" pointer is null because of a memory allocation failure, do not dereference it and do not free the old pointer.