### PR TITLE
test: add tests for miscellaneous ioctl functions

### DIFF
--- a/test/ioctl/meson.build
+++ b/test/ioctl/meson.build
@@ -83,3 +83,12 @@ zns = executable(
 )
 
 test('zns', zns, env: mock_ioctl_env)
+
+misc = executable(
+    'test-misc',
+    'misc.c',
+    dependencies: libnvme_dep,
+    link_with: mock_ioctl,
+)
+
+test('misc', misc, env: mock_ioctl_env)


### PR DESCRIPTION
Use the mock ioctl infrastructure to test the functions in ioctl.h that issue miscellaneous ioctl commands.