### PR TITLE
add missing sym

### DIFF
--- a/scripts/generate-sym-test.py
+++ b/scripts/generate-sym-test.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import re
+import sys
+from pathlib import Path
+from typing import IO
+
+
+def process_sym_file(file: IO[str]) -> None:
+    for line in file:
+        m = re.search(r'^\s+([a-zA-Z0-9_]+);', line)
+        if m:
+            print(f'        {{ "{m[1]}", {m[1]} }},')
+
+
+def include_name(header: str) -> str:
+    path = Path(header)
+
+    if path.name.startswith("libnvme"):
+        return path.name
+
+    parts = path.parts
+    if "nvme" in parts:
+        idx = parts.index("nvme")
+        return "/".join(parts[idx:])
+
+    return path.name
+
+
+def iter_header_statements(file: IO[str]) -> list[str]:
+    text = re.sub(r'/\*.*?\*/', '', file.read(), flags=re.S)
+    statements = []
+    current = []
+    brace_depth = 0
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+
+        if brace_depth:
+            brace_depth += line.count('{') - line.count('}')
+            continue
+
+        if not current:
+            if line[:1].isspace():
+                continue
+            if stripped.startswith(('typedef', 'extern "C"')):
+                continue
+            if stripped.startswith(('struct ', 'enum ', 'union ')) and '(' not in stripped:
+                continue
+
+        current.append(stripped)
+        statement = ' '.join(current)
+
+        if '{' in statement:
+            brace_depth = statement.count('{') - statement.count('}')
+            current = []
+            continue
+
+        if ';' not in statement:
+            continue
+
+        statements.append(statement)
+        current = []
+
+    return statements
+
+
+def process_header_file(file: IO[str]) -> str:
+    text = ''
+
+    for statement in iter_header_statements(file):
+        if statement.startswith(('}', 'static ', 'typedef ')):
+            continue
+        if statement.startswith(('struct ', 'enum ', 'union ')) and '(' not in statement:
+            continue
+
+        statement = re.sub(r'\s*__attribute__\s*\(\(.*?\)\)', '', statement)
+        statement = re.sub(r'\s+', ' ', statement).strip()
+
+        m = re.search(r'^(\S+\s+)+\**(\w+)\s*\(', statement)
+        if m:
+            if not m[2].startswith(('nvme_', 'nvmf_')):
+                continue
+            text += f'        {{ "{m[2]}", {m[2]} }},\n'
+
+    return text
+
+
+print('''/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+''')
+
+for header in sys.argv[2:]:
+    with open(header, 'r') as f:
+        if process_header_file(f):
+            print(f'#include <{include_name(header)}>')
+
+print('''
+/* We want to check deprecated symbols too, without complaining. */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+''')
+
+print('''
+struct symbol {
+        const char *name;
+        const void *symbol;
+};
+static struct symbol symbols_from_sym[] = {''')
+
+with open(sys.argv[1], 'r') as f:
+    process_sym_file(f)
+
+print('''        {}
+}, symbols_from_header[] = {''')
+
+for header in sys.argv[2:]:
+    with open(header, 'r') as f:
+        print(process_header_file(f), end='')
+
+print('''        {}
+};
+
+static int sort_callback(const void *a, const void *b) {
+        const struct symbol *x = a, *y = b;
+        return strcmp(x->name, y->name);
+}
+
+int main(void) {
+        size_t size = sizeof(symbols_from_sym[0]),
+                n_sym = sizeof(symbols_from_sym)/sizeof(symbols_from_sym[0]) - 1,
+                n_header = sizeof(symbols_from_header)/sizeof(symbols_from_header[0]) - 1;
+
+        qsort(symbols_from_sym, n_sym, size, sort_callback);
+        qsort(symbols_from_header, n_header, size, sort_callback);
+
+        puts("From symbol file:");
+        for (size_t i = 0; i < n_sym; i++)
+                printf("%p: %s\\n", symbols_from_sym[i].symbol, symbols_from_sym[i].name);
+
+        puts("\\nFrom header files:");
+        for (size_t i = 0; i < n_header; i++)
+                printf("%p: %s\\n", symbols_from_header[i].symbol, symbols_from_header[i].name);
+
+        puts("");
+        printf("Found %zu symbols from symbol file.\\n", n_sym);
+        printf("Found %zu symbols from header files.\\n", n_header);
+
+        unsigned n_error = 0;
+
+        for (size_t i = 0; i < n_sym; i++)
+                if (!bsearch(symbols_from_sym+i, symbols_from_header, n_header, size, sort_callback)) {
+                        printf("Found in symbol file, but not in headers: %s\\n", symbols_from_sym[i].name);
+                        n_error++;
+                }
+
+        for (size_t i = 0; i < n_header; i++)
+                if (!bsearch(symbols_from_header+i, symbols_from_sym, n_sym, size, sort_callback)) {
+                        printf("Found in header file, but not in symbol file: %s\\n", symbols_from_header[i].name);
+                        n_error++;
+                }
+
+        return n_error == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}''')

