### PR TITLE
libnvme: add lockdown log page support(LID : 0x14)

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2311,6 +2311,38 @@ static inline int nvme_get_log_persistent_event(int fd,
 }
 
 /**
+ * nvme_get_log_lockdown() - Retrieve lockdown Log
+ * @fd:			File descriptor of nvme device
+ * @cnscp:		Contents and Scope of Command and Feature Identifier Lists
+ * @lockdown_log:	Buffer to store the lockdown log
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+static inline int nvme_get_log_lockdown(int fd,
+			__u8 cnscp, struct nvme_lockdown_log *lockdown_log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = lockdown_log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_CMD_AND_FEAT_LOCKDOWN,
+		.len = sizeof(*lockdown_log),
+		.nsid = NVME_NSID_ALL,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = cnscp,
+		.uuidx = NVME_UUID_NONE,
+		.rae = false,
+		.ot = false,
+	};
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+}
+
+/**
  * nvme_set_features() - Set a feature attribute
  * @args:	&struct nvme_set_features_args argument structure
  *

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -2433,6 +2433,36 @@ static inline int nvme_mi_admin_get_log_persistent_event(nvme_mi_ctrl_t ctrl,
 }
 
 /**
+ * nvme_mi_admin_get_log_lockdown() - Retrieve lockdown Log
+ * @ctrl:		Controller to query
+ * @cnscp:		Contents and Scope of Command and Feature Identifier Lists
+ * @lockdown_log:	Buffer to store the lockdown log
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+static inline int nvme_mi_admin_get_log_lockdown(nvme_mi_ctrl_t ctrl,
+			__u8 cnscp, struct nvme_lockdown_log *lockdown_log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = lockdown_log,
+		.args_size = sizeof(args),
+		.lid = NVME_LOG_LID_CMD_AND_FEAT_LOCKDOWN,
+		.len = sizeof(*lockdown_log),
+		.nsid = NVME_NSID_ALL,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = cnscp,
+		.uuidx = NVME_UUID_NONE,
+		.rae = false,
+		.ot = false,
+	};
+	return nvme_mi_admin_get_log(ctrl, &args);
+}
+
+/**
  * nvme_mi_admin_security_send() - Perform a Security Send command on a
  * controller.
  * @ctrl: Controller to send command to

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4659,6 +4659,20 @@ struct nvme_supported_cap_config_list_log {
 };
 
 /**
+ * struct nvme_lockdown_log - Command and Feature Lockdown Log
+ * @cfila:	Contents of the Command and Feature Identifier List field in the log page.
+ * @rsvd1:	Reserved
+ * @lngth:	Length of Command and Feature Identifier List field
+ * @cfil:	Command and Feature Identifier List
+ */
+struct nvme_lockdown_log {
+	__u8	cfila;
+	__u8	rsvd1[2];
+	__u8	lngth;
+	__u8	cfil[508];
+};
+
+/**
  * struct nvme_resv_notification_log - Reservation Notification Log
  * @lpc:	Log Page Count
  * @rnlpt:	See &enum nvme_resv_notify_rnlpt.
@@ -4956,6 +4970,46 @@ enum nvme_fdp_config_fdpa {
 	NVME_FDP_CONFIG_FDPA_FDPVWC_MASK = 0x1,
 	NVME_FDP_CONFIG_FDPA_VALID_SHIFT = 7,
 	NVME_FDP_CONFIG_FDPA_VALID_MASK = 0x1,
+};
+
+/**
+ * enum nvme_lockdown_log_scope - lockdown log page scope attributes
+ * @NVME_LOCKDOWN_ADMIN_CMD:		Scope value for Admin commandS
+ * @NVME_LOCKDOWN_FEATURE_ID:		Scope value for Feature ID
+ * @NVME_LOCKDOWN_MI_CMD_SET:		Scope value for Management Interface commands
+ * @NVME_LOCKDOWN_PCI_CMD_SET:		Scope value for PCI commands
+ */
+enum nvme_lockdown_log_scope {
+	NVME_LOCKDOWN_ADMIN_CMD		= 0x0,
+	NVME_LOCKDOWN_FEATURE_ID	= 0x2,
+	NVME_LOCKDOWN_MI_CMD_SET	= 0x3,
+	NVME_LOCKDOWN_PCI_CMD_SET	= 0x4,
+};
+
+/**
+ * enum nvme_lockdown_log_contents - lockdown log page content attributes
+ * @NVME_LOCKDOWN_SUPPORTED_CMD:		Content value for Supported commands
+ * @NVME_LOCKDOWN_PROHIBITED_CMD:		Content value for prohibited commands
+ * @NVME_LOCKDOWN_PROHIBITED_OUTOFBAND_CMD:	Content value for prohibited side band commands
+ */
+enum nvme_lockdown_log_contents {
+	NVME_LOCKDOWN_SUPPORTED_CMD		= 0x0,
+	NVME_LOCKDOWN_PROHIBITED_CMD		= 0x1,
+	NVME_LOCKDOWN_PROHIBITED_OUTOFBAND_CMD	= 0x2,
+};
+
+/**
+ * enum nvme_lockdown_scope_contents - Lockdown Log shift and mask
+ * @NVME_LOCKDOWN_SS_SHIFT:	Lockdown log scope select Shift
+ * @NVME_LOCKDOWN_SS_MASK:	Lockdown log scope select Mask
+ * @NVME_LOCKDOWN_CS_SHIFT:	Lockdown log contents Shift
+ * @NVME_LOCKDOWN_CS_MASK:	Lockdown log contents Mask
+ */
+enum nvme_lockdown_scope_contents {
+	NVME_LOCKDOWN_SS_SHIFT	= 0,
+	NVME_LOCKDOWN_SS_MASK	= 0xf,
+	NVME_LOCKDOWN_CS_SHIFT	= 4,
+	NVME_LOCKDOWN_CS_MASK	= 0x3,
 };
 
 /**


### PR DESCRIPTION
Adding command APIs for inband, out of band, structures and enums for lockdown log page (LID : 0x14).