### PR TITLE
examples: free the topology tree in display-columnar

### DIFF
--- a/examples/display-columnar.c
+++ b/examples/display-columnar.c
@@ -116,6 +116,8 @@ int main()
 			}
 		}
 	}
+
+	nvme_free_tree(r);
 	return 0;
 }
 


### PR DESCRIPTION
## Problem

`display-columnar` scans the topology via `nvme_scan(NULL)` but never frees it with `nvme_free_tree(r)` — every other scanning example (`display-tree`, `discover-loop`, `telemetry-listen`) does. The process exits right afterwards, so the practical impact is nil, but the example is routinely copied as a starting template and should model correct memory handling (and pass `valgrind --leak-check=full` runs against it).

## Fix

Call `nvme_free_tree(r)` before returning from `main()`.

## Testing

- Builds cleanly; meson suite unaffected (examples). Quick `valgrind --leak-check=full ./build/examples/display-columnar` on a system with no NVMe devices: no longer reports the scanned tree as leaked.