### PR TITLE
types: Add Create Queue Specific (CQS) shift and mask for LM CDQ command

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -2400,7 +2400,7 @@ int nvme_lm_cdq(struct nvme_lm_cdq_args *args)
 		sz = args->sz;
 
 	if (args->sel == NVME_LM_SEL_CREATE_CDQ) {
-		cdw11 = NVME_SET(args->cntlid, LM_CREATE_CDQ_CNTLID) |
+		cdw11 = NVME_SET(NVME_SET(args->cntlid, LM_CREATE_CDQ_CNTLID), LM_CQS) |
 			NVME_LM_CREATE_CDQ_PC;
 		data_len = sz << 2;
 	} else if (args->sel == NVME_LM_SEL_DELETE_CDQ) {

--- a/src/nvme/types.h
+++ b/src/nvme/types.h
@@ -9995,6 +9995,8 @@ struct nvme_ns_mgmt_host_sw_specified {
  * @NVME_LM_QT_SHIFT:			Shift amount to set Queue Type (QT) field relative to MOS
  * @NVME_LM_QT_MASK:			Mask to set QT field relative to MOS
  * @NVME_LM_QT_USER_DATA_MIGRATION_QUEUE: User Data Migration Queue type
+ * @NVME_LM_CQS_SHIFT:			Shift amount for Create Queue Specific (CQS) field
+ * @NVME_LM_CQS_MASK:			Mask to set CQS field
  * @NVME_LM_CREATE_CDQ_PC:		Physically Contiguous (PC)
  * @NVME_LM_CREATE_CDQ_CNTLID_SHIFT:	Shift amount to set CNTLID field relative to MOS
  * @NVME_LM_CREATE_CDQ_CNTLID_MASK:	Mask to set CNTLID field relative to MOS
@@ -10016,6 +10018,8 @@ enum nvme_lm_cdq_fields {
 	/* Controller Data Queue - Create CDQ */
 	NVME_LM_QT_SHIFT			= 0,
 	NVME_LM_QT_MASK				= 0xff,
+	NVME_LM_CQS_SHIFT			= 16,
+	NVME_LM_CQS_MASK			= 0xffff,
 	NVME_LM_QT_USER_DATA_MIGRATION_QUEUE	= 0,
 	NVME_LM_CREATE_CDQ_PC			= 1,
 	NVME_LM_CREATE_CDQ_CNTLID_SHIFT		= 0,


### PR DESCRIPTION
While the NVMe standard defines the Controller Data Queue command's CNTLID field as bits 15:00, this field is offset into CDW11 by the Create Queue Specific (CQS) field in bits 31:16, making the existing CDW format incorrect

Define the `NVME_LM_CQS_SHIFT` and `NVME_LM_CQS_MASK` fields and use the in the `nvme_lm_cdq` ioctl.