### PR TITLE
tree: add routine to fetch subsys serial number

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 LIBNVME_UNRELEASED {
+	global:
+		nvme_subsystem_get_serial;
 };
 
 LIBNVME_1.13 {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -532,6 +532,11 @@ const char *nvme_subsystem_get_model(nvme_subsystem_t s)
 	return s->model;
 }
 
+const char *nvme_subsystem_get_serial(nvme_subsystem_t s)
+{
+	return s->serial;
+}
+
 const char *nvme_subsystem_get_fw_rev(nvme_subsystem_t s)
 {
 	return s->firmware;

--- a/src/nvme/tree.h
+++ b/src/nvme/tree.h
@@ -1355,6 +1355,14 @@ const char *nvme_subsystem_get_iopolicy(nvme_subsystem_t s);
 const char *nvme_subsystem_get_model(nvme_subsystem_t s);
 
 /**
+ * nvme_subsystem_get_serial() - Return the serial number of subsystem
+ * @s:	nvme_subsystem_t object
+ *
+ * Return: Serial number of the current subsystem
+ */
+const char *nvme_subsystem_get_serial(nvme_subsystem_t s);
+
+/**
  * nvme_subsystem_get_fw_rev() - Return the firmware rev of subsystem
  * @s:	nvme_subsystem_t object
  *


### PR DESCRIPTION
Add a new routine to fetch the subsystem serial number.