### PR TITLE
examples: validate AE numbers in mi-mctp-ae

### DIFF
--- a/examples/mi-mctp-ae.c
+++ b/examples/mi-mctp-ae.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
 	const uint8_t AEM_FD_INDEX = 0;
 	const uint8_t STD_IN_FD_INDEX = 1;
 
-	if (argc == 4) {
+	if (argc >= 4) {
 		net = atoi(argv[1]);
 		eid = atoi(argv[2]) & 0xff;
 		argv += 2;
@@ -100,6 +100,11 @@ int main(int argc, char **argv)
 		for (int i = 0; i < event_count; i++) {
 			int event = atoi(argv[1+i]);
 
+			if (event < 0 || event > 255) {
+				fprintf(stderr, "invalid AE number %d (must be 0-255)\n",
+					event);
+				return EXIT_FAILURE;
+			}
 			aem_config.enabled_map.enabled[event] = true;
 		}
 	} else {


### PR DESCRIPTION
## Problem

`mi-mctp-ae` parses AE numbers from argv with `atoi()` and uses the result directly to index the 256-entry `aem_config.enabled_map.enabled[]` array, which is a local on the stack:

```c
int event = atoi(argv[1+i]);
aem_config.enabled_map.enabled[event] = true;
```

Any value outside 0-255 (or negative) is an out-of-bounds write into the surrounding stack frame. This is easy to confirm by construction: a `bool enabled[256]` struct followed by a canary on the stack, written at `enabled[offsetof(canary) - offsetof(enabled)] = true`, leaves the canary corrupted.

In the same code path, `if (argc == 4)` accepts *exactly one* AE number: passing none or several drops to the usage error, although the usage text and the loop are written for a variable-length list (`[AE #s separated by spaces]`).

## Fix

- Reject AE numbers outside 0-255 before indexing.
- Lift `argc == 4` to `argc >= 4` so multiple AEs can be enabled, matching the usage text.

## Testing

- `ninja -C build` builds the example cleanly.
- Old binary behavior reproduced as described above; with the fix:
  - `mi-mctp-ae 1 8 5000` → `invalid AE number 5000 (must be 0-255)`, exit 1, no OOB write;
  - `mi-mctp-ae 1 8 3 5 7` → accepted, proceeds to endpoint setup (fails here only with "No route to host" since the sandbox has no MCTP interfaces — the argv handling itself now works as documented);
  - `mi-mctp-ae 1 8` → usage error, unchanged.