### PR TITLE
types: Added enum for SMVES event of PEL log

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4039,6 +4039,7 @@ struct nvme_persistent_event_entry {
  * @NVME_PEL_SET_FEATURE_EVENT:		Set Feature Event
  * @NVME_PEL_TELEMETRY_CRT:		Telemetry Log Create Event
  * @NVME_PEL_THERMAL_EXCURSION_EVENT:	Thermal Excursion Event
+ * @NVME_PEL_SANITIZE_MEDIA_VERIF_EVENT:Sanitize Media Verification Event
  * @NVME_PEL_VENDOR_SPECIFIC_EVENT:	Vendor Specific Event
  * @NVME_PEL_TCG_DEFINED_EVENT:		TCG Defined Event
  */
@@ -4056,6 +4057,7 @@ enum nvme_persistent_event_types {
 	NVME_PEL_SET_FEATURE_EVENT		= 0x0b,
 	NVME_PEL_TELEMETRY_CRT			= 0x0c,
 	NVME_PEL_THERMAL_EXCURSION_EVENT	= 0x0d,
+	NVME_PEL_SANITIZE_MEDIA_VERIF_EVENT	= 0x0e,
 	NVME_PEL_VENDOR_SPECIFIC_EVENT		= 0xde,
 	NVME_PEL_TCG_DEFINED_EVENT		= 0xdf,
 };


### PR DESCRIPTION
Added enum for Sanitize Media Verification Event Support (SMVES) field in Persistent Event Log.