### PR TITLE
rpm: use defined prefix from meson

### DIFF
--- a/libnvme.spec.in
+++ b/libnvme.spec.in
@@ -21,6 +21,8 @@ Provides: libnvme.so.1
 This package provides header files to include and libraries to link with
 for Linux-native nvme device maangement.
 
+%define _prefix @PREFIX@
+
 %prep
 %autosetup -c
 

--- a/meson.build
+++ b/meson.build
@@ -258,6 +258,7 @@ substs = configuration_data()
 substs.set('NAME',    meson.project_name())
 substs.set('VERSION', meson.project_version())
 substs.set('LICENSE', meson.project_license()[0])
+substs.set('PREFIX', prefixdir)
 configure_file(
     input:         'libnvme.spec.in',
     output:        'libnvme.spec',


### PR DESCRIPTION
meson use default prefix with /usr/local
so rpm default macro defined installation directoy occur error

RPM build errors:
    File not found: /root/rpmbuild/BUILDROOT/libnvme-1.11-0.x86_64/usr/lib64/libnvme*

To fix this use defined prefix from meson

#909 