### PR TITLE
linux: fix nvme_fw_download_seq chunk advance for partial transfers

### DIFF
--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -107,15 +107,20 @@ int nvme_fw_download_seq(int fd, __u32 size, __u32 xfer, __u32 offset,
 		.result = NULL,
 	};
 
+	if (!xfer) {
+		errno = EINVAL;
+		return -1;
+	}
+
 	while (size > 0) {
 		args.data_len = MIN(xfer, size);
 		err = nvme_fw_download(&args);
 		if (err)
 			break;
 
-		args.data += xfer;
-		size -= xfer;
-		args.offset += xfer;
+		args.data += args.data_len;
+		size -= args.data_len;
+		args.offset += args.data_len;
 	}
 
 	return err;

--- a/test/ioctl/misc.c
+++ b/test/ioctl/misc.c
@@ -4,6 +4,7 @@
 
 #include "mock.h"
 #include "util.h"
+#include <errno.h>
 #include <nvme/api-types.h>
 #include <nvme/ioctl.h>
 #include <nvme/types.h>
@@ -289,6 +290,41 @@ static void test_fw_download(void)
 	end_mock_cmds();
 	check(err == 0, "returned error %d, errno %m", err);
 	check(result == 0, "returned result %u", result);
+}
+
+static void test_fw_download_seq(void)
+{
+	__u8 data[4096 + 16];
+	int err;
+
+	/* image size is not a multiple of xfer: last chunk is partial */
+	struct mock_cmd mock_admin_cmds[] = {
+		{
+			.opcode = nvme_admin_fw_download,
+			.cdw10 = (4096 >> 2) - 1,
+			.cdw11 = 0,
+			.data_len = 4096,
+			.in_data = &data[0],
+		},
+		{
+			.opcode = nvme_admin_fw_download,
+			.cdw10 = (16 >> 2) - 1,
+			.cdw11 = 4096 >> 2,
+			.data_len = 16,
+			.in_data = &data[4096],
+		},
+	};
+
+	arbitrary(&data, sizeof(data));
+	set_mock_admin_cmds(mock_admin_cmds, 2);
+	err = nvme_fw_download_seq(TEST_FD, sizeof(data), 4096, 0, data);
+	end_mock_cmds();
+	check(err == 0, "returned error %d, errno %m", err);
+
+	/* a zero transfer size would loop forever */
+	err = nvme_fw_download_seq(TEST_FD, sizeof(data), 0, 0, data);
+	check(err == -1 && errno == EINVAL, "expected EINVAL, got %d, errno %m",
+	      err);
 }
 
 static void test_fw_commit(void)
@@ -1693,6 +1729,7 @@ int main(void)
 	RUN_TEST(ns_attach_ctrls);
 	RUN_TEST(ns_detach_ctrls);
 	RUN_TEST(fw_download);
+	RUN_TEST(fw_download_seq);
 	RUN_TEST(fw_commit);
 	RUN_TEST(security_send);
 	RUN_TEST(security_receive);


### PR DESCRIPTION
## Summary

`nvme_fw_download_seq()` advances `args.data`, `size` and `offset` by the **full chunk size `xfer`**, while only `MIN(xfer, size)` bytes are transferred per iteration. When the image size is not a multiple of `xfer`:

1. the last (short) chunk is downloaded correctly, but
2. the subsequent update walks the state past the end of the caller's buffer and **underflows `size`** (unsigned), so the loop keeps issuing firmware-download commands - roughly 2**20 more - reading (and sending to the controller) up to 4 GB past the end of the image buffer. Depending on controller behavior this can also corrupt the firmware being updated.
3. Separately, `xfer == 0` (either passed directly, or indirectly when `nvme_fw_download` is left with nothing to send and reports success) never terminates.

## Fix

Advance `args.data`, `size` and `args.offset` by the actual transferred length (`args.data_len`) instead of `xfer`, and reject a zero `xfer` up front with `EINVAL`.

## Testing

New unit test `test_fw_download_seq` (mock-ioctl based) covers:

- an image size that is **not a multiple of `xfer`** (4112 bytes with 4096-byte chunks). With the old code this issues further commands reading past the end of the buffer, which the mock catches - the test aborts against unfixed code and passes with the fix.
- the zero-`xfer` rejection.

The rest of the test suite passes (`meson test -C .build`: 29 OK, 2 expected-fail which predate this change).

Signed-off-by: Prabhakar Pujeri <prabhakar.pujeri@dell.com>