### PR TITLE
mi: reject async events that carry the RSP bit in nmp

### DIFF
--- a/src/nvme/mi.c
+++ b/src/nvme/mi.c
@@ -486,7 +486,7 @@ int nvme_mi_async_read(nvme_mi_ep_t ep, struct nvme_mi_resp *resp)
 		return -1;
 	}
 
-	if (!(resp->hdr->nmp & ~(NVME_MI_ROR_REQ << 7))) {
+	if (resp->hdr->nmp & (NVME_MI_ROR_RSP << 7)) {
 		nvme_msg(ep->root, LOG_DEBUG,
 			 "ROR value in response indicates a response\n");
 		errno = EIO;


### PR DESCRIPTION
## Problem

The ROR sanity check in `nvme_mi_async_read()` reads:

```c
if (!(resp->hdr->nmp & ~(NVME_MI_ROR_REQ << 7))) {
	"ROR value in response indicates a response"
```

Since `NVME_MI_ROR_REQ == 0`, `~(0 << 7)` is all-ones, and the expression reduces to `!nmp`: a message is rejected only when **all** nmp bits are clear, while a message with the RSP bit (bit 7) set — the exact condition the check exists for, per its own log text and the sibling check in `nvme_mi_verify_resp()` — sails through.

## Fix

Test bit 7 with `NVME_MI_ROR_RSP`, matching `nvme_mi_verify_resp()'s` polarity:

```c
if (resp->hdr->nmp & (NVME_MI_ROR_RSP << 7)) { ... }
```

## Testing

- Full meson test suite passes (the AEM data-path code is exercised indirectly; no dedicated test for this one-line polarity fix was added — the defect is self-contained boolean logic with the intended polarity documented by both the log message and the parallel implementation in `nvme_mi_verify_resp()`).