### PR TITLE
nbft: allocate descriptor lists with pointer-slot size

### DIFF
--- a/src/nvme/nbft.c
+++ b/src/nvme/nbft.c
@@ -496,7 +496,7 @@ static void read_hfi_descriptors(struct nbft_info *nbft, int num_hfi,
 {
 	int i, cnt;
 
-	nbft->hfi_list = calloc(num_hfi + 1, sizeof(struct nbft_info_hfi));
+	nbft->hfi_list = calloc(num_hfi + 1, sizeof(*nbft->hfi_list));
 	for (i = 0, cnt = 0; i < num_hfi; i++) {
 		if (read_hfi(nbft, &raw_hfi_array[i], &nbft->hfi_list[cnt]) == 0)
 			cnt++;
@@ -508,7 +508,7 @@ static void read_security_descriptors(struct nbft_info *nbft, int num_sec,
 {
 	int i, cnt;
 
-	nbft->security_list = calloc(num_sec + 1, sizeof(struct nbft_info_security));
+	nbft->security_list = calloc(num_sec + 1, sizeof(*nbft->security_list));
 	for (i = 0, cnt = 0; i < num_sec; i++) {
 		if (read_security(nbft, &raw_sec_array[i], &nbft->security_list[cnt]) == 0)
 			cnt++;
@@ -520,7 +520,7 @@ static void read_discovery_descriptors(struct nbft_info *nbft, int num_disc,
 {
 	int i, cnt;
 
-	nbft->discovery_list = calloc(num_disc + 1, sizeof(struct nbft_info_discovery));
+	nbft->discovery_list = calloc(num_disc + 1, sizeof(*nbft->discovery_list));
 	for (i = 0, cnt = 0; i < num_disc; i++) {
 		if (read_discovery(nbft, &raw_disc_array[i], &nbft->discovery_list[cnt]) == 0)
 			cnt++;
@@ -532,7 +532,7 @@ static void read_ssns_descriptors(struct nbft_info *nbft, int num_ssns,
 {
 	int i, cnt;
 
-	nbft->subsystem_ns_list = calloc(num_ssns + 1, sizeof(struct nbft_info_subsystem_ns));
+	nbft->subsystem_ns_list = calloc(num_ssns + 1, sizeof(*nbft->subsystem_ns_list));
 	for (i = 0, cnt = 0; i < num_ssns; i++) {
 		if (read_ssns(nbft, &raw_ssns_array[i], &nbft->subsystem_ns_list[cnt]) == 0)
 			cnt++;


### PR DESCRIPTION
## Problem

The `*_list` members of `struct nbft_info` are NULL-terminated arrays of *pointers* to parsed structures, but three of the four constructors dimensioned the allocation by the pointed-to structure size:

```c
nbft->security_list = calloc(num_sec + 1, sizeof(struct nbft_info_security));
```

`struct nbft_info_security` is currently just `int index` (4 bytes), so with `num_sec >= 2`, `security_list[cnt] = ptr` writes past the allocation. The bug is latent only because `read_security()` is a stub that always fails, so no slot is ever populated (this is also the code area PR #1112 would have started populating).

The other lists (`hfi_list`, `discovery_list`, `subsystem_ns_list`) have the same mismatch but are masked today by those structures being larger than a pointer — an accident of struct size that future field removals could undo.

## Fix

Dimension all four allocations by `sizeof(*list)` so the slots are pointer-sized regardless of how the payload structs evolve.

## Testing

- Full build and meson test suite pass, including the nbft fixture tables.
- The change alters no parse behavior for the existing fixtures (slots are currently zero slots for security, fully populated for the others either way), but makes the allocation provably match the indexing done by the callers.