### PR TITLE
fabrics: reject oversized discovery log record counts

### DIFF
--- a/src/nvme/fabrics.c
+++ b/src/nvme/fabrics.c
@@ -1216,6 +1216,21 @@ static struct nvmf_discovery_log *nvme_discovery_log(
 		if (numrec == 0)
 			break;
 
+		/*
+		 * numrec comes from the (unauthenticated) discovery
+		 * controller and is used to compute the log page buffer
+		 * size. Reject counts so large that the size computation
+		 * would wrap, which would result in a buffer smaller than
+		 * the number of entries that get processed below.
+		 */
+		if (numrec > (SIZE_MAX - sizeof(*log)) / sizeof(*log->entries)) {
+			nvme_msg(r, LOG_ERR,
+				 "%s: invalid number of discovery log records %"
+				 PRIu64 "\n", name, numrec);
+			errno = EINVAL;
+			goto out_free_log;
+		}
+
 		free(log);
 		entries_size = sizeof(*log->entries) * numrec;
 		log = __nvme_alloc(sizeof(*log) + entries_size);

--- a/test/ioctl/discovery.c
+++ b/test/ioctl/discovery.c
@@ -401,6 +401,31 @@ static void test_genctr_error(nvme_ctrl_t c)
 	check(!log, "unexpected log page returned");
 }
 
+static void test_numrec_too_large(nvme_ctrl_t c)
+{
+	/* numrec so large that the buffer size computation would wrap */
+	struct nvmf_discovery_log header = {
+		.numrec = cpu_to_le64(UINT64_MAX /
+				      sizeof(struct nvmf_disc_log_entry)),
+	};
+	struct mock_cmd mock_admin_cmds[] = {
+		{
+			.opcode = nvme_admin_get_log_page,
+			.data_len = HEADER_LEN,
+			.cdw10 = (HEADER_LEN / 4 - 1) << 16 /* NUMDL */
+			       | NVME_LOG_LID_DISCOVER, /* LID */
+			.out_data = &header,
+		},
+	};
+	struct nvmf_discovery_log *log = NULL;
+
+	set_mock_admin_cmds(mock_admin_cmds, ARRAY_SIZE(mock_admin_cmds));
+	check(nvmf_get_discovery_log(c, &log, 1) == -1, "discovery succeeded");
+	end_mock_cmds();
+	check(errno == EINVAL, "incorrect errno: %m");
+	check(!log, "unexpected log page returned");
+}
+
 static void run_test(const char *test_name, void (*test_fn)(nvme_ctrl_t))
 {
 	struct nvme_ctrl c = {.fd = TEST_FD};
@@ -426,4 +451,5 @@ int main(void)
 	RUN_TEST(header_error);
 	RUN_TEST(entries_error);
 	RUN_TEST(genctr_error);
+	RUN_TEST(numrec_too_large);
 }


### PR DESCRIPTION
## Problem

`nvme_discovery_log()` (fabrics.c) reads `numrec` from the discovery log page header returned by an **unauthenticated** discovery controller and uses it directly to size the records buffer:

```c
numrec = le64_to_cpu(log->numrec);
...
entries_size = sizeof(*log->entries) * numrec;   /* wraps for numrec >= 2^54 */
log = __nvme_alloc(sizeof(*log) + entries_size);
```

`struct nvmf_disc_log_entry` is 1024 bytes, so `entries_size` wraps for `numrec >= 2^54`. For example with `numrec = 2^54 + 2` the allocation covers only 2 entries, but afterward the fetched log is considered to hold all `2^54 + 2` entries (`sanitize_discovery_log_entry()` in `nvmf_get_discovery_wargs()` walks `log->entries[i]` and traddr/tsas parsing reads + writes via `strchomp`), causing massive out-of-bounds heap reads and writes.

A memory-corruption primitive reachable by a malicious or buggy discovery controller.

## Fix

Reject record counts whose derived buffer size would not fit into a `size_t` (the multiplication/addition would wrap), returning `EINVAL` before allocating or issuing further Get Log Page commands. Legitimate responses are unaffected: wrap requires numrec ≈ 2^54, while the maximal real response is a few thousand entries.

## Test

`test_numrec_too_large` (mock-ioctl) mocks a header with `numrec = UINT64_MAX / sizeof(entry)` and expects `EINVAL` with no further commands issued. Aborts (SIGABRT via unconsumed mocks / OOB access) against unfixed code; passes with the patch. Full `meson test` suite green.