### PR TITLE
tree: fix nvme_subsystem_scan_namespaces() return handling

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -883,7 +883,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name)
 				continue;
 			if (strcmp(_s->name, name))
 				continue;
-			if (!nvme_subsystem_scan_namespaces(r, _s)) {
+			if (nvme_subsystem_scan_namespaces(r, _s)) {
 				errno = EINVAL;
 				return -1;
 			}
@@ -904,7 +904,7 @@ static int nvme_scan_subsystem(struct nvme_root *r, const char *name)
 			errno = ENOMEM;
 			return -1;
 		}
-		if (!nvme_subsystem_scan_namespaces(r, s)) {
+		if (nvme_subsystem_scan_namespaces(r, s)) {
 			errno = EINVAL;
 			return -1;
 		}


### PR DESCRIPTION
nvme list-subsys with the -vv option currently displays the following:

scan controller nvme0
lookup subsystem /sys/class/nvme-subsystem/nvme-subsys0/nvme0 scan controller nvme0 path nvme0c0n1
scan subsystem nvme-subsys0
scan subsystem nvme-subsys0 namespace nvme0n1
failed to scan subsystem nvme-subsys0: Invalid argument ...

The invalid argument seen above is due to the wrong return handling of nvme_subsystem_scan_namespaces() in nvme_scan_subsystem(). Fix the same.


(upstream nvme-cli commit 8a4df2bc2c66ac403b11902708aec622fa07bf0e)

Fixes: #1104 