### PR TITLE
test: Add library dependency for dlsym

### DIFF
--- a/test/ioctl/meson.build
+++ b/test/ioctl/meson.build
@@ -1,6 +1,8 @@
+dl_dep = dependency('dl')
 mock_ioctl = library(
     'mock-ioctl',
     ['mock.c', 'util.c'],
+    dependencies: [dl_dep],
 )
 
 # Add mock-ioctl to the LD_PRELOAD path so it overrides libc.


### PR DESCRIPTION
Fix build failure for test

[27/79] Linking target test/ioctl/libmock-ioctl.so FAILED: test/ioctl/libmock-ioctl.so
cc  -o test/ioctl/libmock-ioctl.so test/ioctl/libmock-ioctl.so.p/mock.c.o test/ioctl/libmock-ioctl.so.p/util.c.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,--start-group -Wl,-soname,libmock-ioctl.so -Wl,--end-group test/ioctl/libmock-ioctl.so.p/mock.c.o: In function `ioctl': /root/Desktop/repo/libnvme_upstream/.build/../test/ioctl/mock.c:154: undefined reference to `dlsym'