### PR TITLE
tree: hex-decode the sysfs eui attribute into the EUI-64

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -2696,9 +2696,30 @@ static int nvme_strtoi(const char *str, void *res)
 	return 0;
 }
 
+static int hex_digit(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	return -1;
+}
+
 static int nvme_strtoeuid(const char *str, void *res)
 {
-	memcpy(res, str, 8);
+	__u8 *eui = res;
+	int hi, lo, i;
+
+	/* the sysfs eui attribute is the EUI-64 as 16 hex digits */
+	for (i = 0; i < 8; i++) {
+		hi = hex_digit(str[2 * i]);
+		lo = hex_digit(str[2 * i + 1]);
+		if (hi < 0 || lo < 0)
+			return -EINVAL;
+		eui[i] = hi << 4 | lo;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
## Problem

`nvme_strtoeuid()` parses the namespace `eui` sysfs attribute by `memcpy()`ing its first eight characters into `ns->eui64`:

```c
static int nvme_strtoeuid(const char *str, void *res)
{
	memcpy(res, str, 8);
	return 0;
}
```

But the kernel emits the namespace EUI-64 as a 16-digit hex string (`%8ph`), so the "EUI-64" stored in the tree ends up being the ASCII of the first eight hex digits, not the EUI-64 itself. Any consumer comparing `nvme_ns_get_eui64()` against an identify-namespace EUI64 sees a mismatch.

This is the same class of mistake commit 03297d8b ("tree: fix store uuid/nguid from sysfs") fixed for the `uuid` and `nguid` attributes — the `eui` parser was left behind with the raw memcpy.

## Fix

Hex-decode the attribute into the 8 EUI-64 bytes, accepting upper- and lowercase digits, and reject malformed values with `-EINVAL`.

## Testing

- Full meson test suite passes.
- Verified the old vs. new conversion on the kernel's exact output format (`"453a1122c0ffee01\n"`):
  - old: stores `34 35 33 61 31 31 32 32` (ASCII) — wrong;
  - new: stores `45 3a 11 22 c0 ff ee 01` — correct binary EUI-64;
  - malformed input (non-hex characters) is now rejected instead of silently stored.