### PR TITLE
tree: handle the case when host_iface/host_traddr are set to "none"

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1714,8 +1714,8 @@ static ctrl_match_t _candidate_init(struct candidate_args *candidate,
 	candidate->trsvcid = trsvcid;
 	candidate->transport = transport;
 	candidate->subsysnqn = subsysnqn;
-	candidate->host_iface = host_iface;
-	candidate->host_traddr = host_traddr;
+	candidate->host_iface = streqcase0(host_iface, "none") ? NULL : host_iface;
+	candidate->host_traddr = streqcase0(host_traddr, "none") ? NULL : host_traddr;
 
 	if (streq0(subsysnqn, NVME_DISC_SUBSYS_NAME)) {
 		/* Since TP8013, the NQN of discovery controllers can be the


### PR DESCRIPTION
When trying to determine if a candidate configuration matches an existing controller connection, treat the candidate's host_iface or host_traddr set to "none" as a NULL pointer.

This is to avoid using host_iface/host_traddr in the comparison with existing connections and falsely concluding that a new connection needs to be created.

This should fix issue: https://github.com/linux-nvme/nvme-cli/issues/2824