### PR TITLE
ioctl: return -1 with errno intact from nvme_verify_chr()

### DIFF
--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -32,11 +32,11 @@
 
 static int nvme_verify_chr(int fd)
 {
-	static struct stat nvme_stat;
+	struct stat nvme_stat;
 	int err = fstat(fd, &nvme_stat);
 
 	if (err < 0)
-		return errno;
+		return -1;
 
 	if (!S_ISCHR(nvme_stat.st_mode)) {
 		errno = ENOTBLK;

--- a/test/ioctl/misc.c
+++ b/test/ioctl/misc.c
@@ -1678,6 +1678,26 @@ static void run_test(const char *test_name, void (*test_fn)(void))
 	puts(" OK");
 }
 
+static void test_reset_bad_fd(void)
+{
+	int err;
+
+	errno = 0;
+	err = nvme_ctrl_reset(-1);
+	check(err == -1 && errno == EBADF,
+	      "ctrl reset on bad fd: got %d, errno %m", err);
+
+	errno = 0;
+	err = nvme_subsystem_reset(-1);
+	check(err == -1 && errno == EBADF,
+	      "subsystem reset on bad fd: got %d, errno %m", err);
+
+	errno = 0;
+	err = nvme_ns_rescan(-1);
+	check(err == -1 && errno == EBADF,
+	      "ns rescan on bad fd: got %d, errno %m", err);
+}
+
 #define RUN_TEST(name) run_test(#name, test_##name)
 
 int main(void)
@@ -1709,6 +1729,7 @@ int main(void)
 	RUN_TEST(capacity_mgmt);
 	RUN_TEST(lockdown);
 	RUN_TEST(sanitize_nvm);
+	RUN_TEST(reset_bad_fd);
 	RUN_TEST(dev_self_test);
 	RUN_TEST(virtual_mgmt);
 	RUN_TEST(flush);


### PR DESCRIPTION
## Problem

`nvme_verify_chr()` is the shared sanity check for the reset/rescan wrappers (`nvme_subsystem_reset`, `nvme_ctrl_reset`, `nvme_ns_rescan`). Its fstat() failure path does `return errno;` — propagating a *positive* errno through the public API, breaking the library convention of returning `< 0` with errno set. All three callers do `if (ret) return ret;`, so e.g. `nvme_ctrl_reset(badfd)` returns `+EBADF` to the application instead of `-1` with `errno == EBADF`.

(Also addressed here while touching the function: it uses a `static struct stat`, so concurrent resets on two fds race writing into shared storage. There's no shared state worth keeping — make it a local.)

## Fix

- `return -1;` on fstat() failure, preserving the fstat errno (matches the ENOTBLK path's existing style);
- make the `stat` buffer an automatic.

Add `test_reset_bad_fd` to the ioctl/misc suite asserting the `-1` + `errno == EBADF` contract for all three wrappers.

## Testing

- Full meson test suite passes.
- With only the test added (library unpatched) the test aborts immediately (`got 9, errno Bad file descriptor`), confirming it catches the positive-errno path; with the fix the suite is green.