### PR TITLE
mi/mctp: reject responses larger than the response buffer

### DIFF
--- a/src/nvme/mi-mctp.c
+++ b/src/nvme/mi-mctp.c
@@ -344,6 +344,19 @@ static int nvme_mi_mctp_aem_read(struct nvme_mi_ep *ep,
 		goto out;
 	}
 
+	/*
+	 * Datagram sockets return the full datagram length even if the
+	 * message was truncated to fit our buffer. Reject such responses,
+	 * as the peers' message would not be fully present for parsing.
+	 */
+	if (len > resp_len - 1) {
+		nvme_msg(ep->root, LOG_ERR,
+			 "Invalid MCTP response: too large (%zd bytes, buffer %zd)\n",
+			 len, resp_len - 1);
+		errno = EPROTO;
+		goto out;
+	}
+
 	if (resp_msg.msg_namelen < sizeof(src_addr)) {
 		nvme_msg(ep->root, LOG_WARNING, "Unexpected src address length\n");
 		errno = EIO;
@@ -532,6 +545,19 @@ retry:
 	if (len == 0) {
 		nvme_msg(ep->root, LOG_WARNING, "No data from MCTP endpoint\n");
 		errno = EIO;
+		goto out;
+	}
+
+	/*
+	 * Datagram sockets return the full datagram length even if the
+	 * message was truncated to fit our buffer. Reject such responses,
+	 * as the peers' message would not be fully present for parsing.
+	 */
+	if (len > resp_len - 1) {
+		nvme_msg(ep->root, LOG_ERR,
+			 "Invalid MCTP response: too large (%zd bytes, buffer %zd)\n",
+			 len, resp_len - 1);
+		errno = EPROTO;
 		goto out;
 	}
 

--- a/test/mi-mctp.c
+++ b/test/mi-mctp.c
@@ -312,6 +312,23 @@ static void test_read_mi_data(nvme_mi_ep_t ep, struct test_peer *peer)
 	assert(rc == 0);
 }
 
+static void test_mi_resp_too_large(nvme_mi_ep_t ep, struct test_peer *peer)
+{
+	struct nvme_mi_read_nvm_ss_info ss_info;
+	int rc;
+
+	/* The peer sends a datagram much larger than the expected
+	 * response: the kernel returns the full datagram length, while
+	 * only the truncated portion is actually copied to the buffer.
+	 */
+	peer->tx_rc = MAX_BUFSIZ;
+	peer->tx_buf_len = MAX_BUFSIZ - 4; /* leave room for the MIC */
+
+	rc = nvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
+	assert(rc != 0);
+	assert(errno == EPROTO);
+}
+
 static void test_mi_resp_err(nvme_mi_ep_t ep, struct test_peer *peer)
 {
 	struct nvme_mi_read_nvm_ss_info ss_info;
@@ -1408,6 +1425,7 @@ struct test {
 	DEFINE_TEST(read_mi_data),
 	DEFINE_TEST(poll_err),
 	DEFINE_TEST(mi_resp_err),
+	DEFINE_TEST(mi_resp_too_large),
 	DEFINE_TEST(mi_resp_unaligned),
 	DEFINE_TEST(mi_resp_unaligned_expected),
 	DEFINE_TEST(admin_resp_err),


### PR DESCRIPTION
## Problem

MCTP sockets are datagram sockets: `recvmsg()` returns the **full datagram length** even when the datagram is larger than our receive buffer and was truncated (without `MSG_TRUNC` we get no signal of truncation).

Both receive paths trust the return value to locate the 32-bit MIC at the tail of the supposedly-filled buffer:

```c
len = ops.recvmsg(mctp->sd, &resp_msg, MSG_DONTWAIT);
...
memcpy(&mic, mctp->resp_buf + len - sizeof(mic), sizeof(mic));
```

The buffer is sized to the expected response (hdr_len + data_len + 4). A device sending a bigger datagram (bug, or AEM burst on a large-MTU network) makes `len` exceed the allocation and the MIC lookup reads out of the response buffer; the subsequent header/data unpacking likewise runs over the truncated buffer and hands partially-stale data to the parsing layer. Found both in `nvme_mi_mctp_submit()` and `nvme_mi_mctp_aem_read()`.

## Fix

After `recvmsg()`, reject any reported length that cannot fit our buffer (`len > resp_len - 1`) with `EPROTO`, before the length is used. MPR handling and the poll retry loop are preserved: a legitimately timed-out/restarted command flow is unchanged.

## Test

New `test_mi_resp_too_large` drives the wrapped socket to report a full-size (8 KB) datagram for a 40-byte response. With the old code the test fails (garbage MIC / uninitialized data reaching the parser); with the patch the call returns cleanly with `errno = EPROTO`. Full `meson test` suite green; the path also validated with valgrind (no invalid reads on the fixed code; old code shows reads of uninitialized heap/OOB).

Signed-off-by: Prabhakar Pujeri <prabhakar.pujeri@dell.com>