### PR TITLE
fix: fix store uuid/nguid from sysfs

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2704,7 +2704,12 @@ static int nvme_strtoeuid(const char *str, void *res)
 
 static int nvme_strtouuid(const char *str, void *res)
 {
-	memcpy(res, str, NVME_UUID_LEN);
+	unsigned char uuid[NVME_UUID_LEN];
+
+	if (nvme_uuid_from_string(str, uuid))
+		return -EINVAL;
+
+	memcpy(res, uuid, NVME_UUID_LEN);
 	return 0;
 }
 


### PR DESCRIPTION
In sysfs, the UUID is stored as a string with hyphens. You don't need to save the hyphens in the binary representation of the UUID, otherwise you'll get truncated output.