### PR TITLE
types: add new field added in TP4099

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -1570,6 +1570,7 @@ enum nvme_id_ctrl_oaes {
  * @NVME_CTRL_CTRATT_DEL_ENDURANCE_GROUPS: Delete Endurance Groups supported
  * @NVME_CTRL_CTRATT_DEL_NVM_SETS: Delete NVM Sets supported
  * @NVME_CTRL_CTRATT_ELBAS: Extended LBA Formats supported
+ * @NVME_CTRL_CTRATT_MEM: MDTS and Size Limits Exclude Metadata supported
  * @NVME_CTRL_CTRATT_FDPS: Flexible Data Placement supported
  */
 enum nvme_id_ctrl_ctratt {
@@ -1589,6 +1590,7 @@ enum nvme_id_ctrl_ctratt {
 	NVME_CTRL_CTRATT_DEL_ENDURANCE_GROUPS	= 1 << 13,
 	NVME_CTRL_CTRATT_DEL_NVM_SETS		= 1 << 14,
 	NVME_CTRL_CTRATT_ELBAS			= 1 << 15,
+	NVME_CTRL_CTRATT_MEM			= 1 << 16,
 	NVME_CTRL_CTRATT_FDPS			= 1 << 19,
 };
 


### PR DESCRIPTION
As per TP4090, a new field is added as MEM (MDTS and Size Limits Exclude Metadata) under nvme_id_ctrl_ctratt.


Reviewed-by: Steven Seungcheol Lee <sc108.lee@samsung.com>
Reviewed-by: Mohit Kapoor <mohit.kap@samsung.com>