### PR TITLE
mock.c: fix checking of HAVE_GLIBC_IOCTL

### DIFF
--- a/test/ioctl/mock.c
+++ b/test/ioctl/mock.c
@@ -118,7 +118,7 @@ void end_mock_cmds(void)
 	} \
 })
 
-#ifdef HAVE_GLIBC_IOCTL
+#if defined(HAVE_GLIBC_IOCTL) && HAVE_GLIBC_IOCTL == 1
 typedef int (*ioctl_func_t)(int, unsigned long, void *);
 int ioctl(int fd, unsigned long request, ...)
 #else


### PR DESCRIPTION
Commit [ 0d8d0a55 build: do not include config.h globally ] changed to always pass -DHAVE_GLIBC_IOCTL=[0|1], and this causes a regression, for system without glibc ioctl, -DHAVE_GLIBC_IOCTL=0 is passed, and causes error:
../git/test/ioctl/mock.c:123:5: error: conflicting types for 'ioctl'; have 'int(int,  long unsigned int, ...)'
  123 | int ioctl(int fd, unsigned long request, ...)
      |     ^~~~~
In file included from ../git/test/ioctl/mock.c:9:
pathto/usr/include/sys/ioctl.h:115:5: note: previous declaration of 'ioctl' with type 'int(int,  int, ...)'
  115 | int ioctl (int, int, ...);

Fixed by checking value of HAVE_GLIBC_IOCTL in mock.c