### PR TITLE
python, swig: add missing controller attributes

### DIFF
--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -62,9 +62,9 @@ if build_python_bindings
     # Set the PYTHONPATH so that we can run the 
     # tests directly from the build directory.
     test_env = environment()
-    test_env.append('MALLOC_PERTURB_', '0')
-    test_env.append('PYTHONPATH', join_paths(meson.current_build_dir(), '..'))
-    test_env.append('PYTHONMALLOC', 'malloc')
+    test_env.set('MALLOC_PERTURB_', '90')
+    test_env.prepend('PYTHONPATH', join_paths(meson.current_build_dir(), '..'))
+    test_env.set('PYTHONMALLOC', 'malloc')
 
     # Test section
     test('python-import-libnvme', python3, args: ['-c', 'from libnvme import nvme'], env: test_env, depends: pynvme_clib)


### PR DESCRIPTION
Found that some controller attributes (e.g. tls_key) were missing from the SWIG wrapper code. Also found that for some of the attributes, SWIG was generating code that accessed to attributes directly instead of using the getter/setter methods.

For example, SWIG would generate code like this:

  name = c->name;

Instead of that:

  name = nvme_ctrl_get_name(c);

This may have been OK in most cases, but the Python code should really use the getter/setter methods instead of accessing the controller object directly.

SWIG is a weird beast to tame. For example, all the setter/getter methods must exactly match the syntax:

  [class]_[member]_[set|get] (e.g. nvme_ctrl_traddr_get)

However, most of the libnvme functions follow this syntax:

  [class]_[set|get]_[member] (e.g. nvme_ctrl_get_traddr)

The trick to force SWIG to use the setter/getter methods is to define the attributes in a %extend block and provide explicit translation methods for all the setter/getter methods.