### PR TITLE
linux: Correct error handling for derive_psk_digest

### DIFF
--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1122,7 +1122,7 @@ static int derive_nvme_keys(const char *hostnqn, const char *subsysnqn,
 		ret = derive_psk_digest(hostnqn, subsysnqn, version, hmac,
 					retained, key_len,
 					digest, digest_len);
-		if (ret)
+		if (ret < 0)
 			return ret;
 		context = digest;
 	}


### PR DESCRIPTION
Treat only negative return values from derive_psk_digest () as errors.