### PR TITLE
json: honor the errno convention in the no-json stubs

### DIFF
--- a/src/nvme/no-json.c
+++ b/src/nvme/no-json.c
@@ -12,15 +12,18 @@
 
 int json_read_config(nvme_root_t r, const char *config_file)
 {
-	return -ENOTSUP;
+	errno = ENOTSUP;
+	return -1;
 }
 
 int json_update_config(nvme_root_t r, const char *config_file)
 {
-	return -ENOTSUP;
+	errno = ENOTSUP;
+	return -1;
 }
 
 int json_dump_tree(nvme_root_t r)
 {
-	return -ENOTSUP;
+	errno = ENOTSUP;
+	return -1;
 }


### PR DESCRIPTION
## Problem

When libnvme is built without JSON support (`-Dwith_json=disabled`), the `json_read_config()` / `json_update_config()` / `json_dump_tree()` stubs in `no-json.c` return `-ENOTSUP` directly, while the real implementations (and the rest of the library) follow the "return -1 with errno set" convention. Callers inspecting errno after a `-1` see a stale value only when JSON support is compiled out.

## Fix

Set `errno = ENOTSUP; return -1;` in the three stubs.

## Testing

- Full meson test suite passes for the default (json-c present) build; also verified a `-Dwith_json=disabled` build compiles and links.