### PR TITLE
ioctl: Live Migration

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -170,6 +170,12 @@ LIBNVME_1_0 {
 		nvme_default_host;
 		nvme_dev_self_test;
 		nvme_dim_send;
+		nvme_lm_cdq;
+		nvme_lm_track_send;
+		nvme_lm_migration_send;
+		nvme_lm_migration_recv;
+		nvme_lm_set_features_ctrl_data_queue;
+		nvme_lm_get_features_ctrl_data_queue;
 		nvme_directive_recv;
 		nvme_directive_send;
 		nvme_directive_send_id_endir;

--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -962,4 +962,104 @@ struct nvme_dim_args {
 	__u8	tas;
 };
 
+/**
+ * struct nvme_lm_cdq_args - Arguments for Controller Data Queue (CDQ) command
+ * @result:	Set on completion to the command's CQE DWORD 0 controller response
+ * @data:	Pointer to data
+ * @args_size:	Length of structure
+ * @fd:		File descriptor of nvme device
+ * @timeout:	Timeout in ms
+ * @sel:	Select (SEL): This field specifies the type of management operation to perform.
+ * @sz:		Size of CDQ in dwords
+ * @cntlid:	Controller ID: This field specifies the ID of the controller to be used by the
+ *		specified Select (SEL) field.
+ * @cdqid:	Controller Data Queue ID (CDQID): This field specifies the ID of the CDQ to be used
+ *		for the specified Select (SEL) field.
+ */
+struct nvme_lm_cdq_args {
+	__u32	*result;
+	void	*data;
+	int	args_size;
+	int	fd;
+	__u32	timeout;
+	__u8	sel;
+	__u8	sz;
+	__u8	qt;
+	__u16	cntlid;
+	__u16	cdqid;
+};
+
+/**
+ * struct nvme_lm_track_send_args - Arguments for the Track Send command
+ * @result:	Set on completion to the command's CQE DWORD 0 controller response
+ * @args_size:	Length of structure
+ * @fd:		File descriptor of nvme device
+ * @timeout:	Timeout in ms
+ * @sel:	Select (SEL): This field specifies the type of management operation to perform
+ * @lact:	Logging Action (LACT): This field specifies the type of logging action to perform
+ * @cdqid:	Controller Data Queue ID (CDQID): This field specifies the ID of the CDQ to be used
+ *		for the logging action
+ */
+struct nvme_lm_track_send_args {
+	__u32	*result;
+	int	args_size;
+	int	fd;
+	__u32	timeout;
+	__u8	sel;
+	__u8	lact;
+	__u16	cdqid;
+};
+
+/**
+ * struct nvme_lm_migration_send_args - Arguments for the Migration Send command
+ * @result:	Set on completion to the command's CQE DWORD 0 controller response
+ * @data:	Pointer to data
+ * @args_size:	Length of structure
+ * @fd:		File descriptor of nvme device
+ * @timeout:	Timeout in ms
+ * @sel:	Select (SEL): This field specifies the type of management operation to perform
+ */
+struct nvme_lm_migration_send_args {
+	__u32	*result;
+	void	*data;
+	int	args_size;
+	int	fd;
+	__u32	timeout;
+	__u8	sel;
+	__u8	uidx;
+	bool	dudmq;
+	__u8	stype;
+	__u16	cntlid;
+	__u8	seqind;
+	__u8	csvi;
+	__u16	csuuidi;
+	__u64	offset;
+	__u32	numd;
+};
+
+/**
+ * struct nvme_lm_migration_recv_args - Arguments for the Migration Receive command
+ * @result:	Set on completion to the command's CQE DWORD 0 controller response
+ * @data:	Pointer to data
+ * @args_size:	Length of structure
+ * @fd:		File descriptor of nvme device
+ * @timeout:	Timeout in ms
+ * @sel:	Select (SEL): This field specifies the type of management operation to perform
+ */
+struct nvme_lm_migration_recv_args {
+	__u32	*result;
+	void	*data;
+	int	args_size;
+	int	fd;
+	__u32	timeout;
+	__u16	cntlid;
+	__u8	sel;
+	__u8	csvi;
+	__u8	csuidxp;
+	__u16	csuuidi;
+	__u64	offset;
+	__u8	uidx;
+	__u32	numd;
+};
+
 #endif /* _LIBNVME_API_TYPES_H */

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -4242,4 +4242,68 @@ int nvme_zns_append(struct nvme_zns_append_args *args);
  */
 int nvme_dim_send(struct nvme_dim_args *args);
 
+/**
+ * nvme_lm_cdq() - Controller Data Queue - Controller Data Queue command
+ * @args:	&struct nvme_lm_cdq_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.)
+ */
+int nvme_lm_cdq(struct nvme_lm_cdq_args *args);
+
+/**
+ * nvme_lm_track_send() - Track Send command
+ * @args:	&struct nvme_lm_track_send_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_track_send(struct nvme_lm_track_send_args *args);
+
+/**
+ * nvme_lm_migration_send() - Migration Send command
+ * @args:	&struct nvme_lm_migration_send_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_migration_send(struct nvme_lm_migration_send_args *args);
+
+/**
+ * nvme_lm_migration_recv - Migration Receive command
+ * @args:	&struct nvme_lm_migration_rev_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_migration_recv(struct nvme_lm_migration_recv_args *args);
+
+/**
+ * nvme_lm_set_features_ctrl_data_queue - Set Controller Datea Queue feature
+ * @fd:		File descriptor of nvme device
+ * @cdqid:	Controller Data Queue ID (CDQID)
+ * @hp:		Head Pointer
+ * @tpt:	Tail Pointer Trigger
+ * @etpt:	Enable Tail Pointer Trigger
+ * @result:	The command completions result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_set_features_ctrl_data_queue(int fd, __u16 cdqid, __u32 hp, __u32 tpt, bool etpt,
+					 __u32 *result);
+
+/**
+ * nvme_lm_get_features_ctrl_data_queue - Get Controller Data Queue feature
+ * @fd:		File descriptor of nvme device
+ * @cdqid:	Controller Data Queue ID (CDQID)
+ * @data:	Get Controller Data Queue feature data
+ * @result:	The command completions result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_get_features_ctrl_data_queue(int fd, __u16 cdqid,
+					 struct nvme_lm_ctrl_data_queue_fid_data *data,
+					 __u32 *result);
 #endif /* _LIBNVME_IOCTL_H */

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4413,6 +4413,7 @@ struct nvme_eg_event_aggregate_log {
  * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_ENDGRP:	Endurance Group Scope
  * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_DOMAIN:	Domain Scope
  * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_NSS:	NVM Subsystem Scope
+ * @NVME_FID_SUPPORTED_EFFECTS_SCOPE_CDQSCP:	Controller Data Queue Scope
  */
 enum nvme_fid_supported_effects {
 	NVME_FID_SUPPORTED_EFFECTS_FSUPP	= 1 << 0,
@@ -4429,6 +4430,7 @@ enum nvme_fid_supported_effects {
 	NVME_FID_SUPPORTED_EFFECTS_SCOPE_ENDGRP	= 1 << 3,
 	NVME_FID_SUPPORTED_EFFECTS_SCOPE_DOMAIN	= 1 << 4,
 	NVME_FID_SUPPORTED_EFFECTS_SCOPE_NSS	= 1 << 5,
+	NVME_FID_SUPPORTED_EFFECTS_SCOPE_CDQSCP	= 1 << 6,
 };
 
 /**
@@ -5965,6 +5967,8 @@ struct nvme_host_mem_buf_attrs {
  * @NVME_AER_ERROR:	Error event
  * @NVME_AER_SMART:	SMART / Health Status event
  * @NVME_AER_NOTICE:	Notice event
+ * @NVME_AER_IMMEDIATE:	Immediate
+ * @NVME_AER_ONESHOT:	One-Shot
  * @NVME_AER_CSS:	NVM Command Set Specific events
  * @NVME_AER_VS:	Vendor Specific event
  */
@@ -5972,6 +5976,8 @@ enum nvme_ae_type {
 	NVME_AER_ERROR				= 0,
 	NVME_AER_SMART				= 1,
 	NVME_AER_NOTICE				= 2,
+	NVME_AER_IMMEDIATE			= 3,
+	NVME_AER_ONESHOT			= 4,
 	NVME_AER_CSS				= 6,
 	NVME_AER_VS				= 7,
 };
@@ -7743,6 +7749,11 @@ static inline __u32 nvme_status_equals(int status, enum nvme_status_type type,
  * @nvme_admin_fabric_zoning_lookup:	Fabric Zoning Lookup
  * @nvme_admin_fabric_zoning_send:	Fabric Zoning Send
  * @nvme_admin_dbbuf:			Doorbell Buffer Config
+ * @nvme_admin_track_send:		Track Send
+ * @nvme_admin_track_receive:		Track Receive
+ * @nvme_admin_migration_send:		Migration Send
+ * @nvme_admin_migration_receive:	Migration Receive
+ * @nvme_admin_ctrl_data_queue:		Controller Data Queue
  * @nvme_admin_fabrics:			Fabrics Commands
  * @nvme_admin_format_nvm:		Format NVM
  * @nvme_admin_security_send:		Security Send
@@ -7779,6 +7790,11 @@ enum nvme_admin_opcode {
 	nvme_admin_lockdown		= 0x24,
 	nvme_admin_fabric_zoning_lookup	= 0x25,
 	nvme_admin_fabric_zoning_send	= 0x29,
+	nvme_admin_track_send		= 0x3d,
+	nvme_admin_track_receive	= 0x3e,
+	nvme_admin_migration_send	= 0x41,
+	nvme_admin_migration_receive	= 0x42,
+	nvme_admin_ctrl_data_queue	= 0x45,
 	nvme_admin_dbbuf		= 0x7c,
 	nvme_admin_fabrics		= 0x7f,
 	nvme_admin_format_nvm		= 0x80,
@@ -7975,6 +7991,7 @@ enum nvme_cmd_get_log_lid {
  * @NVME_FEAT_FID_SPINUP_CONTROL:	Spinup Control
  * @NVME_FEAT_FID_FDP:			Flexible Data Placement
  * @NVME_FEAT_FID_FDP_EVENTS:		FDP Events
+ * @NVME_FEAT_FID_CTRL_DATA_QUEUE:	Controller Data Queue
  * @NVME_FEAT_FID_ENH_CTRL_METADATA:	Enhanced Controller Metadata
  * @NVME_FEAT_FID_CTRL_METADATA:	Controller Metadata
  * @NVME_FEAT_FID_NS_METADATA:		Namespace Metadata
@@ -8013,6 +8030,7 @@ enum nvme_features_id {
 	NVME_FEAT_FID_SPINUP_CONTROL				= 0x1a,
 	NVME_FEAT_FID_FDP					= 0x1d,
 	NVME_FEAT_FID_FDP_EVENTS				= 0x1e,
+	NVME_FEAT_FID_CTRL_DATA_QUEUE				= 0x21,
 	NVME_FEAT_FID_ENH_CTRL_METADATA				= 0x7d,
 	NVME_FEAT_FID_CTRL_METADATA				= 0x7e,
 	NVME_FEAT_FID_NS_METADATA				= 0x7f,
@@ -9007,4 +9025,324 @@ struct nvme_ns_mgmt_host_sw_specified {
 };
 #endif /* SWIG */
 
+/**
+ * enum nvme_lm_select - Select (SEL): This field specifies the type of management operation to
+ * perform.
+ * @NVME_LM_SELECT_SHIFT:			Shift to set Select (SEL) field in all live
+ *						migration commands.
+ * @NVME_LM_SELECT_MASK:			Mask to set SEL field.
+ * @NVME_LM_CREATE_CONTROLLER_DATA_QUEUE:	Controller Data Queue - Create
+ * @NVME_LM_DELETE_CONTROLLER_DATA_QUEUE:	Controller Data Queue - Delete
+ * @NVME_LM_LOG_USER_DATA_CHANGES:		Track Send - Log User Data Changes
+ * @NVME_LM_TRACK_MEMORY_CHANGES:		Track Send - Track Memory Changes
+ * @NVME_LM_SUSPEND:				Migration Send - Suspend
+ * @NVME_LM_RESUME:				Migration Send - Resume
+ * @NVME_LM_SET_CONTROLLER_STATE:		Migration Send - Set Controller State
+ * @NVME_LM_GET_CONTROLLER_STATE:		Migration Receive - Get Controller State
+ */
+enum nvme_lm_select {
+	NVME_LM_SELECT_SHIFT			= 0,
+	NVME_LM_SELECT_MASK			= 0xff,
+	/* Controller Data Queue */
+	NVME_LM_CREATE_CONTROLLER_DATA_QUEUE	= 0,
+	NVME_LM_DELETE_CONTROLLER_DATA_QUEUE	= 1,
+	/* Track Send */
+	NVME_LM_LOG_USER_DATA_CHANGES		= 0,
+	NVME_LM_TRACK_MEMORY_CHANGES		= 1,
+	/* Migration Send */
+	NVME_LM_SUSPEND				= 0,
+	NVME_LM_RESUME				= 1,
+	NVME_LM_SET_CONTROLLER_STATE		= 2,
+	/* Migration Receive */
+	NVME_LM_GET_CONTROLLER_STATE		= 0,
+};
+
+/**
+ * enum nvme_lm_ctrl_data_queue - Controller Data Queue
+ * @NVME_LM_QUEUE_TYPE_USER_DATA_MIGRATION_QUEUE:	User Data Migration Queue type
+ * @NVME_LM_QUEUE_TYPE_SHIFT:				Shift amount to set Queue Type (QT) field
+ * @NVME_LM_QUEUE_TYPE_MASK:				Mask to set QT field
+ * @NVME_LM_CREATE_CDQ_PC:				Physically Contiguous
+ * @NVME_LM_CREATE_CDQ_CNTLID_SHIFT:			Shift amount to set CNTLID field
+ * @NVME_LM_CREATE_CDQ_CNTLID_MASK:			Mask to set CNTLID field
+ * @NVME_LM_CREATE_CDQ_CDQID_SHIFT:			Shift amount to get CDQID field from Create
+ *							response in completion dword0
+ * @NVME_LM_CREATE_CDQ_CDQID_MASK:			Mask to get CNTLID field from Create
+ *							response in completion dword0
+ * @NVME_LM_DELETE_CDQ_CDQID_SHIFT:			Shift amount to set CDQID field for deletion
+ * @NVME_LM_DELETE_CDQ_CDQID_MASK:			Mask to set CDQID field for deletion
+ *
+ */
+enum nvme_lm_ctrl_data_queue {
+	NVME_LM_QUEUE_TYPE_USER_DATA_MIGRATION_QUEUE	= 0,
+	NVME_LM_QUEUE_TYPE_SHIFT			= 16,
+	NVME_LM_QUEUE_TYPE_MASK				= 0xffff,
+	NVME_LM_CREATE_CDQ_PC				= 1,
+	NVME_LM_CREATE_CDQ_CNTLID_SHIFT			= 16,
+	NVME_LM_CREATE_CDQ_CNTLID_MASK			= 0xffff,
+	NVME_LM_CREATE_CDQ_CDQID_SHIFT			= 0,
+	NVME_LM_CREATE_CDQ_CDQID_MASK			= 0xffff,
+	NVME_LM_DELETE_CDQ_CDQID_SHIFT			= 0,
+	NVME_LM_DELETE_CDQ_CDQID_MASK			= 0xffff,
+};
+
+/**
+ * enum nvme_lm_logging_action - Track Send command - Logging Action (LACT)
+ * @NVME_LM_LACT_STOP_LOGGING:	The controller shall stop logging user data changes to namespaces
+ *				attached to the controller associated with the User Data Migration
+ *				Queue specified in the Controller Data Queue Identifier field.
+ * @NVME_LM_LACT_START_LOGGING:	The controller shall start logging user data changes to namespaces
+ *				attached to the controller associated with the User Data Migration
+ *				Queue into that User Data Migration Queue where those user data
+ *				changes are caused by the controller associated with that User Data
+ *				Migration Queue processing commands.
+ * @NVME_LM_LACT_MASK:		Mask to set Logging Action (LACT)
+ * @NVME_LM_LACT_SHIFT:		Shift to set LACT
+ */
+enum nvme_lm_logging_action {
+	NVME_LM_LACT_STOP_LOGGING			= 0,
+	NVME_LM_LACT_START_LOGGING			= 1,
+	NVME_LM_LACT_MASK				= 0xf,
+	NVME_LM_LACT_SHIFT				= 16,
+};
+
+/**
+ * enum nvme_lm_migration - Migration Send & Migration Receive command options and attributes
+ * @NVME_LM_MIGRATION_CNTLID_SHIFT:	Shift amount to set Controller ID (CNTLID)
+ * @NVME_LM_MIGRATION_CNTLID_MASK:	Mask to set CNTLID
+ * @NVME_LM_MIGRATION_UIDX_SHIFT:	Shift to set UUID Index (UIDX)
+ * @NVME_LM_MIGRATION_UIDX_MASK:	Mask to set UIDX
+ * @NVME_LM_DUDMQ:			Delete User Data Migration Queue (DUDMQ)
+ * @NVME_LM_DUDMQ_SHIFT:		Shift amount to set DUDMQ
+ * @NVME_LM_DUDMQ_MASK:			Mask to set DUDMQ
+ * @NVME_LM_STYPE_NOTIFICATION:		Suspend Type (STYPE) - Suspend Notification
+ * @NVME_LM_STYPE_SUSPEND:		Suspend Type (STYPE) - Suspend
+ * @NVME_LM_STYPE_SHIFT:		Shift amount to set STYPE
+ * @NVME_LM_STYPE_MASK:			Mask to set STYPE
+ * @NVME_LM_SEQIND_NOT_FIRST_NOT_LAST:	This command is not the first or last of a sequence two or
+ *					more Migration Send commands with this management operation
+ *					used to transfer the controller state from host to
+ *					controller
+ * @NVME_LM_SEQIND_FIRST:		This command is the first of a sequence of two or more
+ *					Migration Send commands
+ * @NVME_LM_SEQIND_LAST:		This command is the last command of a sequence of two or
+ *					more Migration Send commands
+ * @NVME_LM_SEQIND_ENTIRE:		This Migration Send command is the only command and contains
+ *					the entire controller state for this management operation
+ * @NVME_LM_SEQIND_SHIFT:		Shift amount to set SEQIND
+ * @NVME_LM_SEQIND_MASK:		Mask to set SEQIND
+ * @NVME_LM_MIGRATION_SEND_CSUUIDI_SHIFT: Shift amount to set Controller State UUID Index (CSUUIDI)
+ * @NVME_LM_MIGRATION_SEND_CSUUIDI_MASK:  Mask to set CSUUIDI
+ * @NVME_LM_MIGRATION_SEND_CSVI_SHIFT:	Shift amount to set Controller State Version Index (CSVI)
+ * @NVME_LM_MIGRATION_SEND_CSVI_MASK:	Mask to set CSVI
+ * @NVME_LM_MIGRATION_RECV_CSUIDXP_SHIFT: Shift amount to set Controller State UUID Index Parameter
+ *					  (CSUIDXP)
+ * @NVME_LM_MIGRATION_RECV_CSUIDXP_MASK:  Mask to set CSUIDXP
+ * @NVME_LM_MIGRATION_RECV_CSUUIDI_SHIFT: Shift amount to set Controller State UUID Index (CSUUIDI).-
+ * @NVME_LM_MIGRATION_RECV_CSUUIDI_MASK:  Mask to set CSUUIDI
+ * @NVME_LM_MIGRATION_RECV_CSVI_SHIFT:	Shift amount to set Controller State Version Index (CSVI)
+ * @NVME_LM_MIGRATION_RECV_CSVI_MASK:	Mask to set CSVI
+ * @NVME_LM_MIGRATION_RECV_CTRL_SUSPENDED: Controller Suspended
+ * @NVME_LM_MIGRATION_RECV_CTRL_SUSPENDED_SHIFT: Shift to get Controller Suspended value in
+ *						 completion dword0 of Migration Receive command
+ * @NVME_LM_MIGRATION_RECV_CTRL_SUSPENDED_MASK:  Mask to get Controller Suspended value in
+ *						 completion dword0 of Migration Receive command
+ */
+enum nvme_lm_migration {
+	NVME_LM_MIGRATION_CNTLID_SHIFT		= 0,
+	NVME_LM_MIGRATION_CNTLID_MASK		= 0xffff,
+	NVME_LM_MIGRATION_UIDX_SHIFT		= 0,
+	NVME_LM_MIGRATION_UIDX_MASK		= 0x7f,
+
+	/* Migration Send - Suspend */
+	NVME_LM_DUDMQ				= 1,
+	NVME_LM_DUDMQ_SHIFT			= 31,
+	NVME_LM_DUDMQ_MASK			= 0x1,
+	NVME_LM_STYPE_NOTIFICATION		= 0,
+	NVME_LM_STYPE_SUSPEND			= 1,
+	NVME_LM_STYPE_SHIFT			= 16,
+	NVME_LM_STYPE_MASK			= 0xff,
+
+	/* Migration Send - Set Controller State */
+	NVME_LM_SEQIND_NOT_FIRST_NOT_LAST	= 0,
+	NVME_LM_SEQIND_FIRST			= 1,
+	NVME_LM_SEQIND_LAST			= 2,
+	NVME_LM_SEQIND_ENTIRE			= 3,
+	NVME_LM_SEQIND_SHIFT			= 16,
+	NVME_LM_SEQIND_MASK			= 0xf,
+	NVME_LM_MIGRATION_SEND_CSUUIDI_SHIFT	= 24,
+	NVME_LM_MIGRATION_SEND_CSUUIDI_MASK	= 0xff,
+	NVME_LM_MIGRATION_SEND_CSVI_SHIFT	= 16,
+	NVME_LM_MIGRATION_SEND_CSVI_MASK	= 0xff,
+
+	/* Migration Receive - Get Controller State */
+	NVME_LM_MIGRATION_RECV_CSUIDXP_SHIFT	= 24,
+	NVME_LM_MIGRATION_RECV_CSUIDXP_MASK	= 0xff,
+	NVME_LM_MIGRATION_RECV_CSUUIDI_SHIFT	= 16,
+	NVME_LM_MIGRATION_RECV_CSUUIDI_MASK	= 0xff,
+	NVME_LM_MIGRATION_RECV_CSVI_SHIFT	= 16,
+	NVME_LM_MIGRATION_RECV_CSVI_MASK	= 0xff,
+	NVME_LM_MIGRATION_RECV_CTRL_SUSPENDED	= 1,
+	NVME_LM_MIGRATION_RECV_CTRL_SUSPENDED_SHIFT = 0,
+	NVME_LM_MIGRATION_RECV_CTRL_SUSPENDED_MASK = 0x1,
+};
+
+/**
+ * struct nvme_lm_io_submission_queue_data - I/O Submission Queue data structure. Fields related to
+ * the contents of Create I/O Submission Queue command that created an I/O Submission Queue.
+ * @prp1:   PRP Entry 1
+ * @qsize:  Queue Size
+ * @qid:    Queue Identifier
+ * @cqid:   Completion Queue Identifier
+ * @attrs:  Attributes
+ * @hp:	    Head Pointer
+ * @tp:	    Tail Pointer
+ * @rsvd20: Reserved
+ */
+struct nvme_lm_io_submission_queue_data {
+	__u64 prp1;
+	__u16 qsize;
+	__u16 qid;
+	__u16 cqid;
+	__u16 attrs;
+	__u16 hp;
+	__u16 tp;
+	__u8  rsvd20[4];
+};
+
+/**
+ * struct nvme_lm_io_completion_queue_data - I/O Completion Queue data structure. Fields related to
+ * the contents of Create I/O Completion Queue command that created an I/O Completion Queue.
+ * @prp1:   PRP Entry 1
+ * @qsize:  Queue Size
+ * @qid:    Queue Identifier
+ * @hp:	    Head Pointer
+ * @tp:	    Tail Pointer
+ * @attrs:  Attributes
+ * @rsvd20: Reserved
+ */
+struct nvme_lm_io_completion_queue_data {
+	__u64 prp1;
+	__u16 qsize;
+	__u16 qid;
+	__u16 hp;
+	__u16 tp;
+	__u32 attrs;
+	__u8  rsvd20[4];
+};
+
+/**
+ * struct nvme_lm_nvme_controller_state_data_header - Controller State data structure header
+ * @ver:   The version of this data structure.
+ * @niosq: The number of I/O Submission Queues contained in this data structure.
+ * @niocq: The number of I/O Completion Queues contained in this data structure.
+ * @rsvd6: Reserved
+ */
+struct nvme_lm_nvme_controller_state_data_header {
+	__u16 ver;
+	__u16 niosq;
+	__u16 niocq;
+	__u16 rsvd6;
+};
+
+/**
+ * struct nvme_lm_nvme_controller_state_data - NVMe Controller State data structure describes the
+ * state of a NVMe Controller's I/O Submission and I/O Completion queues
+ * @hdr: Header
+ * @sqs: I/O Submission Queue list
+ * @cqs: I/O Completion Queue list
+ */
+struct nvme_lm_nvme_controller_state_data {
+	struct nvme_lm_nvme_controller_state_data_header hdr;
+	union {
+		struct nvme_lm_io_submission_queue_data sqs[0];
+		struct nvme_lm_io_completion_queue_data cqs[0];
+	};
+};
+
+/**
+ * struct nvme_lm_controller_state_data_header - Controller State data header structure describes
+ * the contents of the Controller State data
+ * @ver:     Version of this data structure
+ * @csattr:  Controller state attributes
+ * @rsvd3:   Reserved
+ * @nvmecss: NVMe Controller state size in dwords
+ * @vss:     Vendor specific size in dowrds
+ */
+struct nvme_lm_controller_state_data_header {
+	__u16 ver;
+	__u8  csattr;
+	__u8  rsvd3[13];
+	__u8  nvmecss[16];
+	__u8  vss[16];
+};
+
+/**
+ * struct nvme_lm_controller_state_data - Controller State data structure contains data on the
+ * controller's state.
+ * @hdr:  Header
+ * @data: Data
+ */
+struct nvme_lm_controller_state_data {
+	struct nvme_lm_controller_state_data_header hdr;
+	struct nvme_lm_nvme_controller_state_data   data;
+};
+
+/**
+ * enum nvme_lm_queue_attributes - I/O Submission and I/O Completion Queue Attributes
+ * @NVME_LM_IOSQPC_MASK:	Mask to get the Physically Contiguous (PC) bit for this I/O
+ *				submission queue.
+ * @NVME_LM_IOSQPC_SHIFT:	Shift to get the PC bit for this I/O submission queue
+ * @NVME_LM_IOSQPRIO_MASK:	Mask to get the Priority for this I/O submission queue.
+ * @NVME_LM_IOSQPRIO_SHIFT:	Shift to get the Priority for this I/O submission queue.
+ * @NVME_LM_IOCQPC_MASK:	Mask to get the Physicaly Contiguous (PC) bit for this I/O
+ *				completion queue.
+ * @NVME_LM_IOCQPC_SHIFT:	Shift to get the PC bit for this I/O completion queue.
+ * @NVME_LM_IOCQIEN_MASK:	Mask to get the Interrupts Enabled bit for this I/O completion
+ *				queue
+ * @NVME_LM_IOCQIEN_SHIFT:	Shift to get the Interrupts Enabled bit for this I/O completion
+ * @NVME_LM_S0PT_MASK:		Mask to get the value of the Phase Tag bit for Slot 0 of this I/O
+ *				completion queue.
+ * @NVME_LM_S0PT_SHIFT:		Shift to get the value of the Phase Tag bit for Slot 0 of this I/O
+ *				completion queue.
+ * @NVME_LM_IOCQIV_MASK:	Mask to get the Interrupt Vector (IV) for this I/O completion
+ *				queue.
+ * @NVME_LM_IOCQIV_SHIFT:	Shift to get the IV for this I/O completion queue.
+ */
+enum nvme_lm_queue_attributes {
+	/* I/O Submission Queue */
+	NVME_LM_IOSQPC_MASK	= 0x1,
+	NVME_LM_IOSQPC_SHIFT	= 0,
+	NVME_LM_IOSQPRIO_MASK	= 0x3,
+	NVME_LM_IOSQPRIO_SHIFT	= 1,
+	/* I/O Completion Queue */
+	NVME_LM_IOCQPC_MASK	= 0x1,
+	NVME_LM_IOCQPC_SHIFT	= 0,
+	NVME_LM_IOCQIEN_MASK	= 0x1,
+	NVME_LM_IOCQIEN_SHIFT	= 1,
+	NVME_LM_S0PT_MASK	= 0x1,
+	NVME_LM_S0PT_SHIFT	= 2,
+	NVME_LM_IOCQIV_MASK	= 0xffff,
+	NVME_LM_IOCQIV_SHIFT	= 16,
+};
+
+/**
+ * enum nvme_lm_ctrl_data_queue_fid - Controller Data Queue - Set Feature
+ * @NVME_LM_CTRL_DATA_QUEUE_ETPT_MASK:	Mask to set Enable Tail Pointer Trigger (ETPT)
+ * @NVME_LM_CTRL_DATA_QUEUE_ETPT_SHIFT: Shift to set ETPT
+ */
+enum nvme_lm_ctrl_data_queue_fid {
+	NVME_LM_CTRL_DATA_QUEUE_ETPT_MASK	= 0x1,
+	NVME_LM_CTRL_DATA_QUEUE_ETPT_SHIFT	= 31,
+};
+
+/**
+ * struct nvme_lm_ctrl_data_queue_fid_data - Get Controller Data Queue feature data
+ * @hp:		Head Pointer
+ * @tpt:	Tail Pointer Trigger
+ */
+struct nvme_lm_ctrl_data_queue_fid_data {
+	__u32 hp;
+	__u32 tpt;
+};
 #endif /* _LIBNVME_TYPES_H */


### PR DESCRIPTION
Continues efforts from the newly minted TP4159 PCIe Infrastructure for Live Migration specification by adding additional types and ioctl methods.

Depends on completion of #913 