### PR TITLE
mi-mctp: Fix compile error for test/mi-mctp.c when !HAVE_LINUX_MCTP_H

### DIFF
--- a/src/nvme/mi-mctp-compat.h
+++ b/src/nvme/mi-mctp-compat.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#ifndef _MI_MCTP_COMPAT_H
+#define _MI_MCTP_COMPAT_H
+
+#include <linux/types.h>
+
+/* As of kernel v5.15, these AF_MCTP-related definitions are provided by
+ * linux/mctp.h. However, we provide a set here while that header percolates
+ * through to standard includes.
+ *
+ * These were all introduced in the same version as AF_MCTP was defined,
+ * so we can key off the presence of that.
+ */
+
+typedef __u8			mctp_eid_t;
+
+struct mctp_addr {
+	mctp_eid_t		s_addr;
+};
+
+struct sockaddr_mctp {
+	unsigned short int	smctp_family;
+	__u16			__smctp_pad0;
+	unsigned int		smctp_network;
+	struct mctp_addr	smctp_addr;
+	__u8			smctp_type;
+	__u8			smctp_tag;
+	__u8			__smctp_pad1;
+};
+
+#define MCTP_NET_ANY		0x0
+
+#define MCTP_ADDR_NULL		0x00
+#define MCTP_ADDR_ANY		0xff
+
+#define MCTP_TAG_MASK		0x07
+#define MCTP_TAG_OWNER		0x08
+
+#endif /* _MI_MCTP_COMPAT_H */

--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -20,6 +20,8 @@
 
 #if HAVE_LINUX_MCTP_H
 #include <linux/mctp.h>
+#else
+#include "nvme/mi-mctp-compat.h"
 #endif
 
 #include <ccan/endian/endian.h>
@@ -40,41 +42,6 @@
 #if !defined(AF_MCTP)
 #define AF_MCTP 45
 #endif
-
-#if !HAVE_LINUX_MCTP_H
-/* As of kernel v5.15, these AF_MCTP-related definitions are provided by
- * linux/mctp.h. However, we provide a set here while that header percolates
- * through to standard includes.
- *
- * These were all introduced in the same version as AF_MCTP was defined,
- * so we can key off the presence of that.
- */
-
-typedef __u8			mctp_eid_t;
-
-struct mctp_addr {
-	mctp_eid_t		s_addr;
-};
-
-struct sockaddr_mctp {
-	unsigned short int	smctp_family;
-	__u16			__smctp_pad0;
-	unsigned int		smctp_network;
-	struct mctp_addr	smctp_addr;
-	__u8			smctp_type;
-	__u8			smctp_tag;
-	__u8			__smctp_pad1;
-};
-
-#define MCTP_NET_ANY		0x0
-
-#define MCTP_ADDR_NULL		0x00
-#define MCTP_ADDR_ANY		0xff
-
-#define MCTP_TAG_MASK		0x07
-#define MCTP_TAG_OWNER		0x08
-
-#endif /* !AF_MCTP */
 
 #if !defined(MCTP_TAG_PREALLOC)
 /*Adding this here for users with older build MCTP header

--- a/test/mi-mctp.c
+++ b/test/mi-mctp.c
@@ -22,6 +22,12 @@
 #include "nvme/private.h"
 #include "utils.h"
 
+#if HAVE_LINUX_MCTP_H
+#include <linux/mctp.h>
+#else
+#include "nvme/mi-mctp-compat.h"
+#endif
+
 /* 4096 byte max MCTP message, plus space for header data */
 #define MAX_BUFSIZ 8192
 


### PR DESCRIPTION
This PR fixes an issue when building the project on systems that don't support the <linux/mctp.h> header file.