### PR TITLE
mi:     nvme_mi_mi_xfer() is overly restrictive

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -1742,19 +1742,6 @@ int nvme_mi_mi_xfer(nvme_mi_ep_t ep,
 		return -1;
 	}
 
-	/* request and response lengths & offset must be aligned */
-	if ((req_data_size & 0x3) ||
-	    (*resp_data_size & 0x3)) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	/* bidirectional not permitted */
-	if (req_data_size && *resp_data_size) {
-		errno = EINVAL;
-		return -1;
-	}
-
 	mi_req->hdr.type = NVME_MI_MSGTYPE_NVME;
 	mi_req->hdr.nmp = (NVME_MI_ROR_REQ << 7) |
 			  (NVME_MI_MT_MI << 3) |

--- a/test/mi.c
+++ b/test/mi.c
@@ -649,25 +649,9 @@ static void test_mi_invalid_formats(nvme_mi_ep_t ep)
 	ctrl = nvme_mi_init_ctrl(ep, 1);
 	assert(ctrl);
 
-	/* unaligned req size */
-	len = 0;
-
-	rc = nvme_mi_mi_xfer(ep, &req.hdr, 1, &resp, &len);
-	assert(rc != 0);
-
-	/* unaligned resp size */
-	len = 1;
-	rc = nvme_mi_mi_xfer(ep, &req.hdr, 0, &resp, &len);
-	assert(rc != 0);
-
 	/* resp too large */
 	len = 4096 + 4;
 	rc = nvme_mi_mi_xfer(ep, &req.hdr, 0, &resp, &len);
-	assert(rc != 0);
-
-	/* req and resp payloads */
-	len = 4;
-	rc = nvme_mi_mi_xfer(ep, &req.hdr, 4, &resp, &len);
 	assert(rc != 0);
 }
 


### PR DESCRIPTION
MI commands may be unaligned and also have payloads that are being sent and recieved at the same command.  One case of this is AEM Sync. This wasn't seen before because that particular path does not use nvme_mi_mi_xfer().