### PR TITLE
build: disable liburing support per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ A few build options can be specified on the command line when invoking meson.
 | libdbus     | auto, enabled, [disabled] | Enables D-Bus dependent features (libnvme-mi: End point discovery), adds build dependency on libdbus |
 | json-c      | [auto], enabled, disabled | (recommended) Enables JSON-C dependend features (e.g. config.json parsing), adds build depdency on json-c |
 | keyutils    | [auto], enabled, disabled | Enables keyutils dependent features (e.g. authentication), adds build dependency on keyutils |
-| liburing    | [auto], enabled, disabled | Enables liburing dependent features (e.g. get log page by uring cmd), adds build depdency on liburing |
+| liburing    | auto, enabled, [disabled] | Enables liburing dependent features (e.g. get log page by uring cmd), adds build depdency on liburing, very questionable feature. Don't enable it |
 
 See the full configuration options with
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,4 +14,4 @@ option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL suppor
 option('libdbus', type : 'feature', value: 'disabled', description : 'libdbus support')
 option('json-c', type : 'feature', value: 'auto', description : 'JSON support')
 option('keyutils', type: 'feature', value: 'auto', description: 'keyutils support')
-option('liburing', type : 'feature', value: 'auto', description : 'liburing support')
+option('liburing', type : 'feature', value: 'disabled', description : 'liburing support')


### PR DESCRIPTION
The Get Log Page command can be used with io_uring. However, the way it is implemented is highly questionable. In other words, it's a bit crazy.

Therefore, do not enable it unless you fully understand what you're doing.