### PR TITLE
ccan: cast pointers to void * in fprintf for %p format specifier

### DIFF
--- a/ccan/ccan/list/list.c
+++ b/ccan/ccan/list/list.c
@@ -11,7 +11,7 @@ static void *corrupt(const char *abortstr,
 	if (abortstr) {
 		fprintf(stderr,
 			"%s: prev corrupt in node %p (%u) of %p\n",
-			abortstr, node, count, head);
+			abortstr, (const void *)node, count, (const void *)head);
 		abort();
 	}
 	return NULL;


### PR DESCRIPTION
GCC 15 enables stricter format validation by default, triggering -Werror=format= when passing non-void pointers (e.g. `const struct list_node *`) to `%p`:

    ccan/ccan/list/list.c: In function 'corrupt':
    ccan/ccan/list/list.c:13:52: error: format '%p' expects argument of type 'void *', but argument 4 has type 'const struct list_node *' [-Werror=format=]
       13 |                         "%s: prev corrupt in node %p (%u) of %p\n",
          |                                                   ~^
          |                                                    |
          |                                                    void *
       14 |                         abortstr, node, count, head);
          |                                   ~~~~
          |                                   |
          |                                   const struct list_node *
    ccan/ccan/list/list.c:13:63: error: format '%p' expects argument of type 'void *', but argument 6 has type 'const struct list_node *' [-Werror=format=]
       13 |                         "%s: prev corrupt in node %p (%u) of %p\n",
          |                                                              ~^
          |                                                               |
          |                                                               void *
       14 |                         abortstr, node, count, head);
          |                                                ~~~~
          |                                                |
          |                                                const struct list_node *

Per ISO C standard (C99/C11 7.21.6.1), the `%p` conversion specifier expects an argument of type `void *` or `const void *`. Explicitly cast `node` and `head` to `(const void *)` to prevent build failures under modern compiler toolchains with -Werror enabled.