### PR TITLE
fabrics: Use /etc/machine-id as a fallback source for system UUID

### DIFF
--- a/src/nvme/fabrics.h
+++ b/src/nvme/fabrics.h
@@ -316,7 +316,7 @@ char *nvmf_hostid_generate();
  * nvmf_hostnqn_from_file() - Reads the host nvm qualified name from the config
  *			      default location
  *
- * Retrieve the qualified name from the config file located in $SYSCONFIDR/nvme.
+ * Retrieve the qualified name from the config file located in $SYSCONFDIR/nvme.
  * $SYSCONFDIR is usually /etc.
  *
  * Return: The host nqn, or NULL if unsuccessful. If found, the caller


### PR DESCRIPTION
In case when system DMI data are unavailable or bogus, fall back to reading `/etc/machine-id` before resorting to generating a random UUID.

The machine-id file typically contains persistent and unique machine UUID stable for the OS instance.

See https://www.freedesktop.org/software/systemd/man/latest/machine-id.html

Note: while this appears to be part of systemd, the file is present on my OpenRC system, likely created by elogind.

TODO:
- [ ] The specs say the value is confidential and is supposed to be hashed before used publicly. The suggested [sd_id128_get_machine_app_specific(3)](https://www.freedesktop.org/software/systemd/man/latest/sd_id128_get_machine_app_specific.html#) function just performs SHA256 hash with an arbitrary application ID value, however given that openssl use is optional and this should work in a minimal environment, we could perhaps xor the value with some const. Not sure how useful would that be though.