### PR TITLE
linux: use EVP_PKEY_CTX_add1_hkdf_info only once in compat function

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -252,6 +252,22 @@ else
   conf.set('fallthrough', 'do {} while (0) /* fallthrough */')
 endif
 
+if openssl_dep.found()
+  if openssl_dep.type_name() != 'internal'
+    # Check for a bug in the EVP_PKEY_CTX_add1_hkdf_info implementation
+    res = cc.run(
+        files('test/hkdf_add1.c'),
+        dependencies: [openssl_dep],
+        name: 'check hkdf_add1'
+    )
+    if res.returncode() == 1
+      warning('EVP_PKEY_CTX_add1_hkdf_info bahaves incorrectly')
+    else
+      message('EVP_PKEY_CTX_add1_hkdf_info behaves sanely')
+    endif
+  endif
+endif
+
 ################################################################################
 substs = configuration_data()
 substs.set('NAME',    meson.project_name())

--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -1275,7 +1275,7 @@ static int gen_tls_identity(const char *hostnqn, const char *subsysnqn,
 			version, cipher, hostnqn, subsysnqn);
 		return strlen(identity);
 	}
-	if (version > 1) {
+	if (version > 1 || !digest) {
 		errno = EINVAL;
 		return -1;
 	}

--- a/test/hkdf_add1.c
+++ b/test/hkdf_add1.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/**
+ * This file is part of libnvme.
+ * Copyright (c) 2025 SUSE LLC.
+ *
+ * Authors: Daniel Wagner <wagi@kernel.org>
+ */
+
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/kdf.h>
+#include <openssl/params.h>
+#include <stdio.h>
+#include <string.h>
+
+#define SHA256_LEN 32
+
+static EVP_PKEY_CTX *setup_ctx(void)
+{
+	EVP_PKEY_CTX *ctx = NULL;
+	const char *salt = "salt";
+	const char *key = "key";
+
+	ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+	if (!ctx)
+		return NULL;
+	if (EVP_PKEY_derive_init(ctx) <= 0)
+		goto free_ctx;
+	if (EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha256()) <= 0)
+		goto free_ctx;
+	if (EVP_PKEY_CTX_set1_hkdf_salt(ctx,
+			(unsigned char *)salt, strlen(salt)) <= 0)
+		goto free_ctx;
+	if (EVP_PKEY_CTX_set1_hkdf_key(ctx,
+			(unsigned char *)key, strlen(key)) <= 0)
+		goto free_ctx;
+
+	return ctx;
+
+free_ctx:
+	EVP_PKEY_CTX_free(ctx);
+	return NULL;
+}
+
+int main(void)
+{
+	unsigned char out[SHA256_LEN], out2[SHA256_LEN];
+	size_t len = sizeof(out);
+	const char *a = "a";
+	const char *b = "b";
+	EVP_PKEY_CTX *ctx;
+
+	/* out = A + B */
+	ctx = setup_ctx();
+	if (!ctx)
+		return 1;
+	if (EVP_PKEY_CTX_add1_hkdf_info(ctx,
+			(unsigned char *)a, strlen(a)) <= 0)
+		goto free_ctx;
+	if (EVP_PKEY_CTX_add1_hkdf_info(ctx,
+			(unsigned char *)b, strlen(b)) <= 0)
+		goto free_ctx;
+	if (EVP_PKEY_derive(ctx, out, &len) <= 0)
+		goto free_ctx;
+	EVP_PKEY_CTX_free(ctx);
+
+	/* out = B */
+	ctx = setup_ctx();
+	if (!ctx)
+		return 1;
+	if (EVP_PKEY_CTX_add1_hkdf_info(ctx,
+			(unsigned char *)b, strlen(b)) <= 0)
+		goto free_ctx;
+	if (EVP_PKEY_derive(ctx, out2, &len) <= 0)
+		goto free_ctx;
+	EVP_PKEY_CTX_free(ctx);
+
+	printf("EVP_PKEY_CTX_add1_hkdf_info behavior: ");
+	if (!memcmp(out, out2, len)) {
+		printf("set\n");
+		return 1;
+	}
+
+	printf("add\n");
+	return 0;
+
+free_ctx:
+	EVP_PKEY_CTX_free(ctx);
+	return 1;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -131,3 +131,11 @@ if json_c_dep.found()
     subdir('sysfs')
     subdir('config')
 endif
+
+if openssl_dep.found()
+  hkdf_add1 = executable(
+      'hkdf_add1',
+      ['hkdf_add1.c'],
+      dependencies: openssl_dep,
+  )
+endif


### PR DESCRIPTION
linux: use EVP_PKEY_CTX_add1_hkdf_info only once in compat function

OpenSSL prior to 3.3.1 had an issue with EVP_PKEY_CTX_add1_hkdf_info()
where it acted like a 'set1' function instead of an 'add1' as
documented.  Work around that by building the entire info vector outside
of the OpenSSL API and only calling this function once.

This is the same workaround used in commit eff0ffef0273 ("linux: fix
HKDF TLS key derivation back to OpenSSL 3.0.8").

Signed-off-by: Daniel Wagner <wagi@kernel.org>

Fixes: #1053
