### PR TITLE
json: fix inverted fallback in the config dump error message

### DIFF
--- a/src/nvme/json.c
+++ b/src/nvme/json.c
@@ -446,7 +446,7 @@ int json_update_config(nvme_root_t r, const char *config_file)
 					      JSON_C_TO_STRING_NOSLASHESCAPE);
 	if (ret < 0) {
 		nvme_msg(r, LOG_ERR, "Failed to write to %s, %s\n",
-			 config_file ? "stdout" : config_file,
+			 config_file ? config_file : "stdout",
 			 json_util_get_last_err());
 		ret = -1;
 		errno = EIO;


### PR DESCRIPTION
## Problem

The error path of the config dump reports where the write failed:

```c
nvme_msg(r, LOG_ERR, "Failed to write to %s, %s\n",
	 config_file ? "stdout" : config_file,
	 json_util_get_last_err());
```

The ternary is swapped: when `config_file` is set (write to a file failed), the message blames stdout; when dumping to stdout fails, `config_file` is NULL and gets passed to `%s` — undefined behavior (glibc prints `(null)`, other libcs may crash).

## Fix

Print the name when a file was involved, `stdout` otherwise: `config_file ? config_file : "stdout"`.

## Testing

- Full build and meson test suite pass. Cosmetic, single-expression change; no functional behavior in the success paths.