### PR TITLE
tree: detach paths when freeing a namespace

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -632,7 +632,13 @@ nvme_path_t nvme_namespace_next_path(nvme_ns_t ns, nvme_path_t p)
 
 static void __nvme_free_ns(struct nvme_ns *n)
 {
+	struct nvme_path *p, *_p;
+
 	list_del_init(&n->entry);
+	nvme_namespace_for_each_path_safe(n, p, _p) {
+		list_del_init(&p->nentry);
+		p->n = NULL;
+	}
 	nvme_ns_release_fd(n);
 	free(n->generic_name);
 	free(n->name);


### PR DESCRIPTION
## Problem

`__nvme_free_ns()` frees `n->head` without detaching the paths that scanning linked into `head->paths` (via `nvme_subsystem_set_ns_path()` / `nvme_ns_head_scan_path()`, both plain `list_add_tail()` on the same `p->nentry` node).

If a namespace is freed while its controller and paths are still alive, the surviving path objects keep `p->nentry` linked into the freed head and `p->n` pointing at the freed namespace:

- the next `nvme_free_path()` runs `list_del_init(&p->nentry)` which **writes into the freed head** (use-after-free, 2×8-byte heap writes);
- `nvme_path_get_ns()` returns the dangling `p->n` to callers.

Callers this hits: the public `nvme_free_ns()` and `nvme_filter_ns()` (via `nvme_scan_topology(r, filter, ...)`), both of which free a namespace without touching its paths.

`nvme_subsystem_scan_namespace()` handles this correctly when rescans replace a stale namespace (detach + NULL out `p->n` before `__nvme_free_ns()`) - the general free path was missing that handling.

## Fix

Apply the same detach in `__nvme_free_ns()` so every free path - scan-rescan, filtered scans, `nvme_free_ns()` - is covered. The `__nvme_free_ctrl()` teardown order (paths first, then namespaces) makes the added loop a no-op there, so built-in teardown is unchanged.

## Validation

Reproducer: fabricate a namespace head with a linked path (the wiring scanning builds), then `nvme_free_ns()` then `nvme_free_path()`-equivalent teardown.

- before the fix: valgrind shows `Invalid write of size 8` into a 32-byte block `free'd by __nvme_free_ns` (the head);
- with the fix: clean, no invalid accesses.

Full test suite passes.

Signed-off-by: Prabhakar Pujeri <prabhakar.pujeri@dell.com>