### PR TITLE
build: do not include config.h globally

### DIFF
--- a/internal/meson.build
+++ b/internal/meson.build
@@ -21,10 +21,4 @@ config_dep = declare_dependency(
   sources: config_h)
 
 config_h_path = meson.current_build_dir() / 'config.h'
-
-add_project_arguments(
-    [
-        '-include', config_h_path,
-    ],
-    language : 'c',
-)
+config_h_arg =  [ '-include', config_h_path ]

--- a/meson.build
+++ b/meson.build
@@ -230,16 +230,6 @@ conf.set(
     ),
     description: 'Is network address and service translation available'
 )
-conf.set(
-    'HAVE_GLIBC_IOCTL',
-    cc.compiles(
-        '''#include <sys/ioctl.h>
-        int ioctl(int fd, unsigned long request, ...);
-        ''',
-        name: 'ioctl has glibc-style prototype'
-    ),
-    description: 'Is ioctl the glibc interface (rather than POSIX)'
-)
 dl_dep = dependency('dl', required: false)
 conf.set(
     'HAVE_LIBC_DLSYM',

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,6 +55,7 @@ libnvme = library(
     link_args: ['-Wl,--version-script=' + version_script_arg],
     dependencies: deps,
     link_depends: mapfile,
+    c_args: config_h_arg,
     include_directories: [incdir, internal_incdir],
     install: true,
     link_with: libccan,
@@ -81,6 +82,7 @@ libnvme_mi = library(
     'nvme-mi', # produces libnvme-mi.so
     mi_sources,
     version: library_version,
+    c_args: config_h_arg,
     link_args: ['-Wl,--version-script=' + mi_version_script_arg],
     dependencies: mi_deps,
     link_depends: mi_mapfile,
@@ -100,6 +102,7 @@ libnvme_mi_test = library(
     'nvme-mi-test', # produces libnvme-mi-test.so
     mi_sources,
     dependencies: mi_deps,
+    c_args: config_h_arg,
     include_directories: [incdir, internal_incdir],
     install: false,
     link_with: libccan,

--- a/test/ioctl/meson.build
+++ b/test/ioctl/meson.build
@@ -1,8 +1,21 @@
+mock_conf = configuration_data()
+
+mock_conf.set(
+    'HAVE_GLIBC_IOCTL',
+    cc.compiles(
+        '''#include <sys/ioctl.h>
+        int ioctl(int fd, unsigned long request, ...);
+        ''',
+        name: 'ioctl has glibc-style prototype'
+    ),
+    description: 'Is ioctl the glibc interface (rather than POSIX)'
+)
+
 mock_ioctl = library(
     'mock-ioctl',
     ['mock.c', 'util.c'],
-    dependencies: [dl_dep]
-)
+    dependencies: [dl_dep],
+    c_args: ['-DHAVE_GLIBC_IOCTL=' + (mock_conf.get('HAVE_GLIBC_IOCTL') ? '1' : '0')])
 
 # Add mock-ioctl to the LD_PRELOAD path so it overrides libc.
 # Append to LD_PRELOAD so existing libraries, e.g. libasan, are kept.


### PR DESCRIPTION
The python build breaks because of libnvme and the swig generator define variations of fallthrough. Let's only include the config.h for the libraries.

Fixes: #963 