### PR TITLE
build: trigger manual upload PyPi releases

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -27,6 +27,12 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Check out specified tag
+        if: ${{ github.event.inputs.tag != '' }}
+        run: |
+          git fetch --tags
+          git checkout ${{ github.event.inputs.tag }}
+
       - name: Build sdist
         run: |
           pipx run build --sdist
@@ -56,6 +62,12 @@ jobs:
       - name: Allow workspace
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Check out specified tag
+        if: ${{ github.event.inputs.tag != '' }}
+        run: |
+          git fetch --tags
+          git checkout ${{ github.event.inputs.tag }}
 
       - name: Compute dev version from git
         id: version
@@ -113,14 +125,25 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linux-nvme/libnvme'
+    if: (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && github.repository == 'linux-nvme/libnvme'
     steps:
-      - name: Check if it is a release tag
-        id: check-tag
+      - name: Determine match status
+        id: match
         run: |
-           if [[ ${{ github.event.ref }} =~ ^refs/tags/v([0-9]+\.[0-9]+)(\.[0-9]+)?(-rc[0-9]+)?$ ]]; then
-               echo ::set-output name=match::true
-           fi
+          VERSION=""
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+              VERSION="${{ github.event.inputs.tag }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              VERSION="${GITHUB_REF##refs/tags/}"
+          fi
+
+          if [[ "$VERSION" =~ ^v([0-9]+\.[0-9]+)(\.[0-9]+)?(-rc[0-9]+)?$ ]]; then
+              echo "Tag version validated: $VERSION"
+              echo "match=true" >> $GITHUB_OUTPUT
+          else
+              echo "Invalid or missing tag: $VERSION"
+              echo "match=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Download artifiact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -75,7 +75,14 @@ jobs:
           TAG=$(git describe --tags --abbrev=0)
           REV=$(git rev-list "$TAG"..HEAD --count)
           BASE_VERSION="${TAG#v}"
-          VERSION="${BASE_VERSION}.dev${REV}"
+
+          # Check if REV is 0, and don't append '.dev' if so
+          if [ "$REV" -eq 0 ]; then
+            VERSION="${BASE_VERSION}"
+          else
+            VERSION="${BASE_VERSION}.dev${REV}"
+          fi
+
           echo "dev_version=$VERSION" >> $GITHUB_OUTPUT
           echo "Computed dev version: $VERSION"
 


### PR DESCRIPTION
Sometimes the upload fails for $reasons. Have something in place to manually be able to upload PyPi releases.

#967