### PR TITLE
examples: remove unnecessary include of <bits/pthreadtypes.h>

### DIFF
--- a/examples/mi-mctp-csi-test.c
+++ b/examples/mi-mctp-csi-test.c
@@ -21,7 +21,6 @@
 
 #include <ccan/array_size/array_size.h>
 #include <ccan/endian/endian.h>
-#include <bits/pthreadtypes.h>
 
 void fhexdump(FILE *fp, const unsigned char *buf, int len)
 {


### PR DESCRIPTION
The <bits/*.h> header files are GNU libc specific, and should not be used directly from application code. This one in particular is already included by <pthread.h> on glibc.

Fixes build on musl.

See also #1014.