### PR TITLE
python: support TLS and remaining fabrics config options

### DIFF
--- a/libnvme/nvme.i
+++ b/libnvme/nvme.i
@@ -154,6 +154,34 @@ PyObject *hostid_from_file();
 			temp.data_digest = PyObject_IsTrue(value) ? true : false;
 			continue;
 		}
+		if (!PyUnicode_CompareWithASCIIString(key, "queue_size")) {
+			temp.queue_size = PyLong_AsLong(value);
+			continue;
+		}
+		if (!PyUnicode_CompareWithASCIIString(key, "fast_io_fail_tmo")) {
+			temp.fast_io_fail_tmo = PyLong_AsLong(value);
+			continue;
+		}
+		if (!PyUnicode_CompareWithASCIIString(key, "keyring")) {
+			temp.keyring = PyLong_AsLong(value);
+			continue;
+		}
+		if (!PyUnicode_CompareWithASCIIString(key, "tls_key")) {
+			temp.tls_key = PyLong_AsLong(value);
+			continue;
+		}
+		if (!PyUnicode_CompareWithASCIIString(key, "tls_configured_key")) {
+			temp.tls_configured_key = PyLong_AsLong(value);
+			continue;
+		}
+		if (!PyUnicode_CompareWithASCIIString(key, "tls")) {
+			temp.tls = PyObject_IsTrue(value) ? true : false;
+			continue;
+		}
+		if (!PyUnicode_CompareWithASCIIString(key, "concat")) {
+			temp.concat = PyObject_IsTrue(value) ? true : false;
+			continue;
+		}
 	}
 	$1 = &temp;
 };


### PR DESCRIPTION
## Summary

Extend the `nvme_fabrics_config` SWIG typemap so `ctrl.connect()` accepts `queue_size`, `fast_io_fail_tmo`, `keyring`, `tls_key`, `tls_configured_key`, `tls`, and `concat` from the Python config dict, covering every field of `nvme_fabrics_config`.

The TLS-related options (`tls`, `keyring`, `tls_key`, `tls_configured_key`) are needed by nvme-stas to support NVMe/TCP connections protected by TLS Pre-Shared Keys, passing key serials from the kernel keyring.