### PR TITLE
types: Added new field CSER in enum as per TP4167

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -3301,6 +3301,7 @@ struct nvme_cmd_effects_log {
  * @NVME_CMD_EFFECTS_NCC:	Namespace Capability Change
  * @NVME_CMD_EFFECTS_NIC:	Namespace Inventory Change
  * @NVME_CMD_EFFECTS_CCC:	Controller Capability Change
+ * @NVME_CMD_EFFECTS_CSER_MASK:	Command Submission and Execution Relaxations
  * @NVME_CMD_EFFECTS_CSE_MASK:	Command Submission and Execution
  * @NVME_CMD_EFFECTS_UUID_SEL:	UUID Selection Supported
  */
@@ -3310,7 +3311,8 @@ enum nvme_cmd_effects {
 	NVME_CMD_EFFECTS_NCC		= 1 << 2,
 	NVME_CMD_EFFECTS_NIC		= 1 << 3,
 	NVME_CMD_EFFECTS_CCC		= 1 << 4,
-	NVME_CMD_EFFECTS_CSE_MASK	= 3 << 16,
+	NVME_CMD_EFFECTS_CSER_MASK	= 3 << 14,
+	NVME_CMD_EFFECTS_CSE_MASK	= 7 << 16,
 	NVME_CMD_EFFECTS_UUID_SEL	= 1 << 19,
 };
 


### PR DESCRIPTION
As per TP4167, a new field is added as CSER (Command Submission and Execution Relaxations) under nvme_cmd_effects enum. Updated field value for NVME_CMD_EFFECTS_CSE_MASK as CSE takes 3 bits.

Reviewed-by: Mohit Kapoor <mohit.kap@samsung.com>