### PR TITLE
mi: add service control primitive command

### DIFF
--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,3 +1,8 @@
+LIBNVME_MI_1_11 {
+	global:
+		nvme_mi_control;
+};
+
 LIBNVME_MI_1_10 {
 	global:
 		nvme_mi_admin_get_ana_log_atomic;


### PR DESCRIPTION
The `breaked` command will left the SSD in Transmit Mode.
Add API to send the `abort` command to exit the Transmit Mode to
avoid the SSD being stuck in the Transmit Mode.
