### PR TITLE
build: enable python test release workflows

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -34,7 +34,6 @@ jobs:
   upload_test_pypi:
     needs: [build_sdist]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -42,7 +41,7 @@ jobs:
           path: dist
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release-v1
+        uses: pypa/gh-action-pypi-publish:release-v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -66,7 +65,7 @@ jobs:
           name: artifact
           path: dist
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release-v1
+        uses: pypa/gh-action-pypi-publish:release-v1
         if: steps.check-tag.outputs.match == 'true'
         with:
           user: __token__


### PR DESCRIPTION
Enable back the python test release workflow again.