### PR TITLE
tree: fix segfault in nvme_free_tree()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -377,14 +377,17 @@ void nvme_free_tree(nvme_root_t r)
 {
 	struct nvme_host *h, *_h;
 
-	free(r->options);
-	nvme_for_each_host_safe(r, h, _h)
-		__nvme_free_host(h);
-	if (r->config_file)
-		free(r->config_file);
-	if (r->application)
-		free(r->application);
-	free(r);
+	if (r) {
+		if (r->options)
+			free(r->options);
+		nvme_for_each_host_safe(r, h, _h)
+			__nvme_free_host(h);
+		if (r->config_file)
+			free(r->config_file);
+		if (r->application)
+			free(r->application);
+		free(r);
+	}
 }
 
 void nvme_root_release_fds(nvme_root_t r)


### PR DESCRIPTION
Commands like nvme list & list-subsys segfault for the --help option or any invalid command option for that matter:

nvme list -h
...

Segmentation fault (core dumped)

Fix this segfault by ensuring nvme_root_t object exists before dereferencing and freeing it. And while we are it, ensure r->options also exists before freeing it.