### PR TITLE
linux: Remove the use of OpenSSL Engine API

### DIFF
--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -18,7 +18,6 @@
 #include <unistd.h>
 
 #ifdef CONFIG_OPENSSL
-#include <openssl/engine.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/kdf.h>
@@ -738,9 +737,6 @@ int nvme_gen_dhchap_key(char *hostnqn, enum nvme_hmac_alg hmac,
 	const char hmac_seed[] = "NVMe-over-Fabrics";
 	_cleanup_hmac_ctx_ HMAC_CTX *hmac_ctx = NULL;
 	const EVP_MD *md;
-
-	ENGINE_load_builtin_engines();
-	ENGINE_register_all_complete();
 
 	hmac_ctx = HMAC_CTX_new();
 	if (!hmac_ctx) {


### PR DESCRIPTION
OpenSSL engines are not FIPS compatible and corresponding API is deprecated since OpenSSL 3.0. It appears this API is not actually used in the code, so remove it.

----

This is a wild shot and I wouldn't pretend I know what I'm doing. This simple change does however seem to do the trick. Tested only against openssl 3.0. Affects `nvme_gen_dhchap_key()`, tested through `nvme gen-dhchap-key`.

OpenSSL engine support is being removed from Fedora/CentOS Stream/RHEL.