### PR TITLE
docs: add missing API types documentation

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -9,6 +9,7 @@
 #
 
 api_files = [
+  'api-types.h',
   'fabrics.h',
   'filters.h',
   'ioctl.h',


### PR DESCRIPTION
The api-types.h file was not included during documentation generation, thus not being available in the online doc. It was containing some important structures used as arguments for some function calls.