### PR TITLE
types: Change LM CDQ sz argument from u8 to u32.

### DIFF
--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -976,7 +976,9 @@ struct nvme_dim_args {
  *		by the controller if no error is present. For Delete CDQ, this field is the CDQID
  *		to delete.
  * @sel:	Select (SEL): This field specifies the type of management operation to perform.
- * @sz:		For Create CDQ, specifies the size of CDQ, in dwords
+ * @sz_u8:	For Create CDQ, specifies the size of CDQ, in dwords - 1 byte
+ * @rsvd1:	Reserved
+ * @sz:		For Create CDQ, specifies the size of CDQ, in dwords - 4 byte
  */
 struct nvme_lm_cdq_args {
 	__u32	*result;
@@ -988,7 +990,9 @@ struct nvme_lm_cdq_args {
 	__u16	cntlid;
 	__u16	cdqid;
 	__u8	sel;
-	__u8	sz;
+	__u8	sz_u8;
+	__u8	rsvd1[4];
+	__u32	sz;
 };
 
 /**

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -2353,15 +2353,27 @@ int nvme_dim_send(struct nvme_dim_args *args)
 
 int nvme_lm_cdq(struct nvme_lm_cdq_args *args)
 {
+	const size_t size_v1 = sizeof_args(struct nvme_lm_cdq_args, sz_u8, __u64);
+	const size_t size_v2 = sizeof_args(struct nvme_lm_cdq_args, sz, __u64);
 	__u32 cdw10 = NVME_SET(args->sel, LM_CDQ_SEL) |
 		      NVME_SET(args->mos, LM_CDQ_MOS);
-	__u32 cdw11 = 0, data_len = 0;
+	__u32 cdw11 = 0, data_len = 0, sz = 0;
 	int err;
+
+	if (args->args_size < size_v1 || args->args_size > size_v2) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (args->args_size == size_v1)
+		sz = args->sz_u8;
+	else
+		sz = args->sz;
 
 	if (args->sel == NVME_LM_SEL_CREATE_CDQ) {
 		cdw11 = NVME_SET(args->cntlid, LM_CREATE_CDQ_CNTLID) |
 			NVME_LM_CREATE_CDQ_PC;
-		data_len = args->sz << 2;
+		data_len = sz << 2;
 	} else if (args->sel == NVME_LM_SEL_DELETE_CDQ) {
 		cdw11 = NVME_SET(args->cdqid, LM_DELETE_CDQ_CDQID);
 	}
@@ -2370,7 +2382,7 @@ int nvme_lm_cdq(struct nvme_lm_cdq_args *args)
 		.opcode = nvme_admin_ctrl_data_queue,
 		.cdw10 = cdw10,
 		.cdw11 = cdw11,
-		.cdw12 = args->sz,
+		.cdw12 = sz,
 		.addr = (__u64)(uintptr_t)args->data,
 		.data_len = data_len,
 		.timeout_ms = args->timeout,


### PR DESCRIPTION
According to NVMe 2.1 Base Specificaiton, Controller Data Queue Size (CDQSIZE) occupies bits 31:00 of CDW12, so it should be using u32.

![Screenshot 2025-05-02 at 15 31 01](https://github.com/user-attachments/assets/099b05de-ac96-4f28-9aa2-543fc03cbde0)

Note that in other places, like nvme-cli, the correct u32 is used: 

* [nvme-cli/plugins/lm/lm-nvme.c at master · linux-nvme/nvme-cli](https://github.com/linux-nvme/nvme-cli/blob/master/plugins/lm/lm-nvme.c#L67)
* [libnvme/src/nvme/ioctl.c at master · linux-nvme/libnvme](https://github.com/linux-nvme/libnvme/blob/master/src/nvme/ioctl.c#L2325)