### PR TITLE
Fix nvme_ns_id_desc packing.

### DIFF
--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -2955,7 +2955,7 @@ struct nvme_ns_id_desc {
 	__u8	nidl;
 	__le16	rsvd;
 	__u8	nid[];
-};
+} __attribute__((packed));
 
 /**
  * enum nvme_ns_id_desc_nidt - Known namespace identifier types


### PR DESCRIPTION
The namespace identifier length (nidl) field can be any length which could potentially lead to unaligned access.

Signed-off-by: Thieu Le <thieule@google.com>