### PR TITLE
ioctl: Live Migration

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,4 +1,14 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+LIBNVME_1.12 {
+	global:
+		nvme_lm_cdq;
+		nvme_lm_track_send;
+		nvme_lm_migration_send;
+		nvme_lm_migration_recv;
+		nvme_lm_set_features_ctrl_data_queue;
+		nvme_lm_get_features_ctrl_data_queue;
+};
+
 LIBNVME_1.11 {
 	global:
 		nvme_ctrl_get_keyring;

--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -969,13 +969,13 @@ struct nvme_dim_args {
  * @args_size:	Length of structure
  * @fd:		File descriptor of nvme device
  * @timeout:	Timeout in ms
- * @cntlid:	Controller ID: This field specifies the ID of the controller to be used by the
- *		specified Select (SEL) field.
- * @cdqid:	Controller Data Queue ID (CDQID): This field specifies the ID of the CDQ to be used
- *		for the specified Select (SEL) field.
+ * @mos:	Management Operation Specific (MOS): This field is specific to the SEL type
+ * @cntlid:	Controller ID: For Create CDQ, specifies the target migratable controller
+ * @cdqid:	Controller Data Queue ID (CDQID): For Create CDQ, this field is the CDQID created
+ *		by the controller if no error is present. For Delete CDQ, this field is the CDQID
+ *		to delete.
  * @sel:	Select (SEL): This field specifies the type of management operation to perform.
- * @sz:		Size of CDQ in dwords
- * @qt:		Queue Type (QT): This field specifies the type of queue to create
+ * @sz:		For Create CDQ, specifies the size of CDQ, in dwords
  */
 struct nvme_lm_cdq_args {
 	__u32	*result;
@@ -983,11 +983,11 @@ struct nvme_lm_cdq_args {
 	int	args_size;
 	int	fd;
 	__u32	timeout;
+	__u16	mos;
 	__u16	cntlid;
 	__u16	cdqid;
 	__u8	sel;
 	__u8	sz;
-	__u8	qt;
 };
 
 /**
@@ -996,19 +996,18 @@ struct nvme_lm_cdq_args {
  * @args_size:	Length of structure
  * @fd:		File descriptor of nvme device
  * @timeout:	Timeout in ms
- * @cdqid:	Controller Data Queue ID (CDQID): This field specifies the ID of the CDQ to be used
- *		for the logging action
+ * @mos:	Management Operation Specific (MOS): This field is specific to the SEL type
+ * @cdqid:	Controller Data Queue ID (CDQID)
  * @sel:	Select (SEL): This field specifies the type of management operation to perform
- * @lact:	Logging Action (LACT): This field specifies the type of logging action to perform
  */
 struct nvme_lm_track_send_args {
 	__u32	*result;
 	int	args_size;
 	int	fd;
 	__u32	timeout;
+	__u16	mos;
 	__u16	cdqid;
 	__u8	sel;
-	__u8	lact;
 };
 
 /**
@@ -1022,6 +1021,7 @@ struct nvme_lm_track_send_args {
  * @fd:		File descriptor of nvme device
  * @timeout:	Timeout in ms
  * @numd:	Number of Dwords (NUMD): This field specifies the number of dwords being transferred
+ * @mos:	Management Operation Specific (MOS): This field is specific to the SEL type
  * @cntlid:	Controller ID: This field specifies the identifier of the controller to which the
  *		operation is performed.
  * @csuuidi:	Controller State UUID Index (CSUUIDI): A non-zero value in this field specifies the
@@ -1048,6 +1048,7 @@ struct nvme_lm_migration_send_args {
 	int	fd;
 	__u32	timeout;
 	__u32	numd;
+	__u16	mos;
 	__u16	cntlid;
 	__u16	csuuidi;
 	__u8	sel;
@@ -1068,7 +1069,9 @@ struct nvme_lm_migration_send_args {
  * @args_size:	Length of structure
  * @fd:		File descriptor of nvme device
  * @timeout:	Timeout in ms
- * @numdl:	Number of Dwords Lower (NMUDL): This field specifies the number of dwords to return.
+ * @numd:	Number of Dwords (NUMD): This field specifies the number of dwords to return. This
+ *		is a 0's based value.
+ * @mos:	Management Operation Specific (MOS): This field is specific to the SEL type
  * @cntlid:	Controller ID: This field specifies the identifier of the controller to which the
  *		operation is performed.
  * @csuuidi:	Controller State UUID Index (CSUUIDI): A non-zero value in this field specifies the
@@ -1078,9 +1081,7 @@ struct nvme_lm_migration_send_args {
  * @uidx:	UUID Index (UIDX): If this field is set to a non-zero value, then the value of this
  *		field is the index of a UUID in the UUID List (refer to Figure 320) that is used by
  *		the command.
- * @csvi:	Controller State Version Index (CSVI): A non-zero value in this field specifies the
- *		index to a specific entry in the NVMe Controller State Version list of the Supported
- *		Controller State Formats data structure.
+ * @csuidxp:	Controller State UUID Index Parameter (CSUIDXP): This field is vendor specific.
  */
 struct nvme_lm_migration_recv_args {
 	__u64	offset;
@@ -1090,11 +1091,11 @@ struct nvme_lm_migration_recv_args {
 	int	fd;
 	__u32	timeout;
 	__u32	numd;
+	__u16	mos;
 	__u16	cntlid;
 	__u16	csuuidi;
 	__u8	sel;
 	__u8	uidx;
-	__u8	csvi;
 	__u8	csuidxp;
 };
 

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -4258,4 +4258,68 @@ int nvme_zns_append(struct nvme_zns_append_args *args);
  */
 int nvme_dim_send(struct nvme_dim_args *args);
 
+/**
+ * nvme_lm_cdq() - Controller Data Queue - Controller Data Queue command
+ * @args:	&struct nvme_lm_cdq_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.)
+ */
+int nvme_lm_cdq(struct nvme_lm_cdq_args *args);
+
+/**
+ * nvme_lm_track_send() - Track Send command
+ * @args:	&struct nvme_lm_track_send_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_track_send(struct nvme_lm_track_send_args *args);
+
+/**
+ * nvme_lm_migration_send() - Migration Send command
+ * @args:	&struct nvme_lm_migration_send_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_migration_send(struct nvme_lm_migration_send_args *args);
+
+/**
+ * nvme_lm_migration_recv - Migration Receive command
+ * @args:	&struct nvme_lm_migration_rev_args argument structure
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_migration_recv(struct nvme_lm_migration_recv_args *args);
+
+/**
+ * nvme_lm_set_features_ctrl_data_queue - Set Controller Datea Queue feature
+ * @fd:		File descriptor of nvme device
+ * @cdqid:	Controller Data Queue ID (CDQID)
+ * @hp:		Head Pointer
+ * @tpt:	Tail Pointer Trigger
+ * @etpt:	Enable Tail Pointer Trigger
+ * @result:	The command completions result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_set_features_ctrl_data_queue(int fd, __u16 cdqid, __u32 hp, __u32 tpt, bool etpt,
+					 __u32 *result);
+
+/**
+ * nvme_lm_get_features_ctrl_data_queue - Get Controller Data Queue feature
+ * @fd:		File descriptor of nvme device
+ * @cdqid:	Controller Data Queue ID (CDQID)
+ * @data:	Get Controller Data Queue feature data
+ * @result:	The command completions result from CQE dword0
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_lm_get_features_ctrl_data_queue(int fd, __u16 cdqid,
+					 struct nvme_lm_ctrl_data_queue_fid_data *data,
+					 __u32 *result);
 #endif /* _LIBNVME_IOCTL_H */


### PR DESCRIPTION
Continues efforts from the newly minted TP4159 PCIe Infrastructure for Live Migration specification with new ioctls.

Same as #911 but adopts new types.h definitions from #913 and removes MOS derived arguments in favor of generic `mos` field. I figured this was more "future proof".