### PR TITLE
nbft: reject heap objects too small for the structures they decode

### DIFF
--- a/src/nvme/nbft.c
+++ b/src/nvme/nbft.c
@@ -84,7 +84,7 @@ static char *trtype_to_string(__u8 transport_type)
 static int __get_heap_obj(struct nbft_header *header, const char *filename,
 			  const char *descriptorname, const char *fieldname,
 			  struct nbft_heap_obj obj, bool is_string,
-			  char **output)
+			  size_t min_len, char **output)
 {
 	if (le16_to_cpu(obj.length) == 0)
 		return -ENOENT;
@@ -113,16 +113,30 @@ static int __get_heap_obj(struct nbft_header *header, const char *filename,
 				 filename, fieldname, descriptorname);
 			return -EINVAL;
 		}
+	} else if (le16_to_cpu(obj.length) < min_len) {
+		nvme_msg(NULL, LOG_DEBUG,
+			 "file %s: object '%s' in descriptor '%s' is too short (%d, expected %zu)\n",
+			 filename, fieldname, descriptorname,
+			 le16_to_cpu(obj.length), min_len);
+		return -EINVAL;
 	}
 
 	return 0;
 }
 
-#define get_heap_obj(descriptor, obj, is_string, output)	\
-	__get_heap_obj(header, nbft->filename,			\
-		       stringify(descriptor), stringify(obj),	\
-		       descriptor->obj, is_string,		\
-		       output)
+/*
+ * Heap objects with structured (non-string) content are dereferenced as a
+ * struct by the caller, so make sure the object is at least as large as the
+ * structure it is interpreted as.  String and plain byte-array objects
+ * have no minimum: the helper already rejects empty objects, and such
+ * content is sized one byte per element.
+ */
+#define get_heap_obj(descriptor, obj, is_string, output)		\
+	__get_heap_obj(header, nbft->filename,				\
+		       stringify(descriptor), stringify(obj),		\
+		       descriptor->obj, is_string,			\
+		       (is_string) ? 0 : sizeof(**(output)),		\
+		       (char **)(output))
 
 static struct nbft_info_discovery *discovery_from_index(struct nbft_info *nbft, int i)
 {
@@ -227,9 +241,19 @@ static int read_ssns(struct nbft_info *nbft,
 	}
 
 	/* subsystem transport address */
-	ret = get_heap_obj(raw_ssns, subsys_traddr_obj, 0, (char **)&tmp);
+	ret = get_heap_obj(raw_ssns, subsys_traddr_obj, 0, &tmp);
 	if (ret)
 		goto fail;
+
+	/* format_ip_addr() always reads a full 16 bytes of IP address */
+	if (le16_to_cpu(raw_ssns->subsys_traddr_obj.length) < sizeof(struct in6_addr)) {
+		nvme_msg(NULL, LOG_DEBUG,
+			 "file %s: SSNS %d transport address heap object too short (%d bytes)\n",
+			 nbft->filename, ssns->index,
+			 le16_to_cpu(raw_ssns->subsys_traddr_obj.length));
+		ret = -EINVAL;
+		goto fail;
+	}
 
 	format_ip_addr(ssns->traddr, sizeof(ssns->traddr), tmp);
 
@@ -262,7 +286,7 @@ static int read_ssns(struct nbft_info *nbft,
 	}
 
 	/* HFI descriptors */
-	ret = get_heap_obj(raw_ssns, secondary_hfi_assoc_obj, 0, (char **)&ss_hfi_indexes);
+	ret = get_heap_obj(raw_ssns, secondary_hfi_assoc_obj, 0, &ss_hfi_indexes);
 	if (ret)
 		goto fail;
 
@@ -322,7 +346,7 @@ static int read_ssns(struct nbft_info *nbft,
 		struct nbft_ssns_ext_info *ssns_extended_info;
 
 		if (!get_heap_obj(raw_ssns, ssns_extended_info_desc_obj, 0,
-				  (char **)&ssns_extended_info))
+				  &ssns_extended_info))
 			read_ssns_exended_info(nbft, ssns, ssns_extended_info);
 	}
 
@@ -412,7 +436,7 @@ static int read_hfi(struct nbft_info *nbft,
 		strncpy(hfi->transport, trtype_to_string(raw_hfi->trtype),
 			sizeof(hfi->transport));
 
-		ret = get_heap_obj(raw_hfi, trinfo_obj, 0, (char **)&raw_hfi_info_tcp);
+		ret = get_heap_obj(raw_hfi, trinfo_obj, 0, &raw_hfi_info_tcp);
 		if (ret)
 			goto fail;
 


### PR DESCRIPTION
## Problem

Descriptors reference their payload through heap objects ({offset, length}), but the parser only checks with `in_heap()` that the region lies within the NBFT heap — it never checks that the object is large enough for what follows. Non-string objects are subsequently dereferenced as fixed-size structures:

- `read_hfi()` casts the transport-info heap object of a TCP HFI to `struct nbft_hfi_info_tcp *` (128 bytes) and copies it whole;
- `read_ssns()` reads a `struct nbft_ssns_ext_info` out of the SSNS extended-info heap object;
- `read_ssns()` passes the subsystem transport-address object to `format_ip_addr()`, which unconditionally `memcpy()`s a full 16-byte `struct in6_addr`.

A malformed table declaring e.g. a 2-byte transport info object therefore makes the parser read structure-sized data from the declared location. If the object sits near the end of the table buffer the read runs past the heap allocation entirely.

I confirmed this with valgrind using a mutated copy of the `NBFT-static-ipv4` test fixture: with the HFI transport info object shrunk to 2 bytes and its offset moved to just before the end of the buffer, `test/nbft/nbft-dump` reports

```
Invalid read of size 1
Address ... is 4 bytes after a block of size 725 alloc'd
```

i.e. the record is accepted and the parser reads TCP transport info outside the allocation.

## Fix

`__get_heap_obj()` gains a `min_len` parameter; non-string heap objects shorter than that are rejected with `-EINVAL`, which drops the offending descriptor record gracefully (record-level parse failures are already non-fatal by design). The minimum is derived from the output pointer's type with `_Generic` inside the existing `get_heap_obj()` macro, so call sites need no explicit size argument:

- `struct nbft_hfi_info_tcp **` and `struct nbft_ssns_ext_info **` require the full structure size;
- `char **` (strings) and `__u8 **` (opaque byte arrays) keep no minimum, as before.

The `(char **)` casts at the four affected call sites are removed so the generic selection sees the true pointer types, and `read_ssns()` additionally verifies the transport-address object covers a 16-byte IPv6 address before calling `format_ip_addr()` (the object's length field doesn't express the address family — the flags field does).

## Testing

- Full meson test suite passes: the existing `test/nbft` fixture tables still parse identically (no false rejections), and the `tables_bad` fixtures still fail as expected.
- Re-ran `nbft-dump` on the mutated fixture under valgrind: the malformed HFI record is now rejected and dropped (absent from the dump), the rest of the table still parses, and valgrind reports no invalid reads.
- `git stash`'d the change and rebuilt to confirm the unpatched parser both accepts the malformed record and trips the invalid read shown above.