### PR TITLE
fabrics: retry connect command on EINTR

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -243,6 +243,20 @@ else
   conf.set('fallthrough', 'do {} while (0) /* fallthrough */')
 endif
 
+if cc.has_function('TEMP_FAILURE_RETRY', prefix : '#include <errno.h>')
+  conf.set('TFR', 'TEMP_FAILURE_RETRY')
+else
+  conf.set('TFR(exp)', '''					\
+({								\
+	long int __result = 0; 					\
+	do {							\
+		__result = (long int)(exp);			\
+	} while ((__result == -1) && (errno == EINTR));		\
+	__result;						\
+})
+''')
+endif
+
 ################################################################################
 substs = configuration_data()
 substs.set('NAME',    meson.project_name())

--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -814,7 +814,7 @@ static int __nvmf_add_ctrl(nvme_root_t r, const char *argstr)
 
 	nvme_msg(r, LOG_DEBUG, "connect ctrl, '%.*s'\n",
 		 (int)strcspn(argstr,"\n"), argstr);
-	ret = write(fd, argstr, len);
+	ret = TFR(write(fd, argstr, len));
 	if (ret != len) {
 		nvme_msg(r, LOG_INFO, "Failed to write to %s: %s\n",
 			 nvmf_dev, strerror(errno));


### PR DESCRIPTION
When the system call fails with EINTR, retry the operation.

Fixes: #https://github.com/linux-nvme/nvme-cli/issues/2760