### PR TITLE
util: account for the appended spaces in get_entity_version()

### DIFF
--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -844,7 +844,10 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 	/* /proc/sys/kernel/osrelease contains the Linux
 	 * version (e.g. 5.8.0-63-generic)
 	 */
-	buffer[num_bytes++] = ' '; /* Append a space */
+	if (bufsz) {
+		buffer[num_bytes++] = ' '; /* Append a space */
+		bufsz--;
+	}
 	num_bytes += read_file("/proc/sys/kernel/osrelease",
 			       &buffer[num_bytes], &bufsz);
 
@@ -887,7 +890,10 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 
 		if (name_len) {
 			/* Append a space */
-			buffer[num_bytes++] = ' ';
+			if (bufsz) {
+				buffer[num_bytes++] = ' ';
+				bufsz--;
+			}
 			name_len = MIN(name_len, bufsz);
 			memcpy(&buffer[num_bytes], name, name_len);
 			bufsz -= name_len;
@@ -896,7 +902,10 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 
 		if (ver_id_len) {
 			/* Append a space */
-			buffer[num_bytes++] = ' ';
+			if (bufsz) {
+				buffer[num_bytes++] = ' ';
+				bufsz--;
+			}
 			ver_id_len = MIN(ver_id_len, bufsz);
 			memcpy(&buffer[num_bytes], ver_id, ver_id_len);
 			bufsz -= ver_id_len;


### PR DESCRIPTION
## Problem

`get_entity_version()` assembles the version string into a caller-supplied `buffer` of `bufsz` bytes. The logic rests on the invariant `num_bytes + bufsz == capacity`: `read_file()` writes with `fgets(&buffer[num_bytes], bufsz, ...)` and decrements `bufsz` by the bytes consumed.

But each of the three `' '` separators is appended as `buffer[num_bytes++] = ' '` without checking or decrementing `bufsz`. After that write the invariant is broken (off by one), so:

- when the proc content fills the buffer (long custom kernel release strings, tight caller buffers), the next separator write lands one byte **past** the allocation;
- the following `MIN(len, bufsz)` + `memcpy()` still trusts the inflated `bufsz` for another potential one-byte overrun.

## Fix

Guard the three separator appends with `if (bufsz)` and decrement `bufsz`, so the invariant holds throughout and the final `memset(&buffer[num_bytes], 0, bufsz)` stays in bounds.

## Testing

- Full build and meson test suite pass.
- Reasoning validated by tracing the invariant: after a max-length `read_file()`, pre-fix code performs the separator write at `buffer[capacity]`. Realistically reachable only with unusually long `/proc/sys/kernel/osrelease` contents, hence the user-visible impact is a rare 1-2 byte heap overrun.