### PR TITLE
Revert various related big-endian PI commits

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -1920,9 +1920,9 @@ static int nvme_set_var_size_tags(__u32 *cmd_dw2, __u32 *cmd_dw3, __u32 *cmd_dw1
 		return -1;
 	}
 
-	*cmd_dw2 = cpu_to_be32(cdw2);
-	*cmd_dw3 = cpu_to_be32(cdw3);
-	*cmd_dw14 = cpu_to_be32(cdw14);
+	*cmd_dw2 = cdw2;
+	*cmd_dw3 = cdw3;
+	*cmd_dw14 = cdw14;
 	return 0;
 }
 

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -413,10 +413,8 @@ const char *nvme_status_to_string(int status, bool fabrics)
 
 static inline void nvme_init_copy_range_elbt(__u8 *elbt, __u64 eilbrt)
 {
-	int i;
-
-	for (i = 0; i < 8; i++)
-		elbt[9 - i] = (eilbrt >> (8 * i)) & 0xff;
+	__u64 *ref_tag_region = (__u64 *)&elbt[2];
+	*ref_tag_region = eilbrt;
 	elbt[1] = 0;
 	elbt[0] = 0;
 }


### PR DESCRIPTION
This reverts a series of related changes that mapped storage and reference tags into the shared region over multiple CDWords in big-endian ordering. Keith confirmed the CDWords are always in little-endian ordering, and that the MSB-LSB representation in the spec is for the metadata payload itself.