### PR TITLE
ioctl: add nvme_get_egid_log()

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2136,6 +2136,24 @@ static inline int nvme_get_log_rotational_media_info(int fd, __u16 endgid, __u32
 }
 
 /**
+ * nvme_get_log_dispersed_ns_participating_nss() - Retrieve Dispersed Namespace Participating NVM
+ * Subsystems Log
+ * @fd:		File descriptor of nvme device
+ * @nsid:	Namespace Identifier
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_dispersed_ns_participating_nss(int fd, __u32 nsid, __u32 len,
+	struct nvme_dispersed_ns_participating_nss_log *log)
+{
+	return nvme_get_nsid_log(fd, false, NVME_LOG_LID_DISPERSED_NS_PARTICIPATING_NSS, nsid, len,
+				 log);
+}
+
+/**
  * nvme_get_log_phy_rx_eom() - Retrieve Physical Interface Receiver Eye Opening Measurement Log
  * @fd:		File descriptor of nvme device
  * @lsp:	Log specific, controls action and measurement quality

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2379,6 +2379,22 @@ static inline int nvme_get_log_ave_discover(int fd, bool rae, __u32 len,
 }
 
 /**
+ * nvme_get_log_pull_model_ddc_req() - Retrieve Pull Model DDC Request Log
+ * @fd:		File descriptor of nvme device
+ * @rae:	Retain asynchronous events
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_pull_model_ddc_req(int fd, bool rae, __u32 len,
+						  struct nvme_pull_model_ddc_req_log *log)
+{
+	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_PULL_MODEL_DDC_REQ, NVME_NSID_ALL, len, log);
+}
+
+/**
  * nvme_get_log_media_unit_stat() - Retrieve Media Unit Status
  * @fd:		File descriptor of nvme device
  * @domid:	Domain Identifier selection, if supported

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2154,6 +2154,21 @@ static inline int nvme_get_log_dispersed_ns_participating_nss(int fd, __u32 nsid
 }
 
 /**
+ * nvme_get_log_mgmt_addr_list() - Retrieve Management Address List Log
+ * @fd:		File descriptor of nvme device
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_mgmt_addr_list(int fd, __u32 len,
+					      struct nvme_mgmt_addr_list_log *log)
+{
+	return nvme_get_log_simple(fd, NVME_LOG_LID_MGMT_ADDR_LIST, len, log);
+}
+
+/**
  * nvme_get_log_phy_rx_eom() - Retrieve Physical Interface Receiver Eye Opening Measurement Log
  * @fd:		File descriptor of nvme device
  * @lsp:	Log specific, controls action and measurement quality

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2120,6 +2120,22 @@ static inline int nvme_get_log_boot_partition(int fd, bool rae,
 }
 
 /**
+ * nvme_get_log_rotational_media_info() - Retrieve Rotational Media Information Log
+ * @fd:		File descriptor of nvme device
+ * @endgid:	Endurance Group Identifier
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_rotational_media_info(int fd, __u16 endgid, __u32 len,
+						     struct nvme_rotational_media_info_log *log)
+{
+	return nvme_get_endgid_log(fd, false, NVME_LOG_LID_ROTATIONAL_MEDIA_INFO, endgid, len, log);
+}
+
+/**
  * nvme_get_log_phy_rx_eom() - Retrieve Physical Interface Receiver Eye Opening Measurement Log
  * @fd:		File descriptor of nvme device
  * @lsp:	Log specific, controls action and measurement quality

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -1370,6 +1370,30 @@ static inline int nvme_get_nsid_log(int fd, bool rae,
 	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
 }
 
+static inline int nvme_get_endgid_log(int fd, bool rae, enum nvme_cmd_get_log_lid lid, __u16 endgid,
+				    __u32 len, void *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = lid,
+		.len = len,
+		.nsid = NVME_NSID_NONE,
+		.csi = NVME_CSI_NVM,
+		.lsi = endgid,
+		.lsp = NVME_LOG_LSP_NONE,
+		.uuidx = NVME_LOG_LSP_NONE,
+		.rae = rae,
+		.ot = false,
+	};
+
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+}
+
 static inline int nvme_get_log_simple(int fd, enum nvme_cmd_get_log_lid lid,
 				      __u32 len, void *log)
 {

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2239,6 +2239,41 @@ static inline int nvme_get_log_reachability_groups(int fd, __u32 len, bool rgo, 
 }
 
 /**
+ * nvme_get_log_reachability_associations() - Retrieve Reachability Associations Log
+ * @fd:		File descriptor of nvme device
+ * @rao:	Return associations only
+ * @rae:	Retain asynchronous events
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_reachability_associations(int fd, bool rao, bool rae, __u32 len,
+	struct nvme_reachability_associations_log *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_REACHABILITY_ASSOCIATIONS,
+		.len = len,
+		.nsid = NVME_NSID_ALL,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = rao,
+		.uuidx = NVME_LOG_LSP_NONE,
+		.rae = rae,
+		.ot = false,
+	};
+
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+}
+
+/**
  * nvme_get_log_discovery() - Retrieve Discovery log page
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2363,6 +2363,22 @@ static inline int nvme_get_log_host_discover(int fd, bool allhoste, bool rae, __
 }
 
 /**
+ * nvme_get_log_ave_discover() - Retrieve AVE Discovery Log
+ * @fd:		File descriptor of nvme device
+ * @rae:	Retain asynchronous events
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_ave_discover(int fd, bool rae, __u32 len,
+					    struct nvme_ave_discover_log *log)
+{
+	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_AVE_DISCOVER, NVME_NSID_ALL, len, log);
+}
+
+/**
  * nvme_get_log_media_unit_stat() - Retrieve Media Unit Status
  * @fd:		File descriptor of nvme device
  * @domid:	Domain Identifier selection, if supported

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2274,6 +2274,23 @@ static inline int nvme_get_log_reachability_associations(int fd, bool rao, bool 
 }
 
 /**
+ * nvme_get_log_changed_alloc_ns_list() - Retrieve Changed Allocated Namespace List Log
+ * @fd:		File descriptor of nvme device
+ * @rae:	Retain asynchronous events
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_changed_alloc_ns_list(int fd, bool rae, __u32 len,
+						     struct nvme_ns_list *log)
+{
+	return nvme_get_nsid_log(fd, rae, NVME_LOG_LID_CHANGED_ALLOC_NS_LIST, NVME_NSID_ALL, len,
+				 log);
+}
+
+/**
  * nvme_get_log_discovery() - Retrieve Discovery log page
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2328,6 +2328,41 @@ static inline int nvme_get_log_discovery(int fd, bool rae,
 }
 
 /**
+ * nvme_get_log_host_discover() - Retrieve Host Discovery Log
+ * @fd:		File descriptor of nvme device
+ * @allhoste:	All host entries
+ * @rae:	Retain asynchronous events
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_host_discover(int fd, bool allhoste, bool rae, __u32 len,
+					     struct nvme_host_discover_log *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_HOST_DISCOVER,
+		.len = len,
+		.nsid = NVME_NSID_ALL,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = allhoste,
+		.uuidx = NVME_LOG_LSP_NONE,
+		.rae = rae,
+		.ot = false,
+	};
+
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+}
+
+/**
  * nvme_get_log_media_unit_stat() - Retrieve Media Unit Status
  * @fd:		File descriptor of nvme device
  * @domid:	Domain Identifier selection, if supported

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -2204,6 +2204,41 @@ static inline int nvme_get_log_phy_rx_eom(int fd, __u8 lsp, __u16 controller,
 }
 
 /**
+ * nvme_get_log_reachability_groups() - Retrieve Reachability Groups Log
+ * @fd:		File descriptor of nvme device
+ * @rgo:	Return groups only
+ * @rae:	Retain asynchronous events
+ * @len:	The allocated length of the log page
+ * @log:	User address to store the log page
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise
+ */
+static inline int nvme_get_log_reachability_groups(int fd, __u32 len, bool rgo, bool rae,
+						   struct nvme_reachability_groups_log *log)
+{
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = log,
+		.args_size = sizeof(args),
+		.fd = fd,
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = NVME_LOG_LID_REACHABILITY_GROUPS,
+		.len = len,
+		.nsid = NVME_NSID_ALL,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = rgo,
+		.uuidx = NVME_LOG_LSP_NONE,
+		.rae = rae,
+		.ot = false,
+	};
+
+	return nvme_get_log_page(fd, NVME_LOG_PAGE_PDU_SIZE, &args);
+}
+
+/**
  * nvme_get_log_discovery() - Retrieve Discovery log page
  * @fd:		File descriptor of nvme device
  * @rae:	Retain asynchronous events

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -7008,6 +7008,20 @@ struct nvme_ave_discover_log {
 };
 
 /**
+ * struct nvme_pull_model_ddc_req_log - Pull Model DDC Request Log
+ * @ori:	Operation Request Identifier
+ * @rsvd1:	Reserved
+ * @tpdrpl:	Total Pull Model DDC Request Log Page Length
+ * @osp:	Operation Specific Parameters
+ */
+struct nvme_pull_model_ddc_req_log {
+	__u8	ori;
+	__u8	rsvd1[3];
+	__le32	tpdrpl;
+	__u8	osp[];
+};
+
+/**
  * struct nvme_mi_read_nvm_ss_info - NVM Subsystem Information Data Structure
  * @nump:	Number of Ports
  * @mjr:	NVMe-MI Major Version Number

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4805,6 +4805,26 @@ struct nvme_dispersed_ns_participating_nss_log {
 };
 
 /**
+ * struct nvme_mgmt_addr_desc - Management Address Descriptor
+ * @mat:	Management Address Type
+ * @rsvd1:	Reserved
+ * @madrs:	Management Address
+ */
+struct nvme_mgmt_addr_desc {
+	__u8	mat;
+	__u8	rsvd1[3];
+	__u8	madrs[508];
+};
+
+/**
+ * struct nvme_mgmt_addr_list_log - Management Address List Log
+ * @mad:	Management Address Descriptor
+ */
+struct nvme_mgmt_addr_list_log {
+	struct nvme_mgmt_addr_desc	mad[8];
+};
+
+/**
  * struct nvme_eom_lane_desc - EOM Lane Descriptor
  * @rsvd0:	Reserved
  * @mstatus:	Measurement Status

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -6958,6 +6958,56 @@ struct nvme_host_discover_log {
 };
 
 /**
+ * struct nvme_ave_tr_record - AVE Transport Record
+ * @aveadrfam:	AVE Address Family
+ * @rsvd1:	Reserved
+ * @avetrsvcid:	AVE Transport Service Identifier
+ * @avetraddr:	AVE Transport Address
+ */
+struct nvme_ave_tr_record {
+	__u8	aveadrfam;
+	__u8	rsvd1;
+	__le16	avetrsvcid;
+	__u8	avetraddr[16];
+};
+
+/**
+ * struct nvme_ave_discover_log_entry - AVE Discovery Log Entry
+ * @tel:	Total Entry Length
+ * @avenqn:	AVE NQN
+ * @numatr:	Number of AVE Transport Records
+ * @rsvd229:	Reserved
+ * @atr:	AVE Transport Record List
+ */
+struct nvme_ave_discover_log_entry {
+	__le32				tel;
+	char				avenqn[224];
+	__u8				numatr;
+	__u8				rsvd229[3];
+	struct nvme_ave_tr_record	atr[];
+};
+
+/**
+ * struct nvme_ave_discover_log - AVE Discovery Log
+ * @genctr:	Generation Counter
+ * @numrec:	Number of Records
+ * @recfmt:	Record Format
+ * @rsvd18:	Reserved
+ * @tadlpl:	Total AVE Discovery Log Page Length
+ * @rsvd24:	Reserved
+ * @adlpe:	AVE Discovery Log Page Entry List
+ */
+struct nvme_ave_discover_log {
+	__le64					genctr;
+	__le64					numrec;
+	__le16					recfmt;
+	__u8					rsvd18[2];
+	__le32					tadlpl;
+	__u8					rsvd24[1000];
+	struct nvme_ave_discover_log_entry	adlpe[];
+};
+
+/**
  * struct nvme_mi_read_nvm_ss_info - NVM Subsystem Information Data Structure
  * @nump:	Number of Ports
  * @mjr:	NVMe-MI Major Version Number

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4790,6 +4790,21 @@ struct nvme_rotational_media_info_log {
 };
 
 /**
+ * struct nvme_dispersed_ns_participating_nss_log - Dispersed Namespace Participating NVM Subsystems
+ * Log
+ * @genctr:		Generation Counter
+ * @numpsub:		Number of Participating NVM Subsystems
+ * @rsvd16:		Reserved
+ * @participating_nss:	Participating NVM Subsystem Entry
+ */
+struct nvme_dispersed_ns_participating_nss_log {
+	__le64	genctr;
+	__le64	numpsub;
+	__u8	rsvd16[240];
+	__u8	participating_nss[];
+};
+
+/**
  * struct nvme_eom_lane_desc - EOM Lane Descriptor
  * @rsvd0:	Reserved
  * @mstatus:	Measurement Status

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -6906,6 +6906,58 @@ struct nvmf_connect_data {
 };
 
 /**
+ * struct nvme_host_ext_discover_log - Host Extended Discovery Log
+ * @trtype:	Transport Type
+ * @adrfam:	Address Family
+ * @rsvd2:	Reserved
+ * @eflags:	Entry Flags
+ * @rsvd12:	Reserved
+ * @hostnqn:	Host NVMe Qualified Name
+ * @traddr:	Transport Address
+ * @tsas:	Transport Specific Address Subtype
+ * @tel:	Total Entry Length
+ * @numexat:	Number of Extended Attributes
+ * @rsvd1030:	Reserved
+ * @exat:	Extended Attributes List
+ */
+struct nvme_host_ext_discover_log {
+	__u8			trtype;
+	__u8			adrfam;
+	__u8			rsvd2[8];
+	__le16			eflags;
+	__u8			rsvd12[244];
+	char			hostnqn[NVME_NQN_LENGTH];
+	char			traddr[NVMF_TRADDR_SIZE];
+	union nvmf_tsas		tsas;
+	__le32			tel;
+	__le16			numexat;
+	__u8			rsvd1030[2];
+	struct nvmf_ext_attr	exat[];
+};
+
+/**
+ * struct nvme_host_discover_log - Host Discovery Log
+ * @genctr:	Generation Counter
+ * @numrec:	Number of Records
+ * @recfmt:	Record Format
+ * @hdlpf:	Host Discovery Log Page Flags
+ * @rsvd19:	Reserved
+ * @thdlpl:	Total Host Discovery Log Page Length
+ * @rsvd24:	Reserved
+ * @hedlpe:	Host Extended Discovery Log Page Entry List
+ */
+struct nvme_host_discover_log {
+	__le64					genctr;
+	__le64					numrec;
+	__le16					recfmt;
+	__u8					hdlpf;
+	__u8					rsvd19;
+	__le32					thdlpl;
+	__u8					rsvd24[1000];
+	struct nvme_host_ext_discover_log	hedlpe[];
+};
+
+/**
  * struct nvme_mi_read_nvm_ss_info - NVM Subsystem Information Data Structure
  * @nump:	Number of Ports
  * @mjr:	NVMe-MI Major Version Number

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4766,6 +4766,30 @@ enum nvme_boot_partition_info {
 #define NVME_BOOT_PARTITION_INFO_ABPID(bpinfo)	NVME_GET(bpinfo, BOOT_PARTITION_INFO_ABPID)
 
 /**
+ * struct nvme_rotational_media_info_log - Rotational Media Information Log
+ * @endgid:	Endurance Group Identifier
+ * @numa:	Number of Actuators
+ * @nrs:	Nominal Rotational Speed
+ * @rsvd6:	Reserved
+ * @spinc:	Spinup Count
+ * @fspinc:	Failed Spinup Count
+ * @ldc:	Load Count
+ * @fldc:	Failed Load Count
+ * @rsvd24:	Reserved
+ */
+struct nvme_rotational_media_info_log {
+	__le16	endgid;
+	__le16	numa;
+	__le16	nrs;
+	__u8	rsvd6[2];
+	__le32	spinc;
+	__le32	fspinc;
+	__le32	ldc;
+	__le32	fldc;
+	__u8	rsvd24[488];
+};
+
+/**
  * struct nvme_eom_lane_desc - EOM Lane Descriptor
  * @rsvd0:	Reserved
  * @mstatus:	Measurement Status

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4957,6 +4957,36 @@ enum nvme_phy_rx_eom_progress {
 };
 
 /**
+ * struct nvme_reachability_group_desc - Reachability Group Descriptor
+ * @rgid:	Reachability Group ID
+ * @nnid:	Number of NSID Values
+ * @chngc:	Change Count
+ * @rsvd16:	Reserved
+ * @nsid:	Namespace Identifier List
+ */
+struct nvme_reachability_group_desc {
+	__le32	rgid;
+	__le32	nnid;
+	__le64	chngc;
+	__u8	rsvd16[16];
+	__le32	nsid[];
+};
+
+/**
+ * struct nvme_reachability_groups_log - Reachability Groups Log
+ * @chngc:	Change Count
+ * @nrgd:	Number of Reachability Group Descriptors
+ * @rsvd10:	Reserved
+ * @rgd:	Reachability Group Descriptor List
+ */
+struct nvme_reachability_groups_log {
+	__le64					chngc;
+	__le16					nrgd;
+	__u8					rsvd10[6];
+	struct nvme_reachability_group_desc	rgd[];
+};
+
+/**
  * struct nvme_media_unit_stat_desc - Media Unit Status Descriptor
  * @muid:	  Media Unit Identifier
  * @domainid:	  Domain Identifier

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -4987,6 +4987,38 @@ struct nvme_reachability_groups_log {
 };
 
 /**
+ * struct nvme_reachability_association_desc - Reachability Association Descriptor
+ * @rasid:	Reachability Association ID
+ * @nrid:	Number of RGID Values
+ * @chngc:	Change Count
+ * @rac:	Reachability Association Characteristics
+ * @rsvd17:	Reserved
+ * @ngid:	Reachability Group Identifier List
+ */
+struct nvme_reachability_association_desc {
+	__le32	rasid;
+	__le32	nrid;
+	__le64	chngc;
+	__u8	rac;
+	__u8	rsvd17[15];
+	__le32	ngid[];
+};
+
+/**
+ * struct nvme_reachability_associations_log - Reachability Associations Log
+ * @chngc:	Change Count
+ * @nrad:	Number of Reachability Association Descriptors
+ * @rsvd10:	Reserved
+ * @rad:	Reachability Association Descriptor List
+ */
+struct nvme_reachability_associations_log {
+	__le64						chngc;
+	__le16						nrad;
+	__u8						rsvd10[6];
+	struct nvme_reachability_association_desc	rad[];
+};
+
+/**
  * struct nvme_media_unit_stat_desc - Media Unit Status Descriptor
  * @muid:	  Media Unit Identifier
  * @domainid:	  Domain Identifier


### PR DESCRIPTION
This is to use for the endurance group scope log page.