### PR TITLE
examples: fix select() usage in telemetry-listen

### DIFF
--- a/examples/telemetry-listen.c
+++ b/examples/telemetry-listen.c
@@ -102,7 +102,7 @@ static void check_telemetry(nvme_ctrl_t c, int ufd)
 	}
 }
 
-static void wait_events(fd_set *fds, struct events *e, int nr)
+static void wait_events(fd_set *fds, struct events *e, int nr, int maxfd)
 {
 	int ret, i;
 
@@ -110,12 +110,15 @@ static void wait_events(fd_set *fds, struct events *e, int nr)
 		check_telemetry(e[i].c, e[i].uevent_fd);
 
 	while (1) {
-		ret = select(nr, fds, NULL, NULL, NULL);
+		/* select() clears the bits of inactive fds, restore them */
+		fd_set read_fds = *fds;
+
+		ret = select(maxfd + 1, &read_fds, NULL, NULL, NULL);
 		if (ret < 0)
 			return;
 
 		for (i = 0; i < nr; i++) {
-			if (!FD_ISSET(e[i].uevent_fd, fds))
+			if (!FD_ISSET(e[i].uevent_fd, &read_fds))
 				continue;
 			check_telemetry(e[i].c, e[i].uevent_fd);
 		}
@@ -126,6 +129,7 @@ int main()
 {
 	struct events *e;
 	fd_set fds;
+	int maxfd = -1;
 	int i = 0;
 
 	nvme_subsystem_t s;
@@ -143,6 +147,10 @@ int main()
 				i++;
 
 	e = calloc(i, sizeof(struct events));
+	if (i > 0 && !e) {
+		nvme_free_tree(r);
+		return EXIT_FAILURE;
+	}
 	FD_ZERO(&fds);
 	i = 0;
 
@@ -154,6 +162,8 @@ int main()
 				if (fd < 0)
 					continue;
 				FD_SET(fd, &fds);
+				if (fd > maxfd)
+					maxfd = fd;
 				e[i].uevent_fd = fd;
 				e[i].c = c;
 				i++;
@@ -161,7 +171,8 @@ int main()
 		}
 	}
 
-	wait_events(&fds, e, i);
+	if (i > 0)
+		wait_events(&fds, e, i, maxfd);
 	nvme_free_tree(r);
 	free(e);
 


### PR DESCRIPTION
## Problem

`wait_events()` passes `nr` (the number of uevent fds) as the first argument to `select()`, but that argument is the highest fd number plus one. Since stdio occupies fds 0-2, the uevent fds always start at 3, so with 1-3 controllers `select(nr)` watches a range that contains none of the fds of interest — the listener blocks forever and never handles a telemetry AEN, which is the tool's entire purpose. (With enough controllers — fd count above 3+nr — some lower-numbered uevent fds start waking the loop, making the failure inconsistent and hard to spot.)

Two more issues in the same loop:

1. `select()` clears the bits of inactive fds in the set passed to it. The same `fds` set is reused every iteration without re-arming, so once the first event fires, the surviving set contains only the fds that were active that round; all other fds stop waking the loop from then on.
2. When no controller with a usable uevent file exists (`nr == 0`), `select(0, ...)` returns immediately and the loop spins at 100% CPU forever. (Also, `calloc()`'s return value is not checked.)

Quick demonstration of the nfds semantics (no NVMe hardware needed):

```c
int p[2]; pipe(p);
int fd = dup2(p[0], 7);          /* an fd above the count */
write(p[1], "x", 1);
FD_ZERO(&fds); FD_SET(fd, &fds);
select(1, &fds, NULL, NULL, &tv);      /* -> 0: ready fd missed  */
```

vs. `select(fd + 1, ...)` -> 1, event seen.

## Fix

- Track the highest uevent fd while `FD_SET`ing and pass `maxfd + 1` to `select()`.
- Operate on a local copy of the watched set so each loop iteration waits on the complete fd set again.
- Skip the wait loop when no controller was found, and check the `calloc()` result.

## Testing

- `ninja -C build` builds the example cleanly (examples are enabled in the default configuration).
- Full meson test suite passes (unchanged — examples are not covered by runtime tests; the select() semantics of nfds were verified with the standalone snippet above).