### PR TITLE
mi: fix AEM ack response buffer size

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -2682,9 +2682,15 @@ int nvme_mi_aem_process(nvme_mi_ep_t ep, void *userdata)
 		reset_list_info(ep->aem_ctx);
 
 		if (action == NVME_MI_AEM_HNA_ACK) {
-			response_len = sizeof(response_buffer);
+			/*
+			 * The ack response data is written to the occurrence
+			 * list area, which starts after the message header.
+			 */
+			response_len = sizeof(response_buffer) -
+				offsetof(struct nvme_mi_aem_msg, occ_list_hdr);
 
-			rc = nvme_mi_aem_ack(ep, &response->occ_list_hdr, &response_len);
+			rc = nvme_mi_aem_ack(ep, &response->occ_list_hdr,
+					     &response_len);
 			if (rc)
 				goto cleanup;
 


### PR DESCRIPTION
## Problem

`nvme_mi_aem_process()` reads an async event message and, when the handler requests an ack (`NVME_MI_AEM_HNA_ACK`), asks for the ack response into the same 4096-byte stack buffer:

```c
uint8_t response_buffer[4096];
struct nvme_mi_aem_msg *response = (struct nvme_mi_aem_msg *)response_buffer;
...
response_len = sizeof(response_buffer);
nvme_mi_aem_ack(ep, &response->occ_list_hdr, &response_len);
```

The ack response data is written to `&response->occ_list_hdr`, which is `sizeof(struct nvme_mi_msg_hdr)` (4) bytes into the buffer. Passing the full buffer size lets the transport write up to 4096 bytes starting 4 bytes in, overflowing the stack buffer by up to 4 bytes. The initial read of the async message correctly uses `sizeof(response_buffer) - sizeof(struct nvme_mi_aem_msg)`; only the ack path uses the wrong size. The two `aem_sync()` users place the occurrence list at offset 0 and their full-buffer size is exact, so they are unaffected.

Story short: a list with e.g. ~170 pending events triggers the overflow.

## Fix

Pass the size of the area that actually receives data: `sizeof(response_buffer) - offsetof(struct nvme_mi_aem_msg, occ_list_hdr)`.

Built and full `meson test` suite run; the existing AEM tests in test/mi-mctp (enable/process/ack flows) all pass.

Signed-off-by: Prabhakar Pujeri <prabhakar.pujeri@dell.com>