### PR TITLE
tree: Fix potential NULL pointer dereference in nvme_host_get_ids()

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -145,9 +145,9 @@ int nvme_host_get_ids(nvme_root_t r,
 	h = nvme_first_host(r);
 	if (h) {
 		if (!hid)
-			hid = strdup(nvme_host_get_hostid(h));
+			hid = xstrdup(nvme_host_get_hostid(h));
 		if (!hnqn)
-			hnqn = strdup(nvme_host_get_hostnqn(h));
+			hnqn = xstrdup(nvme_host_get_hostnqn(h));
 	}
 
 	/* /etc/nvme/hostid and/or /etc/nvme/hostnqn */


### PR DESCRIPTION
The nvme_host_get_hostid() and nvme_host_get_hostnqn() functions can return NULL when the host configuration is incomplete or invalid. Using strdup() directly on these return values causes a segmentation fault when NULL is passed to strdup().

Replace strdup() calls with xstrdup() to safely handle NULL input values.