--- a/src/libnvme-mi.map
+++ b/src/libnvme-mi.map
@@ -1,5 +1,21 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 LIBNVME_MI_UNRELEASED {
+	global:
+		nvme_mi_aem_aeei_get_aee;
+		nvme_mi_aem_aeei_get_aeeid;
+		nvme_mi_aem_aeei_set_aee;
+		nvme_mi_aem_aeei_set_aeeid;
+		nvme_mi_aem_aemti_get_aemgn;
+		nvme_mi_aem_aeolli_get_aeoltl;
+		nvme_mi_aem_aeolli_set_aeoltl;
+		nvme_mi_aem_aesi_get_aese;
+		nvme_mi_aem_aesi_get_aesid;
+		nvme_mi_aem_aesi_set_aee;
+		nvme_mi_aem_aesi_set_aesid;
+		nvme_mi_aem_open;
+		nvme_mi_ep_set_mprt_max;
+		nvme_mi_mi_config_get_async_event;
+		nvme_mi_mi_config_set_async_event;
 };
 
 LIBNVME_MI_1_15 {

--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -1,5 +1,14 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 LIBNVME_UNRELEASED {
+	global:
+		nvme_ctrl_is_discovered;
+		nvme_ctrl_set_discovered;
+		nvme_get_lba_status_log;
+		nvme_iface_matching_addr;
+		nvme_iface_primary_addr_matches;
+		nvme_ns_head_get_sysfs_dir;
+		nvme_ns_identify_descs;
+		nvme_scan_ns_head_paths;
 };
 
 LIBNVME_1_16 {

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,6 +47,19 @@ mapfile = 'libnvme.map'
 version_script_arg = join_paths(source_dir, mapfile)
 mi_mapfile = 'libnvme-mi.map'
 mi_version_script_arg = join_paths(source_dir, mi_mapfile)
+libnvme_sym = files(mapfile)
+libnvme_mi_sym = files(mi_mapfile)
+libnvme_sym_headers = files(
+    'nvme/fabrics.h',
+    'nvme/filters.h',
+    'nvme/ioctl.h',
+    'nvme/linux.h',
+    'nvme/log.h',
+    'nvme/nbft.h',
+    'nvme/tree.h',
+    'nvme/util.h',
+)
+libnvme_mi_sym_headers = files('nvme/mi.h')
 
 libnvme = library(
     'nvme', # produces libnvme.so

--- a/src/nvme/mi.h
+++ b/src/nvme/mi.h
@@ -971,6 +971,36 @@ __u16 nvme_mi_ctrl_id(nvme_mi_ctrl_t ctrl);
  */
 char *nvme_mi_endpoint_desc(nvme_mi_ep_t ep);
 
+/**
+ * nvme_mi_submit_entry() - Weak hook called before submitting an MI request
+ * @type: message type
+ * @hdr: request message header
+ * @hdr_len: request message header length
+ * @data: request payload
+ * @data_len: request payload length
+ *
+ * This weak function may be overridden by applications for request logging.
+ *
+ * Return: user data to pass to &nvme_mi_submit_exit().
+ */
+void *nvme_mi_submit_entry(__u8 type, const struct nvme_mi_msg_hdr *hdr,
+			   size_t hdr_len, const void *data, size_t data_len);
+
+/**
+ * nvme_mi_submit_exit() - Weak hook called after receiving an MI response
+ * @type: message type
+ * @hdr: response message header
+ * @hdr_len: response message header length
+ * @data: response payload
+ * @data_len: response payload length
+ * @user_data: user data returned from &nvme_mi_submit_entry()
+ *
+ * This weak function may be overridden by applications for response logging.
+ */
+void nvme_mi_submit_exit(__u8 type, const struct nvme_mi_msg_hdr *hdr,
+			 size_t hdr_len, const void *data, size_t data_len,
+			 void *user_data);
+
 /* MI Command API: nvme_mi_mi_ prefix */
 
 /**

--- a/test/meson.build
+++ b/test/meson.build
@@ -124,6 +124,42 @@ psk = executable(
 
 test('psk', psk)
 
+generate_sym_test = files('../scripts/generate-sym-test.py')
+
+test_libnvme_sym_c = custom_target(
+    'test-libnvme-sym.c',
+    input: [libnvme_sym, libnvme_sym_headers],
+    output: 'test-libnvme-sym.c',
+    command: [generate_sym_test, libnvme_sym, libnvme_sym_headers],
+    capture: true,
+    depend_files: generate_sym_test,
+)
+
+test_libnvme_mi_sym_c = custom_target(
+    'test-libnvme-mi-sym.c',
+    input: [libnvme_mi_sym, libnvme_mi_sym_headers],
+    output: 'test-libnvme-mi-sym.c',
+    command: [generate_sym_test, libnvme_mi_sym, libnvme_mi_sym_headers],
+    capture: true,
+    depend_files: generate_sym_test,
+)
+
+test_libnvme_sym = executable(
+    'test-libnvme-sym',
+    test_libnvme_sym_c,
+    dependencies: libnvme_dep,
+    include_directories: [incdir, internal_incdir],
+)
+test('libnvme-sym', test_libnvme_sym)
+
+test_libnvme_mi_sym = executable(
+    'test-libnvme-mi-sym',
+    test_libnvme_mi_sym_c,
+    dependencies: libnvme_mi_dep,
+    include_directories: [incdir, internal_incdir],
+)
+test('libnvme-mi-sym', test_libnvme_mi_sym)
+
 subdir('ioctl')
 subdir('nbft')
 


### PR DESCRIPTION
Noticed a few exported symbols were missing from the public headers. 
Add a generated symbol/header consistency check following
systemd's approach to automatically verify that public headers and version scripts stay in sync.