### PR TITLE
linux: do not return w/o OpenSSL support enabled

### DIFF
--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1681,7 +1681,10 @@ long nvme_revoke_tls_key(const char *keyring, const char *key_type,
 int __nvme_import_keys_from_config(nvme_host_t h, nvme_ctrl_t c,
 				   long *keyring_id, long *key_id)
 {
-	return -ENOTSUP;
+	*keyring_id = 0;
+	*key_id = 0;
+
+	return 0;
 }
 #endif
 


### PR DESCRIPTION
__nvme_import_keys_from_config is helper to import the TLS keys. When we don't have OpenSSL builds enabled, this should be a no op. Thus don't return an error in this case.

Fixes: #https://github.com/linux-nvme/nvme-cli/issues/2555