### PR TITLE
tree: fix segfault in nvme_free_tree()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -377,14 +377,17 @@ void nvme_free_tree(nvme_root_t r)
 {
 	struct nvme_host *h, *_h;
 
-	free(r->options);
-	nvme_for_each_host_safe(r, h, _h)
-		__nvme_free_host(h);
-	if (r->config_file)
-		free(r->config_file);
-	if (r->application)
-		free(r->application);
-	free(r);
+	if (r) {
+		if (r->options)
+			free(r->options);
+		nvme_for_each_host_safe(r, h, _h)
+			__nvme_free_host(h);
+		if (r->config_file)
+			free(r->config_file);
+		if (r->application)
+			free(r->application);
+		free(r);
+	}
 }
 
 void nvme_root_release_fds(nvme_root_t r)


### PR DESCRIPTION
Commands like nvme list & list-subsys segfault when run with the -h or invalid command options:

...

  [  --timeout=<NUM>, -t <NUM> ]        --- timeout value,
Segmentation fault (core dumped)

Fix this by ensuring nvme_root_t object exists before dereferencing its members and freeing it.