### PR TITLE
base64: harden base64_decode() padding and residual-bit validation

### DIFF
--- a/src/nvme/base64.c
+++ b/src/nvme/base64.c
@@ -66,19 +66,24 @@ int base64_encode(const unsigned char *src, int srclen, char *dst)
 int base64_decode(const char *src, int srclen, unsigned char *dst)
 {
 	uint32_t ac = 0;
-	int i, bits = 0;
+	int i, bits = 0, pads = 0;
 	unsigned char *bp = dst;
 
 	for (i = 0; i < srclen; i++) {
-		const char *p = strchr(base64_table, src[i]);
+		const char *p;
 
 		if (src[i] == '=') {
-			ac = (ac << 6);
-			bits += 6;
-			if (bits >= 8)
-				bits -= 8;
+			if (bits < 2 || pads >= 2)
+				/* padding only terminates a 4-char quantum */
+				return -EINVAL;
+			pads++;
+			bits -= 2;
 			continue;
 		}
+		if (pads)
+			/* no data after padding */
+			return -EINVAL;
+		p = strchr(base64_table, src[i]);
 		if (!p || !src[i])
 			return -EINVAL;
 		ac = (ac << 6) | (p - base64_table);
@@ -88,8 +93,12 @@ int base64_decode(const char *src, int srclen, unsigned char *dst)
 			*bp++ = (unsigned char)(ac >> bits);
 		}
 	}
-	if (ac && ((1 << bits) - 1))
-		return -EAGAIN;
+	if (bits)
+		/* missing padding to a multiple of four characters */
+		return -EINVAL;
+	if (ac & ((1 << (2 * pads)) - 1))
+		/* bits that the padding drops must be zero */
+		return -EINVAL;
 
 	return bp - dst;
 }

--- a/test/base64.c
+++ b/test/base64.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/**
+ * This file is part of libnvme.
+ *
+ * Unit tests for the base64 encoder/decoder.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+int base64_encode(const unsigned char *src, int srclen, char *dst);
+int base64_decode(const char *src, int srclen, unsigned char *dst);
+
+struct vector {
+	const char *b64;
+	const char *plain; /* NULL: decode must fail */
+};
+
+/* RFC 4648 test vectors plus malformed padding placements */
+static struct vector vectors[] = {
+	{ "", "" },
+	{ "Zg==", "f" },
+	{ "Zm8=", "fo" },
+	{ "Zm9v", "foo" },
+	{ "Zm9vYg==", "foob" },
+	{ "Zm9vYmE=", "fooba" },
+	{ "Zm9vYmFy", "foobar" },
+	/* non-zero bits hidden by padding */
+	{ "Zh==", NULL },
+	{ "QUJ=", NULL },
+	/* padding only terminates a 4-char quantum, at most twice */
+	{ "Zg=", NULL },
+	{ "Z===", NULL },
+	{ "Zm9vYg=", NULL },
+	{ "Zg==Zg==", NULL },
+	{ "=Zm9", NULL },
+	{ "Zm=g", NULL },
+	/* missing padding */
+	{ "Zg", NULL },
+	{ "Zm9", NULL },
+	/* not in the alphabet */
+	{ "Zm9v?", NULL },
+};
+
+static int nfail;
+
+static void run_vectors(void)
+{
+	unsigned char plain[64];
+	char b64[64];
+	unsigned int i;
+	int rc;
+
+	for (i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+		struct vector *v = &vectors[i];
+
+		rc = base64_decode(v->b64, strlen(v->b64), plain);
+		if (!v->plain) {
+			if (rc >= 0) {
+				printf("FAIL: '%s' decoded, expected rejection\n", v->b64);
+				nfail++;
+			}
+			continue;
+		}
+		if (rc != (int)strlen(v->plain) ||
+		    memcmp(plain, v->plain, strlen(v->plain))) {
+			printf("FAIL: '%s' did not decode to '%s'\n", v->b64, v->plain);
+			nfail++;
+			continue;
+		}
+		rc = base64_encode((const unsigned char *)v->plain,
+				   strlen(v->plain), b64);
+		if (rc != (int)strlen(v->b64) ||
+		    memcmp(b64, v->b64, strlen(v->b64))) {
+			printf("FAIL: '%s' did not round-trip to '%s'\n",
+			       v->plain, v->b64);
+			nfail++;
+		}
+	}
+}
+
+/* exercise every quantum/resize boundary with a round trip */
+static void run_roundtrips(void)
+{
+	unsigned char data[253], back[256];
+	char enc[344];
+	int i, e, d;
+
+	for (i = 0; i < (int)sizeof(data); i++)
+		data[i] = (unsigned char)i;
+
+	for (i = 0; i <= (int)sizeof(data); i++) {
+		e = base64_encode(data, i, enc);
+		d = base64_decode(enc, e, back);
+		if (d != i || memcmp(data, back, i)) {
+			printf("FAIL: round trip of %d bytes\n", i);
+			nfail++;
+		}
+	}
+}
+
+int main(void)
+{
+	run_vectors();
+	run_roundtrips();
+
+	if (nfail) {
+		printf("%d test(s) failed\n", nfail);
+		return 1;
+	}
+	printf("all tests passed\n");
+	return 0;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -124,6 +124,14 @@ psk = executable(
 
 test('psk', psk)
 
+base64 = executable(
+    'test-base64',
+    ['base64.c', '../src/nvme/base64.c'],
+    include_directories: [incdir, internal_incdir]
+)
+
+test('base64', base64)
+
 generate_sym_test = files('../scripts/generate-sym-test.py')
 
 test_libnvme_sym_c = custom_target(


### PR DESCRIPTION
## Problem

The end-of-data validity check in `base64_decode()` reads:

```c
if (ac && ((1 << bits) - 1))
	return -EAGAIN;
```

That's `ac && mask`, not `ac & mask`. Two consequences:

1. When the input carries padding, the loop always ends with `bits == 0`, so `(1 << bits) - 1` is 0 and the check can never fire: non-canonical encodings whose padding hides non-zero bits (`"Zh=="`, `"QUJ="`) are silently accepted.
2. `'='` characters are accepted anywhere — in the middle of the data or more than two of them — by shifting an extra 6 zero bits into the accumulator per pad, so strings like `"Zm=g"`, `"=Zm9"`, `"Zg==Zg=="` decode to garbage instead of failing.

Both gaps are latent for the in-tree caller (TLS PSK import) because it feeds multiples-of-4, padded strings and verifies a digest afterwards — but the decoder itself doesn't enforce its contract.

## Fix

- `'='` may only terminate the final quantum: at most twice, and only while a partial quantum is pending (`bits >= 2`); data after padding is EINVAL.
- An unpadded partial quantum at end of input is EINVAL.
- The low `2 * pads` bits the padding stands for must be zero, so non-canonical encodings with garbage in the dropped bits are rejected.

## Testing

New unit test `test/base64.c` (plugged into meson; it compiles `base64.c` directly since the decoder is internal and not in `libnvme.map`):

- all RFC 4648 vectors (`"Zg=="` … `"Zm9vYmFy"`) still decode and re-encode to their canonical form;
- malformed variants (`"Zh=="`, `"QUJ="`, `"Z==="`, `"Zg==Zg=="`, `"=Zm9"`, `"Zm=g"`, `"Zm9vYg="`, truncated/padded-missing forms) are rejected;
- round-trip sweep of every length 0..253 bytes.

The six `expected rejection` vectors fail against the unpatched decoder and pass with the fix; full meson suite green.