### PR TITLE
build: avoid breaking cross builds with OpenSSL enabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -252,7 +252,7 @@ else
   conf.set('fallthrough', 'do {} while (0) /* fallthrough */')
 endif
 
-if openssl_dep.found()
+if openssl_dep.found() and meson.can_run_host_binaries()
   if openssl_dep.type_name() != 'internal'
     # Check for a bug in the EVP_PKEY_CTX_add1_hkdf_info implementation
     res = cc.run(


### PR DESCRIPTION
The OpenSSL sanity check wants to be executed, thus we should only try this if it's possible. Since this is just a warning, we can just skip it if if it is not possible.

Fixes: #1089 