### PR TITLE
Rework controller reconfiguation

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1149,6 +1149,13 @@ static struct nvmf_discovery_log *nvme_discovery_log(
 		.uuidx = NVME_UUID_NONE,
 	};
 
+	if (!name) {
+		nvme_msg(r, LOG_ERR,
+			 "controller not connected\n");
+		errno = ENOTCONN;
+		return NULL;
+	}
+
 	log = __nvme_alloc(sizeof(*log));
 	if (!log) {
 		nvme_msg(r, LOG_ERR,

--- a/src/nvme/private.h
+++ b/src/nvme/private.h
@@ -75,7 +75,22 @@ struct nvme_ctrl {
 	struct list_head paths;
 	struct list_head namespaces;
 	struct nvme_subsystem *s;
+	struct nvme_fabrics_config cfg;
 
+	/* Immutable attributes */
+	char *transport;
+	char *subsysnqn;
+	char *traddr;
+	char *trsvcid;
+
+	/* persistent across reconfiguration */
+	char *dhchap_key;
+	char *dhchap_ctrl_key;
+	char *keyring;
+	char *tls_key_identity;
+	char *tls_key;
+
+	/* reset during reconfiguration */
 	int fd;
 	char *name;
 	char *sysfs_dir;
@@ -87,15 +102,6 @@ struct nvme_ctrl {
 	char *queue_count;
 	char *serial;
 	char *sqsize;
-	char *transport;
-	char *subsysnqn;
-	char *traddr;
-	char *trsvcid;
-	char *dhchap_key;
-	char *dhchap_ctrl_key;
-	char *keyring;
-	char *tls_key_identity;
-	char *tls_key;
 	char *cntrltype;
 	char *cntlid;
 	char *dctype;
@@ -104,7 +110,6 @@ struct nvme_ctrl {
 	bool unique_discovery_ctrl;
 	bool discovered;
 	bool persistent;
-	struct nvme_fabrics_config cfg;
 };
 
 struct nvme_subsystem {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -1311,7 +1311,7 @@ nvme_path_t nvme_ctrl_next_path(nvme_ctrl_t c, nvme_path_t p)
 
 #define FREE_CTRL_ATTR(a) \
 	do { free(a); (a) = NULL; } while (0)
-void nvme_deconfigure_ctrl(nvme_ctrl_t c)
+static void __nvme_deconfigure_ctrl(nvme_ctrl_t c)
 {
 	nvme_ctrl_release_fd(c);
 	FREE_CTRL_ATTR(c->name);
@@ -1323,16 +1323,21 @@ void nvme_deconfigure_ctrl(nvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->queue_count);
 	FREE_CTRL_ATTR(c->serial);
 	FREE_CTRL_ATTR(c->sqsize);
-	FREE_CTRL_ATTR(c->dhchap_key);
-	FREE_CTRL_ATTR(c->dhchap_ctrl_key);
-	FREE_CTRL_ATTR(c->keyring);
-	FREE_CTRL_ATTR(c->tls_key_identity);
-	FREE_CTRL_ATTR(c->tls_key);
 	FREE_CTRL_ATTR(c->address);
 	FREE_CTRL_ATTR(c->dctype);
 	FREE_CTRL_ATTR(c->cntrltype);
 	FREE_CTRL_ATTR(c->cntlid);
 	FREE_CTRL_ATTR(c->phy_slot);
+}
+
+void nvme_deconfigure_ctrl(nvme_ctrl_t c)
+{
+	__nvme_deconfigure_ctrl(c);
+	FREE_CTRL_ATTR(c->dhchap_key);
+	FREE_CTRL_ATTR(c->dhchap_ctrl_key);
+	FREE_CTRL_ATTR(c->keyring);
+	FREE_CTRL_ATTR(c->tls_key_identity);
+	FREE_CTRL_ATTR(c->tls_key);
 }
 
 int nvme_disconnect_ctrl(nvme_ctrl_t c)
@@ -2049,20 +2054,7 @@ static int nvme_reconfigure_ctrl(nvme_root_t r, nvme_ctrl_t c, const char *path,
 	 * It's necesssary to release any resources first because a ctrl
 	 * can be reused.
 	 */
-	nvme_ctrl_release_fd(c);
-	FREE_CTRL_ATTR(c->name);
-	FREE_CTRL_ATTR(c->sysfs_dir);
-	FREE_CTRL_ATTR(c->firmware);
-	FREE_CTRL_ATTR(c->model);
-	FREE_CTRL_ATTR(c->state);
-	FREE_CTRL_ATTR(c->numa_node);
-	FREE_CTRL_ATTR(c->queue_count);
-	FREE_CTRL_ATTR(c->serial);
-	FREE_CTRL_ATTR(c->sqsize);
-	FREE_CTRL_ATTR(c->cntrltype);
-	FREE_CTRL_ATTR(c->cntlid);
-	FREE_CTRL_ATTR(c->dctype);
-	FREE_CTRL_ATTR(c->phy_slot);
+	__nvme_deconfigure_ctrl(c);
 
 	d = opendir(path);
 	if (!d) {

--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -245,6 +245,9 @@ static void nvme_filter_ctrl(nvme_root_t r, nvme_ctrl_t c,
 	if (f(NULL, c, NULL, f_args))
 		return;
 
+	if (!nvme_ctrl_get_name(c))
+		return;
+
 	nvme_msg(r, LOG_DEBUG, "filter out controller %s\n",
 		 nvme_ctrl_get_name(c));
 	nvme_free_ctrl(c);
@@ -1815,6 +1818,8 @@ nvme_ctrl_t __nvme_lookup_ctrl(nvme_subsystem_t s, const char *transport,
 
 	c = p ? nvme_subsystem_next_ctrl(s, p) : nvme_subsystem_first_ctrl(s);
 	for (; c != NULL; c = nvme_subsystem_next_ctrl(s, c)) {
+		if (!nvme_ctrl_get_name(c))
+			continue;
 		if (ctrl_match(c, &candidate)) {
 			matching_c = c;
 			break;


### PR DESCRIPTION
Calling nvme_reconfigure_ctrl() requires some attributes to be cleared and other to remain constant. This patchset documents the scope of the controller attributes, and also ensures that the code does not trip over an empty 'name' attribute (which is volatile and only set after 'connect' succeeded).

Fixes: https://github.com/linux-nvme/libnvme/issues/951