### PR TITLE
Make examples build selectable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -282,7 +282,9 @@ subdir('libnvme')
 if get_option('tests')
     subdir('test')
 endif
-subdir('examples')
+if get_option('examples')
+    subdir('examples')
+endif
 subdir('doc')
 
 ################################################################################

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('rstdir', type : 'string', value : '', description : 'directory for ReST 
 
 option('docs', type : 'combo', choices : ['false', 'html', 'man', 'rst', 'all'], description : 'install documentation')
 option('docs-build', type : 'boolean', value : false,  description : 'build documentation')
+option('examples', type : 'boolean', value : true, description : 'build examples')
 option('tests', type : 'boolean', value : true, description : 'build tests')
 
 option('python', type : 'feature', value: 'auto', description : 'Generate libnvme python bindings')


### PR DESCRIPTION
Sometimes we don't need to build examples and increase some dependency we don't have(i.e. bits/pthreadtypes.h in musl) so let's add examples option true by default.
