### PR TITLE
tree: always set the host key

### DIFF
--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -287,8 +287,10 @@ static void json_update_port(struct json_object *ctrl_array, nvme_ctrl_t c)
 	const char *transport, *value;
 
 	transport = nvme_ctrl_get_transport(c);
-	if (!strcmp(transport, "pcie"))
+	if (!strcmp(transport, "pcie")) {
+		json_object_put(port_obj);
 		return;
+	}
 
 	json_object_object_add(port_obj, "transport",
 			       json_object_new_string(transport));

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1984,9 +1984,7 @@ static void nvme_read_sysfs_dhchap(nvme_root_t r, nvme_ctrl_t c)
 	char *host_key, *ctrl_key;
 
 	host_key = nvme_get_ctrl_attr(c, "dhchap_secret");
-	if (host_key && c->s && c->s->h && c->s->h->dhchap_key &&
-			(!strcmp(c->s->h->dhchap_key, host_key) ||
-			 !strcmp("none", host_key))) {
+	if (host_key && !strcmp(host_key, "none")) {
 		free(host_key);
 		host_key = NULL;
 	}


### PR DESCRIPTION
The current logic will not set the host secret to the controller when
the sysfs value and the value from the host object are identically.

Thus, if the controller has a host key us this one and add it to
controller, if missing try to use the one from the host object.

Signed-off-by: Daniel Wagner <wagi@kernel.org>

