### PR TITLE
types: Fix Live Migration SEQIND Shift and Mask

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -9990,8 +9990,8 @@ enum nvme_lm_migration_send_fields {
 	NVME_LM_RESUME_CNTLID_MASK			= 0xffff,
 
 	/* Migration Send - Set Controller State */
-	NVME_LM_SEQIND_SHIFT				= 16,
-	NVME_LM_SEQIND_MASK				= 0xf,
+	NVME_LM_SEQIND_SHIFT				= 0,
+	NVME_LM_SEQIND_MASK				= 0x3,
 	NVME_LM_SEQIND_NOT_FIRST_NOT_LAST		= 0,
 	NVME_LM_SEQIND_FIRST				= 1,
 	NVME_LM_SEQIND_LAST				= 2,


### PR DESCRIPTION
This change fixes Sequence Indicator (SEQIND) Shift and Mask to match the NVM Express Base Specification, Revision 2.1.

The Mask and Shift are defined relative to Mos:

```
 * @NVME_LM_SEQIND_SHIFT:			Shift amount to set Sequence Indicator (SEQIND)
 *						field relative to MOS
 * @NVME_LM_SEQIND_MASK:			Mask to set SEQIND field relative to MOS
```

Relative to Mos, the `SHIFT` should be 0 and `MASK` should be 0b11 (0x3).
![Screenshot 2025-04-08 at 20 32 07](https://github.com/user-attachments/assets/de1b02a5-b45a-4b74-800b-05f1bcfdb1a7)
