### PR TITLE
Fixup HKDF-Expand-Label algorithm

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -3,6 +3,8 @@ LIBNVME_UNRELEASED {
 	global:
 		nvme_set_etdas;
 		nvme_clear_etdas;
+		nvme_insert_tls_key_compat;
+		nvme_generate_tls_key_identity_compat;
 };
 
 LIBNVME_1_14 {

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1344,10 +1344,10 @@ int nvme_scan_tls_keys(const char *keyring, nvme_scan_tls_keys_cb_t cb,
 	return ret;
 }
 
-static long __nvme_insert_tls_key_versioned(key_serial_t keyring_id, const char *key_type,
-					    const char *hostnqn, const char *subsysnqn,
-					    int version, int hmac,
-					    unsigned char *configured_key, int key_len)
+static long __nvme_insert_tls_key(key_serial_t keyring_id, const char *key_type,
+				  const char *hostnqn, const char *subsysnqn,
+				  int version, int hmac,
+				  unsigned char *configured_key, int key_len)
 {
 	_cleanup_free_ unsigned char *psk = NULL;
 	_cleanup_free_ char *identity = NULL;
@@ -1401,10 +1401,10 @@ long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
 	ret = nvme_set_keyring(keyring_id);
 	if (ret < 0)
 		return 0;
-	return __nvme_insert_tls_key_versioned(keyring_id, key_type,
-					       hostnqn, subsysnqn,
-					       version, hmac,
-					       configured_key, key_len);
+	return __nvme_insert_tls_key(keyring_id, key_type,
+				     hostnqn, subsysnqn,
+				     version, hmac,
+				     configured_key, key_len);
 }
 
 long nvme_revoke_tls_key(const char *keyring, const char *key_type,
@@ -1447,10 +1447,10 @@ static long __nvme_import_tls_key(long keyring_id,
 		 * configured key. Derive a new key and load the newly
 		 * created key into the keystore.
 		 */
-		return __nvme_insert_tls_key_versioned(keyring_id, "psk",
-						       hostnqn, subsysnqn,
-						       version, hmac,
-						       key_data, key_len);
+		return __nvme_insert_tls_key(keyring_id, "psk",
+					     hostnqn, subsysnqn,
+					     version, hmac,
+					     key_data, key_len);
 	}
 
 	return nvme_update_key(keyring_id, "psk", identity,

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1156,22 +1156,29 @@ char *nvme_generate_tls_key_identity(const char *hostnqn, const char *subsysnqn,
 	int ret = -1;
 
 	identity_len = nvme_identity_len(hmac, version, hostnqn, subsysnqn);
-	if (identity_len < 0)
+	if (identity_len < 0) {
+		errno = EINVAL;
 		return NULL;
+	}
 
 	identity = malloc(identity_len);
-	if (!identity)
+	if (!identity) {
+		errno = ENOMEM;
 		return NULL;
+	}
 
 	psk = malloc(key_len);
-	if (!psk)
+	if (!psk) {
+		errno = ENOMEM;
 		goto out_free_identity;
+	}
 
 	memset(psk, 0, key_len);
 	ret = derive_nvme_keys(hostnqn, subsysnqn, identity, version, hmac,
 			       configured_key, psk, key_len);
 out_free_identity:
 	if (ret < 0) {
+		errno = -ret;
 		free(identity);
 		identity = NULL;
 	}

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1426,7 +1426,7 @@ long nvme_revoke_tls_key(const char *keyring, const char *key_type,
 	return keyctl_revoke(key);
 }
 
-static long __nvme_insert_tls_key(long keyring_id,
+static long __nvme_import_tls_key(long keyring_id,
 				  const char *hostnqn, const char *subsysnqn,
 				  const char *identity, const char *key)
 {
@@ -1505,7 +1505,7 @@ int __nvme_import_keys_from_config(nvme_host_t h, nvme_ctrl_t c,
 		id = nvme_lookup_key("psk", identity);
 
 	if (!id)
-		id = __nvme_insert_tls_key(kr_id, hostnqn,
+		id = __nvme_import_tls_key(kr_id, hostnqn,
 					   subsysnqn, identity, key);
 
 	if (id <= 0) {

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -401,6 +401,32 @@ long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
 				   unsigned char *configured_key, int key_len);
 
 /**
+ * nvme_insert_tls_key_compat() - Derive and insert TLS key
+ * @keyring:    Keyring to use
+ * @key_type:	Type of the resulting key
+ * @hostnqn:	Host NVMe Qualified Name
+ * @subsysnqn:	Subsystem NVMe Qualified Name
+ * @version:	Key version to use
+ * @hmac:	HMAC algorithm
+ * @configured_key:	Configured key data to derive the key from
+ * @key_len:	Length of @configured_key
+ *
+ * Derives a 'retained' TLS key as specified in NVMe TCP 1.0a (if
+ * @version s set to '0') or NVMe TP8028 (if @version is set to '1) and
+ * stores it as type @key_type in the keyring specified by @keyring.
+ * This version differs from @nvme_insert_tls_key_versioned() in that it
+ * uses the original implementation for HKDF Expand-Label which does not
+ * prefix the 'info' and 'label' strings with the length.
+ *
+ * Return: The key serial number if the key could be inserted into
+ * the keyring or 0 with errno otherwise.
+ */
+long nvme_insert_tls_key_compat(const char *keyring, const char *key_type,
+				const char *hostnqn, const char *subsysnqn,
+				   int version, int hmac,
+				   unsigned char *configured_key, int key_len);
+
+/**
  * nvme_generate_tls_key_identity() - Generate the TLS key identity
  * @hostnqn:	Host NVMe Qualified Name
  * @subsysnqn:	Subsystem NVMe Qualified Name
@@ -419,6 +445,30 @@ long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
 char *nvme_generate_tls_key_identity(const char *hostnqn, const char *subsysnqn,
 				     int version, int hmac,
 				     unsigned char *configured_key, int key_len);
+
+/**
+ * nvme_generate_tls_key_identity_compat() - Generate the TLS key identity
+ * @hostnqn:	Host NVMe Qualified Name
+ * @subsysnqn:	Subsystem NVMe Qualified Name
+ * @version:	Key version to use
+ * @hmac:	HMAC algorithm
+ * @configured_key:	Configured key data to derive the key from
+ * @key_len:	Length of @configured_key
+ *
+ * Derives a 'retained' TLS key as specified in NVMe TCP and
+ * generate the corresponding TLs identity. This version differs
+ * from @nvme_generate_tls_key_identity() in that it uses the original
+ * implementation for HKDF-Expand-Label which does not prefix the 'info'
+ * and 'label' string with the length.
+ *
+ * Return: The string containing the TLS identity. It is the responsibility
+ * of the caller to free the returned string.
+ */
+char *nvme_generate_tls_key_identity_compat(const char *hostnqn,
+					    const char *subsysnqn,
+					    int version, int hmac,
+					    unsigned char *configured_key,
+					    int key_len);
 
 /**
  * nvme_revoke_tls_key() - Revoke TLS key from keyring

--- a/src/nvme/linux.h
+++ b/src/nvme/linux.h
@@ -413,7 +413,8 @@ long nvme_insert_tls_key_versioned(const char *keyring, const char *key_type,
  * generate the corresponding TLs identity.
  *
  * Return: The string containing the TLS identity. It is the responsibility
- * of the caller to free the returned string.
+ * of the caller to free the returned string. On error NULL is returned with
+ * errno set.
  */
 char *nvme_generate_tls_key_identity(const char *hostnqn, const char *subsysnqn,
 				     int version, int hmac,


### PR DESCRIPTION
Hi all,

here's my attempt to fixup the HKDF-Expand-Label algorithm. The first patch (from Chris Leech) implements the RFC-conformant algorithm for HKDF-Expand-Label, and the second patch adds back the original implementation via a new function nvme_import_tls_key_compat()