### PR TITLE
TLS key changes cleanups

### DIFF
--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -434,11 +434,14 @@ int json_update_config(nvme_root_t r, const char *config_file)
 		}
 	}
 	if (!config_file) {
-		ret = json_object_to_fd(1, json_root, JSON_C_TO_STRING_PRETTY);
+		ret = json_object_to_fd(1, json_root,
+					JSON_C_TO_STRING_PRETTY |
+					JSON_C_TO_STRING_NOSLASHESCAPE);
 		printf("\n");
 	} else
 		ret = json_object_to_file_ext(config_file, json_root,
-					      JSON_C_TO_STRING_PRETTY);
+					      JSON_C_TO_STRING_PRETTY |
+					      JSON_C_TO_STRING_NOSLASHESCAPE);
 	if (ret < 0) {
 		nvme_msg(r, LOG_ERR, "Failed to write to %s, %s\n",
 			 config_file ? "stdout" : config_file,
@@ -592,7 +595,9 @@ int json_dump_tree(nvme_root_t r)
 	}
 	json_object_object_add(json_root, "hosts", host_array);
 
-	ret = json_object_to_fd(r->log.fd, json_root, JSON_C_TO_STRING_PRETTY);
+	ret = json_object_to_fd(r->log.fd, json_root,
+				JSON_C_TO_STRING_PRETTY |
+				JSON_C_TO_STRING_NOSLASHESCAPE);
 	if (ret < 0) {
 		nvme_msg(r, LOG_ERR, "Failed to write, %s\n",
 			 json_util_get_last_err());

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1604,79 +1604,6 @@ int __nvme_import_keys_from_config(nvme_host_t h, nvme_ctrl_t c,
 
 	return 0;
 }
-
-static char *__nvme_export_key(long keyring, long key_id, char **identity)
-{
-	_cleanup_free_ unsigned char *key = NULL;
-	int len, ver, hmac;
-	char type, *desc, *encoded_key;
-
-	key = nvme_read_key(keyring, key_id, &len);
-	if (!key) {
-		/*
-		 * Accessing the keyring is a priveleged opartion, thus it
-		 * might fail for a normal user, this is not an error.
-		 */
-		return NULL;
-	}
-
-	desc = nvme_describe_key_serial(key_id);
-	if (!desc) {
-		/*
-		 * Revoked keys don't return a description, thus ignore
-		 * them.
-		 */
-		return NULL;
-	}
-
-	if (sscanf(desc, "NVMe%01d%c%02d %*s", &ver, &type, &hmac) != 3)
-		return NULL;
-
-	encoded_key = nvme_export_tls_key_versioned(ver, hmac, key, len);
-	if (!encoded_key)
-		return NULL;
-
-	if (identity)
-		*identity = desc;
-	return encoded_key;
-}
-
-static void export_keys_to_config(nvme_ctrl_t c)
-{
-	char *identity = NULL, *encoded_key;
-
-	if (!c->cfg.tls)
-		return;
-	/*
-	 * Do not update the configuration blindly. The user could have
-	 * provided configuration, but they keys are not loaded into
-	 * keystore yet.
-	 */
-
-	encoded_key =
-	    __nvme_export_key(c->cfg.keyring, c->cfg.tls_key, &identity);
-	if (identity) {
-		nvme_ctrl_set_tls_key_identity(c, identity);
-		free(identity);
-	}
-	if (encoded_key) {
-		nvme_ctrl_set_tls_key(c, encoded_key);
-		free(encoded_key);
-	}
-}
-
-int __nvme_export_keys_to_config(nvme_root_t r)
-{
-	nvme_host_t h;
-	nvme_subsystem_t s;
-	nvme_ctrl_t c;
-
-	nvme_for_each_host(r, h)
-		nvme_for_each_subsystem(h, s)
-			nvme_subsystem_for_each_ctrl(s, c)
-				export_keys_to_config(c);
-	return 0;
-}
 #else
 long nvme_lookup_keyring(const char *keyring)
 {
@@ -1753,11 +1680,6 @@ long nvme_revoke_tls_key(const char *keyring, const char *key_type,
 
 int __nvme_import_keys_from_config(nvme_host_t h, nvme_ctrl_t c,
 				   long *keyring_id, long *key_id)
-{
-	return -ENOTSUP;
-}
-
-int __nvme_export_keys_to_config(nvme_root_t r)
 {
 	return -ENOTSUP;
 }

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -302,6 +302,5 @@ void __nvme_mi_mctp_set_ops(const struct __mi_mctp_socket_ops *newops);
 
 int __nvme_import_keys_from_config(nvme_host_t h, nvme_ctrl_t c,
 				   long *keyring_id, long *key_id);
-int __nvme_export_keys_to_config(nvme_root_t r);
 
 #endif /* _LIBNVME_PRIVATE_H */

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -346,20 +346,6 @@ int nvme_update_config(nvme_root_t r)
 
 int nvme_dump_config(nvme_root_t r)
 {
-	int err;
-
-	err = __nvme_export_keys_to_config(r);
-	if (err) {
-		if (err == -ENOTSUP) {
-			nvme_msg(r, LOG_NOTICE,
-				 "exporting keys to the configuration failed because keysutils is missing\n");
-		} else {
-			nvme_msg(r, LOG_ERR,
-				 "exporting keys to the configuration failed with %s\n",
-				 nvme_errno_to_string(err));
-		}
-	}
-
 	return json_update_config(r, NULL);
 }
 


### PR DESCRIPTION
A couple of small fixes to make the recent TLS key handling work in all cases. 

The first commit addresses the problem that the TLS key would always added to the config output. This doesn't make sense if the user only provided `--tls` on the command line. Thus we can rip out all the export code triggered from the `nvme_dump_config` path.

Second commit addresses the problem that the JSON output was not identically with the input. The TLS keys got additional encoded. That's unnecessary and nvme-cli already disabled this for the JSON output, so we should properly also do this in libnvme.