### PR TITLE
build: fix python release workflows

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,11 +42,11 @@ jobs:
           path: dist
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12
+        uses: pypa/gh-action-pypi-publish@release-v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
   upload_pypi:
     needs: [build_sdist]
@@ -66,7 +66,7 @@ jobs:
           name: artifact
           path: dist
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12
+        uses: pypa/gh-action-pypi-publish@release-v1
         if: steps.check-tag.outputs.match == 'true'
         with:
           user: __token__


### PR DESCRIPTION
Use the latest stable version of the action.