### PR TITLE
libnvme: export nvmf_exat_ptr_next

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -7,6 +7,7 @@ LIBNVME_1.12 {
 		nvme_lm_migration_recv;
 		nvme_lm_set_features_ctrl_data_queue;
 		nvme_lm_get_features_ctrl_data_queue;
+		nvmf_exat_ptr_next;
 };
 
 LIBNVME_1.11 {


### PR DESCRIPTION
The API function will be used by the host-discovery-log command.