### PR TITLE
Makefile: Add new targets and update meson command syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,38 +9,52 @@ NAME          := libnvme
 .DEFAULT_GOAL := ${NAME}
 BUILD-DIR     := .build
 
+.PHONY: update-subprojects
+update-subprojects:
+	meson subprojects update
+
 ${BUILD-DIR}:
-	meson $@
+	meson setup $@
 	@echo "Configuration located in: $@"
 	@echo "-------------------------------------------------------"
 
 .PHONY: ${NAME}
 ${NAME}: ${BUILD-DIR}
-	ninja -C ${BUILD-DIR}
+	meson compile -C ${BUILD-DIR}
 
 .PHONY: clean
 clean:
 ifneq ("$(wildcard ${BUILD-DIR})","")
-	ninja -C ${BUILD-DIR} -t $@
+	meson compile --clean -C ${BUILD-DIR}
 endif
 
 .PHONY: purge
 purge:
 ifneq ("$(wildcard ${BUILD-DIR})","")
 	rm -rf ${BUILD-DIR}
+	meson subprojects purge --confirm
 endif
 
-.PHONY: install dist
-install dist: ${BUILD-DIR}
-	cd ${BUILD-DIR} && meson $@
+.PHONY: install
+install: ${NAME}
+	meson install -C ${BUILD-DIR} --skip-subprojects
 
 .PHONY: uninstall
 uninstall:
 	cd ${BUILD-DIR} && meson --internal uninstall
 
+.PHONY: dist
+dist: ${NAME}
+	meson dist -C ${BUILD-DIR} --formats gztar
+
 .PHONY: test
-test: ${BUILD-DIR}
-	ninja -C ${BUILD-DIR} $@
+test: ${NAME}
+	meson test -C ${BUILD-DIR}
+
+# Test strictly libnvme (do not run tests on all the subprojects)
+.PHONY: test-strict
+test-strict: ${NAME}
+	meson test -C ${BUILD-DIR} --suite libnvme
 
 .PHONY: rpm
 rpm: ${BUILD-DIR}


### PR DESCRIPTION
This pull request simply updates the meson syntax for some of the existing targets and provides a few additional targets as follows:

- For the "install" target, use "--skip-subprojects" so that only libnvme (and not the subprojects) get installed.
- For the "purge" target, add "meson subprojects purge".
- Added "update-subprojects" target
- Added "test-strict" target. This is to limit testing to libnvme and not all the subprojects.