### PR TITLE
ioctl: honor the save parameter in nvme_set_features_host_behavior()

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -934,7 +934,7 @@ int nvme_set_features_host_behavior(int fd, bool save,
 	struct nvme_feat_host_behavior *data)
 {
 	return nvme_set_features_data(fd, NVME_FEAT_FID_HOST_BEHAVIOR,
-		NVME_NSID_NONE, 0, false, sizeof(*data), data, NULL);
+		NVME_NSID_NONE, 0, save, sizeof(*data), data, NULL);
 }
 
 int nvme_set_features_sanitize(int fd, bool nodrm, bool save, __u32 *result)

--- a/test/ioctl/features.c
+++ b/test/ioctl/features.c
@@ -1022,13 +1022,13 @@ static void test_get_lba_sts_interval(void)
 
 static void test_set_host_behavior(void)
 {
-	/* nvme_set_features_host_behavior() ignores SAVE */
 	struct nvme_feat_host_behavior behavior;
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_set_features,
 		.in_data = &behavior,
 		.data_len = sizeof(behavior),
-		.cdw10 = NVME_FEAT_FID_HOST_BEHAVIOR,
+		.cdw10 = (uint32_t)1 << 31 /* SAVE */
+		       | NVME_FEAT_FID_HOST_BEHAVIOR,
 	};
 	int err;
 


### PR DESCRIPTION
## Problem

`nvme_set_features_host_behavior(fd, save, data)` accepts a `save` argument like every other set-features wrapper but passes a literal `false` to `nvme_set_features_data()`:

```c
return nvme_set_features_data(fd, NVME_FEAT_FID_HOST_BEHAVIOR,
	NVME_NSID_NONE, 0, false, sizeof(*data), data, NULL);
```

The host-behavior feature is therefore never saved across controller resets even when the caller asks for it, silently violating the API contract. The existing unit test even carries a comment documenting the bug (`/* nvme_set_features_host_behavior() ignores SAVE */`) instead of asserting the expected behavior.

## Fix

Pass the `save` parameter through, and update `test_set_host_behavior` to expect the SAVE bit (cdw10 bit 31) set, consistent with the other feature tests.

## Testing

- Full meson test suite passes.
- With only the test change (library unpatched): `test-features` fails with `got cdw10 0x16, expected 0x80000016` and aborts, confirming the test catches the dropped SAVE bit.
- With the fix: suite green.