### PR TITLE
tree: do not try to strdup NULL pointer

### DIFF
--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -335,4 +335,11 @@ void __nvme_mi_mctp_set_ops(const struct __mi_mctp_socket_ops *newops);
 int __nvme_import_keys_from_config(nvme_host_t h, nvme_ctrl_t c,
 				   long *keyring_id, long *key_id);
 
+static inline char *xstrdup(const char *s)
+{
+	if (!s)
+		return NULL;
+	return strdup(s);
+}
+
 #endif /* _LIBNVME_PRIVATE_H */

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2073,8 +2073,8 @@ static int nvme_reconfigure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	}
 	closedir(d);
 
-	c->name = strdup(name);
-	c->sysfs_dir = strdup(path);
+	c->name = xstrdup(name);
+	c->sysfs_dir = xstrdup(path);
 	c->firmware = nvme_get_ctrl_attr(c, "firmware_rev");
 	c->model = nvme_get_ctrl_attr(c, "model");
 	c->state = nvme_get_ctrl_attr(c, "state");
@@ -2230,7 +2230,7 @@ skip_address:
 		return NULL;
 	}
 	FREE_CTRL_ATTR(c->address);
-	c->address = strdup(addr);
+	c->address = xstrdup(addr);
 	if (s->subsystype && !strcmp(s->subsystype, "discovery"))
 		c->discovery_ctrl = true;
 	ret = nvme_reconfigure_ctrl(r, c, path, name);


### PR DESCRIPTION
blktests nvme/003 using the loop transport fails because nvme_ctrl_alloc tries to strdup NULL pointers (address or sysfs_dir).

Introduce a 'safe' strdup version and start this version.

Reported-by: Tomáš Bžatek <tbzatek@redhat.com>
Reported-by: Yi Zhang <yi.zhang@redhat.com>
Fixes: e64249888521 ("tree: free ctrl attributes when (re)configure ctrl")

Fixes: #1045 #https://github.com/linux-nvme/nvme-cli/issues/2885