### PR TITLE
tests: do not unconditionally depend on dlsym

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -246,6 +246,12 @@ conf.set(
     ),
     description: 'Is ioctl the glibc interface (rather than POSIX)'
 )
+dl_dep = dependency('dl', required: false)
+conf.set(
+    'HAVE_LIBC_DLSYM',
+    cc.has_function('dlsym', dependencies: dl_dep),
+    description: 'Is dlsym function present',
+)
 
 if cc.has_function_attribute('fallthrough')
   conf.set('fallthrough', '__attribute__((__fallthrough__))')

--- a/test/ioctl/meson.build
+++ b/test/ioctl/meson.build
@@ -1,6 +1,7 @@
 mock_ioctl = library(
     'mock-ioctl',
     ['mock.c', 'util.c'],
+    dependencies: [dl_dep]
 )
 
 # Add mock-ioctl to the LD_PRELOAD path so it overrides libc.

--- a/test/ioctl/mock.c
+++ b/test/ioctl/mock.c
@@ -151,9 +151,13 @@ int ioctl(int fd, int request, ...)
 		result64 = true;
 		break;
 	default:
+#if HAVE_LIBC_LDSYM
 		real_ioctl = dlsym(RTLD_NEXT, "ioctl");
 		if (!real_ioctl)
 			fail("Error: dlsym failed to find original ioctl\n");
+#else
+		fail("Error: unhandled ioctl\n");
+#endif
 	}
 
 	va_start(args, request);


### PR DESCRIPTION
Older versions of glibc do not have dl as builtin in. Thus include libdl when it's available.

While at it also make the mock library to depend hard on the presents of dlsym. It's only necessary for s390.

Fixes: cbbfdd0ddfa2 ("test/mock: pass thru unknown ioctls")
Reported-by: Steven Seungcheol Lee <sc108.lee@samsung.com>