### PR TITLE
linux:  Add functions to set and clear etdas bit

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 LIBNVME_UNRELEASED {
+	global:
+		nvme_set_etdas;
+		nvme_clear_etdas;
 };
 
 LIBNVME_1_14 {

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -121,6 +121,53 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 	return err;
 }
 
+int nvme_set_etdas(int fd, bool *changed)
+{
+	struct nvme_feat_host_behavior da4;
+	int err;
+
+	err = nvme_get_features_host_behavior(fd, 0, &da4, NULL);
+	if (err)
+		return err;
+
+	if (da4.etdas) {
+		*changed = false;
+		return 0;
+	}
+
+	da4.etdas = 1;
+
+	err = nvme_set_features_host_behavior(fd, 0, &da4);
+	if (err)
+		return err;
+
+	*changed = true;
+	return 0;
+}
+
+int nvme_clear_etdas(int fd, bool *changed)
+{
+	struct nvme_feat_host_behavior da4;
+	int err;
+
+	err = nvme_get_features_host_behavior(fd, 0, &da4, NULL);
+	if (err)
+		return err;
+
+	if (!da4.etdas) {
+		*changed = false;
+		return 0;
+	}
+
+	da4.etdas = 0;
+	err = nvme_set_features_host_behavior(fd, 0, &da4);
+	if (err)
+		return err;
+
+	*changed = true;
+	return 0;
+}
+
 int nvme_get_telemetry_max(int fd, enum nvme_telemetry_da *da, size_t *data_tx)
 {
 	_cleanup_free_ struct nvme_id_ctrl *id_ctrl = NULL;

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -35,6 +35,28 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 			 void *buf);
 
 /**
+ * nvme_set_etdas() - Set the Extended Telemetry Data Area 4 Supported bit
+ * @fd:		File descriptor of nvme device
+ * @changed:	boolean to indicate whether or not the host
+ *		behavior support feature had been changed
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_set_etdas(int fd, bool *changed);
+
+/**
+ * nvme_clear_etdas() - Clear the Extended Telemetry Data Area 4 Supported bit
+ * @fd:		File descriptor of nvme device
+ * @changed:	boolean to indicate whether or not the host
+ *		behavior support feature had been changed
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or -1 with errno set otherwise.
+ */
+int nvme_clear_etdas(int fd, bool *changed);
+
+/**
  * nvme_get_telemetry_max() - Get telemetry limits
  * @fd:		File descriptor of nvme device
  * @da:		On success return max supported data area


### PR DESCRIPTION
To retrieve telemetry log data area 4, the Extended Telemetry Data Area 4 Supported in the Host Behavior Support feature needs to be set.  The bit will be cleared after the log has been retrieved.  This commit will add functions to set and clear that bit.


[wagi: - added changed argument to clear function
       - refactored error handling (return early)]

substituted : #1044 