### PR TITLE
nbft: bound descriptor lists by struct size, not file-declared length

### DIFF
--- a/src/nvme/nbft.c
+++ b/src/nvme/nbft.c
@@ -603,8 +603,9 @@ static int parse_raw_nbft(struct nbft_info *nbft)
 	if (control->num_hfi > 0) {
 		struct nbft_hfi *raw_hfi_array;
 
-		verify(le32_to_cpu(control->hfio) + sizeof(struct nbft_hfi) *
-		       control->num_hfi <= le32_to_cpu(header->length),
+		verify((unsigned long long)le32_to_cpu(control->hfio) +
+		       sizeof(struct nbft_hfi) * control->num_hfi <=
+		       le32_to_cpu(header->length),
 		       "invalid hfi descriptor list offset");
 		raw_hfi_array = (struct nbft_hfi *)(raw_nbft + le32_to_cpu(control->hfio));
 		read_hfi_descriptors(nbft, control->num_hfi, raw_hfi_array,
@@ -617,8 +618,9 @@ static int parse_raw_nbft(struct nbft_info *nbft)
 	if (control->num_sec > 0) {
 		struct nbft_security *raw_security_array;
 
-		verify(le32_to_cpu(control->seco) + le16_to_cpu(control->secl) *
-		       control->num_sec <= le32_to_cpu(header->length),
+		verify((unsigned long long)le32_to_cpu(control->seco) +
+		       sizeof(struct nbft_security) * control->num_sec <=
+		       le32_to_cpu(header->length),
 		       "invalid security profile desciptor list offset");
 		raw_security_array = (struct nbft_security *)(raw_nbft +
 				     le32_to_cpu(control->seco));
@@ -633,8 +635,9 @@ static int parse_raw_nbft(struct nbft_info *nbft)
 	if (control->num_disc > 0) {
 		struct nbft_discovery *raw_discovery_array;
 
-		verify(le32_to_cpu(control->disco) + le16_to_cpu(control->discl) *
-		       control->num_disc <= le32_to_cpu(header->length),
+		verify((unsigned long long)le32_to_cpu(control->disco) +
+		       sizeof(struct nbft_discovery) * control->num_disc <=
+		       le32_to_cpu(header->length),
 		       "invalid discovery profile descriptor list offset");
 		raw_discovery_array = (struct nbft_discovery *)(raw_nbft +
 				      le32_to_cpu(control->disco));
@@ -648,8 +651,9 @@ static int parse_raw_nbft(struct nbft_info *nbft)
 	if (control->num_ssns > 0) {
 		struct nbft_ssns *raw_ssns_array;
 
-		verify(le32_to_cpu(control->ssnso) + le16_to_cpu(control->ssnsl) *
-		       control->num_ssns <= le32_to_cpu(header->length),
+		verify((unsigned long long)le32_to_cpu(control->ssnso) +
+		       sizeof(struct nbft_ssns) * control->num_ssns <=
+		       le32_to_cpu(header->length),
 		       "invalid subsystem namespace descriptor list offset");
 		raw_ssns_array = (struct nbft_ssns *)(raw_nbft +
 				 le32_to_cpu(control->ssnso));


### PR DESCRIPTION
## Problem

The bounds `verify()` for the security, discovery and SSNS descriptor lists trusts the table's declared per-record length while the parser strides by `sizeof(struct)`:

```c
verify(le32_to_cpu(control->ssnso) + le16_to_cpu(control->ssnsl) *
       control->num_ssns <= le32_to_cpu(header->length), ...);

raw_ssns_array = ...;
read_ssns_descriptors(nbft, control->num_ssns, raw_ssns_array, ...);
/* iterates: &raw_ssns_array[i] == ssnso + i * sizeof(struct nbft_ssns) */
```

A table declaring e.g. `ssnsl=1, num_ssns=100` in a 725-byte file passes the verify, and the parser proceeds to read records far past the end of the table buffer. Confirmed empirically by patching the `NBFT-static-ipv4` test fixture: unpatched nbft-dump performs invalid reads past the 725-byte allocation (valgrind: `Invalid read of size 1`) and exits 0, silently discarding the garbage records.

Additionally the same `offset + len * count` expression is evaluated in 32-bit arithmetic; a large declared offset can wrap the sum below `header->length` and defeat the check.

## Fix

Mirror the existing HFI check for all four lists: `offset + sizeof(struct_type) * count <= header->length`, evaluated in 64-bit arithmetic.

## Testing

- Full meson test suite passes; `nbft-dump` output for every fixture in `test/nbft/tables/` is byte-identical before/after.
- With the instrumented fixture: unpatched code accepts and performs out-of-bounds reads (valgrind `Invalid read`); patched code rejects the table with `EINVAL` (nbft-dump exit 2), valgrind-clean.