### PR TITLE
tree: actually free filtered-out subsystems

### DIFF
--- a/src/nvme/tree.c
+++ b/src/nvme/tree.c
@@ -36,6 +36,8 @@
 #include "log.h"
 #include "private.h"
 
+static void __nvme_free_subsystem(struct nvme_subsystem *s);
+
 /**
  * struct candidate_args - Used to look for a controller matching these parameters
  * @transport:		Transport type: loop, fc, rdma, tcp
@@ -225,7 +227,7 @@ static void nvme_filter_subsystem(nvme_root_t r, nvme_subsystem_t s,
 
 	nvme_msg(r, LOG_DEBUG, "filter out subsystem %s\n",
 		 nvme_subsystem_get_name(s));
-	nvme_free_subsystem(s);
+	__nvme_free_subsystem(s);
 }
 
 static void nvme_filter_ns(nvme_root_t r, nvme_ns_t n,


### PR DESCRIPTION
## Problem

The scan filters drop rejected objects via the public free wrappers:

```c
nvme_free_ns(n);          /* real free */
nvme_free_ctrl(c);        /* real free */
nvme_free_subsystem(s);   /* empty SWIG stub! */
```

`nvme_filter_subsystem()` therefore never removes a subsystem rejected by the scan filter — it stays linked in the tree, visible to subsequent operations, and the subsystem (plus its now-parentless ctrls/namespaces) leaks. Only the subsystem-level path is broken; namespaces and controllers are freed properly.

## Fix

Call the internal `__nvme_free_subsystem()` — the same routine the host teardown path uses — with a forward declaration since the filter sits above the definition in tree.c.

## Testing

- Full build and meson test suite pass. No test currently supplies a non-NULL scan filter, so this path is compile- and review-validated: the change is a one-line swap to the internal deleter the sibling filters effectively use.