### PR TITLE
linux:  Add functions to set and clear etdas bit

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -2,6 +2,12 @@
 LIBNVME_UNRELEASED {
 };
 
+LIBNVME_1_15 {
+	global:
+		nvme_set_etdas;
+		nvme_clear_etdas;
+};
+
 LIBNVME_1_14 {
 	global:
 		nvme_get_features_temp_thresh2;

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -121,6 +121,41 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 	return err;
 }
 
+int nvme_set_etdas(int fd,
+		bool *host_behavior_changed)
+{
+	__u32 result;
+	int err;
+	struct nvme_feat_host_behavior da4_enable;
+
+	*host_behavior_changed = false;
+	err = nvme_get_features_host_behavior(fd, 0, &da4_enable, &result);
+
+	if (!err && !da4_enable.etdas) {
+		da4_enable.etdas = 1;
+		err = nvme_set_features_host_behavior(fd, 0, &da4_enable);
+		*host_behavior_changed = true;
+	}
+
+	return err;
+}
+
+int nvme_clear_etdas(int fd)
+{
+	__u32 result;
+	int err;
+	struct nvme_feat_host_behavior da4_disable;
+
+	err = nvme_get_features_host_behavior(fd, 0, &da4_disable, &result);
+
+	if (!err && da4_disable.etdas) {
+		da4_disable.etdas = 0;
+		err = nvme_set_features_host_behavior(fd, 0, &da4_disable);
+	}
+
+	return err;
+}
+
 int nvme_get_telemetry_max(int fd, enum nvme_telemetry_da *da, size_t *data_tx)
 {
 	_cleanup_free_ struct nvme_id_ctrl *id_ctrl = NULL;

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -35,6 +35,27 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 			 void *buf);
 
 /**
+ * nvme_set_etdas() - Set the Extended Telemetry Data Area 4 Supported bit
+ * @fd:		File descriptor of nvme device
+ * @host_behavior_changed: boolean to indicate whether or not the host
+ *          behavior support feature had been changed
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_set_etdas(int fd,
+		bool *host_behavior_changed);
+
+/**
+ * nvme_clear_etdas() - Clear the Extended Telemetry Data Area 4 Supported bit
+ * @fd:		File descriptor of nvme device
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_clear_etdas(int fd);
+
+/**
  * nvme_get_telemetry_max() - Get telemetry limits
  * @fd:		File descriptor of nvme device
  * @da:		On success return max supported data area


### PR DESCRIPTION
To retrieve telemetry log data area 4, the Extended Telemetry Data Area 4 Supported in the Host Behavior Support feature needs to be set.  The bit will be cleared after the log has been retrieved.  This commit will add functions to set and clear that bit.