### PR TITLE
nbft: keep SSNS hfi list contiguous and free it on errors

### DIFF
--- a/src/nvme/nbft.c
+++ b/src/nvme/nbft.c
@@ -282,6 +282,7 @@ static int read_ssns(struct nbft_info *nbft,
 	}
 	ssns->num_hfis = 1;
 	for (i = 0; i < le16_to_cpu(raw_ssns->secondary_hfi_assoc_obj.length); i++) {
+		struct nbft_info_hfi *hfi;
 		bool duplicate = false;
 		int j;
 
@@ -303,13 +304,18 @@ static int read_ssns(struct nbft_info *nbft,
 			continue;
 		}
 
-		ssns->hfis[i + 1] = hfi_from_index(nbft, ss_hfi_indexes[i]);
-		if (ss_hfi_indexes[i] && !ssns->hfis[i + 1])
+		if (!ss_hfi_indexes[i])
+			/* zero marks an unused association slot */
+			continue;
+
+		hfi = hfi_from_index(nbft, ss_hfi_indexes[i]);
+		if (!hfi) {
 			nvme_msg(NULL, LOG_DEBUG,
 				 "file %s: SSNS %d HFI %d not found\n",
 				 nbft->filename, ssns->index, ss_hfi_indexes[i]);
-		else
-			ssns->num_hfis++;
+			continue;
+		}
+		ssns->hfis[ssns->num_hfis++] = hfi;
 	}
 
 	/* SSNS NQN */
@@ -330,6 +336,7 @@ static int read_ssns(struct nbft_info *nbft,
 	return 0;
 
 fail:
+	free(ssns->hfis);
 	free(ssns);
 	return ret;
 }


### PR DESCRIPTION
## Problem

In `read_ssns()`, the `ssns->hfis` array and `ssns->num_hfis` disagree:

```c
ssns->hfis[i + 1] = hfi_from_index(nbft, ss_hfi_indexes[i]);
if (ss_hfi_indexes[i] && !ssns->hfis[i + 1])
	nvme_msg(...);          /* hole in the array */
else
	ssns->num_hfis++;       /* but this one is counted... */
```

Writing at `[i + 1]` preserves raw positions while only successful lookups are counted, so the array ends up with NULL holes: a consumer iterating the first `num_hfis` entries dereferences NULL, while one walking the pointer-sentinel stops early and silently loses interfaces. A zero-valued association index (the "no association" marker) also lands a NULL that is counted in `num_hfis`.

Separately, `fail:` frees `ssns` but not the `ssns->hfis` array allocated partway through — leaking it on the primary-HFI-not-found and NQN-lookup error paths (the failed SSNS is not linked into `subsystem_ns_list`, so `nvme_nbft_free()` can never reclaim it).

## Fix

- Store only resolved HFIs, consecutively, with an explicit skip for zero ("unused") association slots; `num_hfis` increments per stored entry, so the first `num_hfis` slots are always valid pointers.
- Free `ssns->hfis` alongside `ssns` in the `fail:` path.

## Testing

- Full meson test suite passes; `nbft-dump` output for every fixture in `test/nbft/tables/` is byte-identical before/after (verified by diff), so no valid file changes meaning.
- Existing duplicate-index filtering behavior is unchanged.