### PR TITLE
types: add new field added in TP4090

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -2298,7 +2298,7 @@ enum nvme_id_nsfeat {
 	NVME_NS_FEAT_NATOMIC		= 1 << 1,
 	NVME_NS_FEAT_DULBE		= 1 << 2,
 	NVME_NS_FEAT_ID_REUSE		= 1 << 3,
-	NVME_NS_FEAT_IO_OPT		= 1 << 4,
+	NVME_NS_FEAT_IO_OPT		= 3 << 4,
 };
 
 /**
@@ -2723,7 +2723,8 @@ struct nvme_id_ctrl_nvm {
  * @pifa:	Protection Information Format Attribute
  * @rsvd10:	Reserved
  * @elbaf:	List of Extended LBA Format Support
- * @rsvd268:	Reserved
+ * @npdgl:	Namespace Preferred Deallocate Granularity Large
+ * @rsvd272:	Reserved
  */
 struct nvme_nvm_id_ns {
 	__le64	lbstm;
@@ -2731,7 +2732,8 @@ struct nvme_nvm_id_ns {
 	__u8	pifa;
 	__u8	rsvd10[2];
 	__le32	elbaf[64];
-	__u8	rsvd268[3828];
+	__le32	npdgl;
+	__u8	rsvd272[3824];
 };
 
 /**


### PR DESCRIPTION
As per TP4090, a new field support is added as NPDGL (Namespace Preferred Deallocate Granularity Large) and so the bit-field of NSFEAT, OPTPERF get extended by 1 bit.


Reviewed-by: Steven Seungcheol Lee <sc108.lee@samsung.com>
Reviewed-by: Mohit Kapoor <mohit.kap@samsung.com>