### PR TITLE
linux: add nvme_revoke_tls_key

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -6,6 +6,7 @@ LIBNVME_1.10 {
 		nvme_get_ana_log_len_from_id_ctrl;
 		nvme_init_default_logging;
 		nvme_parse_uri;
+		nvme_revoke_tls_key;
 		nvme_root_skip_namespaces;
 		nvmf_hostid_generate;
 		nvmf_hostnqn_generate_from_hostid;

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1363,6 +1363,24 @@ long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
 	return key;
 }
 
+long nvme_revoke_tls_key(const char *keyring, const char *key_type,
+			 const char *identity)
+{
+	key_serial_t keyring_id;
+	long key;
+
+	keyring_id = nvme_lookup_keyring(keyring);
+	if (keyring_id == 0) {
+		errno = ENOKEY;
+		return 0;
+	}
+
+	key = keyctl_search(keyring_id, key_type, identity, 0);
+	if (key < 0)
+		return -1;
+
+	return keyctl_revoke(key);
+}
 #else
 long nvme_lookup_keyring(const char *keyring)
 {
@@ -1421,6 +1439,15 @@ long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
 				   const char *hostnqn, const char *subsysnqn,
 				   int version, int hmac,
 				   unsigned char *configured_key, int key_len)
+{
+	nvme_msg(NULL, LOG_ERR, "key operations not supported; "
+		 "recompile with keyutils support.\n");
+	errno = ENOTSUP;
+	return -1;
+}
+
+long nvme_revoke_tls_key(const char *keyring, const char *key_type,
+			 const char *identity)
 {
 	nvme_msg(NULL, LOG_ERR, "key operations not supported; "
 		 "recompile with keyutils support.\n");

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -412,6 +412,17 @@ char *nvme_generate_tls_key_identity(const char *hostnqn, const char *subsysnqn,
 				     unsigned char *configured_key, int key_len);
 
 /**
+ * nvme_revoke_tls_key() - Revoke TLS key from keyring
+ * @keyring:    Keyring to use
+ * @key_type:    Type of the key to revoke
+ * @identity:    Key identity string
+ *
+ * Return: 0 on success or on failure -1 with errno set.
+ */
+long nvme_revoke_tls_key(const char *keyring, const char *key_type,
+			 const char *identity);
+
+/**
  * nvme_export_tls_key() - Export a TLS key
  * @key_data:	Raw data of the key
  * @key_len:	Length of @key_data


### PR DESCRIPTION
Add a functio to revoke a TLS key from a keyring.

see #https://github.com/linux-nvme/nvme-cli/issues/2365