### PR TITLE
mi: fix missing braces around initializer warnings

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -43,7 +43,7 @@ executable(
 executable(
     'mi-mctp-csi-test',
     ['mi-mctp-csi-test.c'],
-    dependencies: libnvme_mi_dep,
+    dependencies: [libnvme_mi_dep, threads_dep],
     include_directories: [incdir, internal_incdir]
 )
 

--- a/meson.build
+++ b/meson.build
@@ -238,6 +238,7 @@ conf.set(
     description: 'Is network address and service translation available'
 )
 
+threads_dep = dependency('threads', required: true)
 dl_dep = dependency('dl', required: false)
 conf.set(
     'HAVE_LIBC_DLSYM',


### PR DESCRIPTION
The fix required for the muon build on CentOS.